### PR TITLE
Legion Camp Overhaul and Map improvements

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -1237,7 +1237,7 @@
 	},
 /area/f13/wasteland)
 "bFu" = (
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/underground/cave)
 "bHb" = (
 /obj/structure/cable{
@@ -1429,7 +1429,7 @@
 /area/f13/underground/cave)
 "bUi" = (
 /obj/structure/flora/junglebush/b,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/bunker)
 "bUN" = (
 /obj/machinery/door/airlock/security{
@@ -2282,7 +2282,7 @@
 /area/f13/wasteland)
 "dkH" = (
 /obj/structure/flora/junglebush/c,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/bunker)
 "dkK" = (
 /obj/structure/closet/wardrobe,
@@ -2701,7 +2701,7 @@
 "dMZ" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/junglebush/large,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/underground/cave)
 "dNC" = (
 /obj/machinery/chem_master/condimaster{
@@ -3263,7 +3263,7 @@
 /area/f13/bunker)
 "eAJ" = (
 /obj/structure/flora/grass/jungle,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/bunker)
 "eBf" = (
 /obj/effect/turf_decal/box,
@@ -4327,7 +4327,7 @@
 /area/f13/vault)
 "fYO" = (
 /obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/bunker)
 "fYY" = (
 /obj/structure/cable{
@@ -4575,7 +4575,7 @@
 /area/f13/bunker)
 "gnO" = (
 /mob/living/simple_animal/hostile/gecko,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/bunker)
 "gnU" = (
 /mob/living/simple_animal/hostile/radscorpion/black,
@@ -5212,7 +5212,7 @@
 /area/f13/vault)
 "gYw" = (
 /obj/structure/flora/junglebush/large,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/underground/cave)
 "gYy" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
@@ -5986,7 +5986,7 @@
 /area/f13/tunnel)
 "ifo" = (
 /mob/living/simple_animal/hostile/mirelurk/hunter,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/underground/cave)
 "ifN" = (
 /obj/structure/rack,
@@ -6118,7 +6118,7 @@
 /area/f13/underground/cave)
 "irk" = (
 /obj/structure/flora/junglebush,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/bunker)
 "irT" = (
 /obj/structure/sign/warning/securearea,
@@ -6258,7 +6258,7 @@
 /area/f13/bunker)
 "iBQ" = (
 /mob/living/simple_animal/hostile/cazador/young,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/bunker)
 "iCB" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -6553,7 +6553,7 @@
 /area/f13/wasteland)
 "iYb" = (
 /obj/structure/flora/rock/jungle,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/bunker)
 "iYd" = (
 /obj/structure/table,
@@ -6763,7 +6763,7 @@
 "jqN" = (
 /mob/living/simple_animal/hostile/mirelurk,
 /obj/structure/flora/grass/jungle,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/underground/cave)
 "jru" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7918,7 +7918,7 @@
 /area/f13/vault)
 "kTA" = (
 /obj/structure/flora/junglebush/large,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/bunker)
 "kUP" = (
 /obj/structure/barricade/wooden/strong,
@@ -8019,7 +8019,7 @@
 /area/f13/bunker)
 "lbh" = (
 /obj/item/candle/tribal_torch,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/bunker)
 "lbj" = (
 /obj/structure/table/wood,
@@ -8103,7 +8103,7 @@
 	},
 /area/f13/bunker)
 "lhe" = (
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/bunker)
 "lhh" = (
 /obj/structure/rack,
@@ -8181,11 +8181,11 @@
 /area/f13/wasteland)
 "lqa" = (
 /obj/structure/flora/junglebush,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/underground/cave)
 "lqf" = (
 /mob/living/simple_animal/hostile/giantant,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/bunker)
 "lqv" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -10229,7 +10229,7 @@
 /area/f13/vault)
 "nZs" = (
 /obj/structure/flora/wasteplant/wild_punga,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/bunker)
 "nZw" = (
 /obj/structure/flora/junglebush/large,
@@ -10445,7 +10445,7 @@
 /area/f13/bunker)
 "oky" = (
 /mob/living/simple_animal/hostile/fireant,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/bunker)
 "okz" = (
 /obj/structure/table,
@@ -10514,7 +10514,7 @@
 /area/f13/bunker)
 "osJ" = (
 /mob/living/simple_animal/hostile/mirelurk,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/underground/cave)
 "osK" = (
 /turf/closed/wall/f13/tunnel,
@@ -10752,7 +10752,7 @@
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
 	},
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/bunker)
 "oJH" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -11178,7 +11178,7 @@
 /area/f13/bunker)
 "pny" = (
 /obj/structure/flora/grass/jungle,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/underground/cave)
 "pnV" = (
 /obj/effect/turf_decal/delivery,
@@ -12443,7 +12443,7 @@
 /area/f13/vault)
 "qWw" = (
 /obj/structure/flora/grass/jungle/b,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/underground/cave)
 "qWZ" = (
 /obj/machinery/computer/crew,
@@ -13298,7 +13298,7 @@
 /area/f13/bunker)
 "shP" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/underground/cave)
 "shZ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -13346,7 +13346,7 @@
 /area/f13/vault)
 "sjo" = (
 /obj/structure/flora/grass/jungle/b,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/bunker)
 "sjy" = (
 /obj/structure/bed/mattress{
@@ -13887,7 +13887,7 @@
 "tjZ" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/grass/jungle,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/underground/cave)
 "tkj" = (
 /obj/machinery/chem_master/advanced,
@@ -16472,7 +16472,7 @@
 "wFT" = (
 /obj/structure/flora/grass/jungle,
 /mob/living/simple_animal/hostile/cazador/young,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/bunker)
 "wFW" = (
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -8,7 +8,7 @@
 /turf/open/water,
 /area/f13/caves)
 "aaN" = (
-/obj/structure/simple_door/room,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "abd" = (
@@ -26,7 +26,9 @@
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/item/reagent_containers/pill/patch/healingpowder,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
 /area/f13/legion)
 "abL" = (
 /obj/structure/barricade/sandbags,
@@ -89,7 +91,6 @@
 /area/f13/caves)
 "adD" = (
 /obj/structure/chair/bench,
-/obj/effect/landmark/start/f13/settler,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
@@ -131,10 +132,11 @@
 	},
 /area/f13/wasteland)
 "afj" = (
-/obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/pda,
-/turf/open/floor/wood/f13/oak,
+/obj/effect/landmark/start/f13/explorer,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
 /area/f13/legion)
 "afL" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -147,6 +149,10 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop2"
 	},
+/area/f13/wasteland)
+"agd" = (
+/obj/structure/stacklifter,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "agf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -181,11 +187,6 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
-"agO" = (
-/obj/structure/table/wood,
-/obj/structure/bedsheetbin,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "agU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/machinepile,
@@ -199,15 +200,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"aha" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "ahh" = (
 /obj/item/kirbyplants,
 /turf/open/indestructible/ground/outside/dirt{
@@ -293,12 +285,11 @@
 /area/f13/building)
 "ajN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	req_one_access_txt = "25"
+/obj/structure/chair/office{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/ncr)
 "ajO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -349,9 +340,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "akA" = (
-/obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/decoration/rag,
+/obj/structure/barricade/wooden/strong{
+	obj_integrity = 500
+	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "akI" = (
@@ -461,13 +454,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"aof" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/effect/landmark/start/f13/explorer,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "aoo" = (
 /obj/structure/table/wood,
 /obj/machinery/door/poddoor/shutters{
@@ -478,6 +464,11 @@
 /obj/structure/railing,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"aop" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/turf/open/floor/carpet/black,
+/area/f13/legion)
 "aoD" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -494,6 +485,12 @@
 	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland)
+"aoL" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress3"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "aoV" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "shadowleft"
@@ -550,13 +547,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "aqL" = (
-/obj/structure/rack,
-/obj/item/kitchen/fork{
-	pixel_x = 8;
-	pixel_y = 2
+/obj/item/trash/sosjerky{
+	pixel_x = -6
 	},
-/obj/machinery/light/small{
-	dir = 8
+/obj/item/trash/sosjerky{
+	pixel_x = 1;
+	pixel_y = 10
+	},
+/obj/item/trash/sosjerky{
+	icon_state = "dr_gibb";
+	pixel_x = 4;
+	pixel_y = -3
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
@@ -564,14 +565,6 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"arq" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -6
-	},
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "ars" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderrighttop"
@@ -677,16 +670,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
 "auH" = (
-/obj/structure/table,
-/obj/item/ammo_casing/shotgun/buckshot,
-/obj/item/clothing/head/beret,
-/obj/item/clothing/ears/earmuffs,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/ncr)
 "auU" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/f13{
@@ -751,7 +740,9 @@
 /area/f13/wasteland)
 "awT" = (
 /obj/effect/landmark/start/f13/auxilia,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
 /area/f13/legion)
 "axr" = (
 /obj/structure/fence{
@@ -788,6 +779,10 @@
 /obj/item/clothing/gloves/boxing,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"ayd" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "ayw" = (
 /obj/effect/spawner/lootdrop/crafts,
 /turf/open/floor/plasteel/barber{
@@ -966,11 +961,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "aDX" = (
-/obj/structure/fermenting_barrel,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/ncr)
 "aEq" = (
 /mob/living/simple_animal/hostile/wolf,
 /turf/open/indestructible/ground/outside/road{
@@ -978,9 +974,23 @@
 	},
 /area/f13/wasteland)
 "aFF" = (
-/obj/item/claymore/machete/training,
+/obj/structure/weightlifter,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"aFK" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/poison/giant_spider{
+	desc = "Slayer of recruits, and queen of the Legion camp toilets. This furry oversized arachnid has the dangerous fangs for any that break into her nest, as well as an apetite for the unrobust.";
+	name = "Shelob"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/legion)
 "aFM" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -1002,14 +1012,7 @@
 /area/f13/building)
 "aHo" = (
 /obj/structure/table/wood,
-/obj/item/trash/sosjerky{
-	icon_state = "plate"
-	},
-/obj/item/kitchen/fork{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "aHs" = (
@@ -1087,18 +1090,12 @@
 	},
 /area/f13/building)
 "aJh" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"aKo" = (
-/obj/effect/decal/fakelattice{
-	density = 0;
-	pixel_x = 17
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/ncr)
 "aKs" = (
 /obj/item/clothing/shoes/sneakers/black,
 /turf/open/floor/f13/wood,
@@ -1111,13 +1108,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"aKv" = (
-/obj/structure/fence/wooden{
-	dir = 1;
-	icon_state = "post_wood"
-	},
-/turf/open/floor/wood/f13/stage_tl,
-/area/f13/wasteland)
 "aKD" = (
 /obj/structure/chair/left{
 	dir = 8
@@ -1260,7 +1250,7 @@
 	desc = "A sign denoting the presence of a likely very moist molerat.";
 	name = "wet molerat sign"
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "aPg" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -1280,12 +1270,6 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/village)
-"aPB" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "aPN" = (
 /obj/structure/fireplace{
 	dir = 8
@@ -1293,12 +1277,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "aPQ" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
 "aPR" = (
 /obj/structure/rack,
@@ -1331,13 +1311,15 @@
 	},
 /area/f13/wasteland)
 "aQT" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/ncr)
 "aRl" = (
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
@@ -1466,15 +1448,13 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
-"aVH" = (
-/obj/structure/simple_door/tentflap_cloth,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
 "aVY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/carpet/black,
-/area/f13/legion)
+/obj/machinery/door/airlock/grunge{
+	name = "Prison Management";
+	req_access_txt = "121"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/ncr)
 "aWg" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/chem_tin/radx,
@@ -1492,7 +1472,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "aWF" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -1523,7 +1503,7 @@
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "aXC" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
@@ -1620,15 +1600,9 @@
 	},
 /area/f13/building)
 "bal" = (
-/obj/structure/rack,
-/obj/item/shovel/spade,
-/obj/item/shovel,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/cultivator,
-/obj/item/storage/bag/plants,
-/obj/item/scythe,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/ncr)
 "bav" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -1639,6 +1613,10 @@
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"bby" = (
+/obj/structure/decoration/vent,
+/turf/closed/wall/f13/wood,
+/area/f13/legion)
 "bbz" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -1680,13 +1658,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bcj" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheethos"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office{
+	dir = 1
 	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/ncr)
 "bcF" = (
 /obj/structure/chair/wood/modern{
 	dir = 1;
@@ -1718,12 +1695,12 @@
 	},
 /area/f13/wasteland)
 "bea" = (
-/obj/structure/flora/tree/tall{
-	layer = 4;
-	pixel_y = 9
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
 	},
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
+	dir = 4;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "bej" = (
@@ -1895,23 +1872,22 @@
 	},
 /area/f13/wasteland)
 "bkT" = (
-/obj/structure/window/fulltile/wood_window,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/closed/wall/f13/store,
-/area/f13/building)
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ncrlockdown";
+	name = "Lockdown Shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/ncr)
 "bkY" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"bla" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/effect/landmark/start/f13/campfollower,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "blv" = (
 /obj/structure/decoration/shock,
 /turf/closed/wall/rust,
@@ -1924,12 +1900,14 @@
 /turf/open/water,
 /area/f13/caves)
 "blZ" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerpavement"
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "ncrlockdown";
+	name = "Lockdown";
+	req_access_txt = "121"
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/ncr)
 "bmh" = (
 /turf/open/floor/wood/f13/stage_br,
 /area/f13/building)
@@ -1953,16 +1931,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "bnn" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/building)
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/ncr)
 "bnD" = (
 /obj/structure/table/wood/settler,
 /obj/item/claymore/machete/training,
@@ -2001,8 +1975,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "bof" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old,
+/obj/structure/chair/wood/modern{
+	dir = 1
+	},
+/obj/machinery/light/small,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "bol" = (
@@ -2118,8 +2094,7 @@
 	},
 /area/f13/wasteland)
 "bqm" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/f13/doctor,
+/obj/structure/filingcabinet,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "bqs" = (
@@ -2168,12 +2143,13 @@
 /turf/open/floor/wood/f13/oakbroken,
 /area/f13/building)
 "brE" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
+/obj/structure/filingcabinet,
+/obj/effect/turf_decal/stripes/white/box,
+/obj/machinery/light{
+	dir = 4
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/ncr)
 "brZ" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -2202,20 +2178,10 @@
 	},
 /area/f13/ncr)
 "btj" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/closet/fridge,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/machinery/photocopier,
+/obj/effect/turf_decal/stripes/white/box,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/ncr)
 "btN" = (
 /turf/closed/wall/f13/wood,
 /area/f13/ncr)
@@ -2340,7 +2306,9 @@
 "bwM" = (
 /obj/effect/landmark/start/f13/auxilia,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
 /area/f13/legion)
 "bwV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2488,11 +2456,9 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "bAo" = (
-/obj/structure/fence/corner,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outermaincornerinner"
-	},
-/area/f13/wasteland)
+/obj/machinery/door/unpowered/wooddoor,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/ncr)
 "bAq" = (
 /obj/structure/tires/half,
 /turf/open/indestructible/ground/outside/dirt{
@@ -2580,8 +2546,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bDy" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/breadhard,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "bDO" = (
 /obj/structure/filingcabinet,
@@ -2805,7 +2772,7 @@
 "bMP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "bMZ" = (
 /obj/effect/landmark/start/f13/raider,
@@ -2871,14 +2838,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "bPj" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal,
+/turf/open/floor/carpet/black,
+/area/f13/ncr)
 "bPU" = (
 /obj/structure/chair/wood/worn{
 	dir = 8
@@ -2897,13 +2860,8 @@
 	},
 /area/f13/wasteland)
 "bQm" = (
-/obj/structure/table/wood/settler,
-/obj/item/lighter,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/floor/carpet/black,
+/area/f13/ncr)
 "bQr" = (
 /obj/structure/chair/stool/f13stool,
 /turf/open/floor/f13/wood{
@@ -2973,6 +2931,7 @@
 /area/f13/ncr)
 "bRF" = (
 /obj/structure/table,
+/obj/item/kitchen/knife,
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -3036,6 +2995,11 @@
 /obj/machinery/mineral/wasteland_vendor/medical,
 /turf/open/floor/plating/f13/inside,
 /area/f13/building)
+"bUF" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "bUR" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/floor/wood/f13/oak,
@@ -3178,13 +3142,6 @@
 "cbr" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"cbV" = (
-/obj/structure/fence/wooden{
-	dir = 1;
-	icon_state = "post_wood"
-	},
-/turf/open/floor/wood/f13/stage_tr,
-/area/f13/wasteland)
 "cbX" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -3213,8 +3170,8 @@
 	},
 /area/f13/wasteland)
 "cde" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/wood/f13/oak,
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
 "cdt" = (
 /turf/open/indestructible/ground/outside/ruins{
@@ -3250,7 +3207,7 @@
 "cfp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/wood,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "cfz" = (
 /mob/living/simple_animal/hostile/handy,
@@ -3260,15 +3217,6 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/water,
 /area/f13/caves)
-"chq" = (
-/obj/structure/chair/wood/modern{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "cht" = (
 /obj/structure/fence{
 	dir = 1
@@ -3279,17 +3227,14 @@
 	},
 /area/f13/wasteland)
 "chv" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/closet,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "chA" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/turf/open/floor/carpet/black,
+/area/f13/ncr)
 "chM" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -3323,12 +3268,6 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"ciq" = (
-/obj/structure/chair/wood/modern{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "ciH" = (
 /obj/structure/sink/kitchen{
@@ -3386,6 +3325,13 @@
 /obj/machinery/light,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"cjL" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress3"
+	},
+/obj/item/soap/homemade,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "cjS" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase,
@@ -3532,7 +3478,7 @@
 	name = "wasteland jail"
 	},
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "cnD" = (
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/outside/dirt{
@@ -3565,6 +3511,13 @@
 	name = "temple wall"
 	},
 /area/f13/caves)
+"cot" = (
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "cov" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/village)
@@ -3769,10 +3722,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"cxH" = (
-/obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "cxL" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/dirt{
@@ -3880,6 +3829,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"cCU" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/legion)
 "cDd" = (
 /obj/structure/chair/stool/bar,
 /mob/living/simple_animal/hostile/raider/thief,
@@ -3904,10 +3860,6 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "cEC" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	pixel_y = 4
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -3927,11 +3879,11 @@
 	},
 /area/f13/building)
 "cEV" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft3"
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/area/f13/wasteland)
+/turf/open/floor/carpet/black,
+/area/f13/ncr)
 "cFe" = (
 /obj/structure/billboard/cola,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3985,6 +3937,8 @@
 /area/f13/wasteland)
 "cGV" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/machinery/processor/chopping_block,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
@@ -4038,9 +3992,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "cIL" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building)
+/obj/machinery/light,
+/turf/open/floor/carpet/black,
+/area/f13/ncr)
 "cJs" = (
 /obj/item/trash/pistachios,
 /turf/open/indestructible/ground/outside/dirt,
@@ -4115,14 +4069,9 @@
 	},
 /area/f13/building)
 "cLP" = (
-/obj/item/paper,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/carpet/black,
+/area/f13/ncr)
 "cLW" = (
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/f13/wood{
@@ -4141,14 +4090,14 @@
 	},
 /area/f13/wasteland)
 "cMg" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = 16
 	},
-/mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	icon_state = "floorrusty"
 	},
-/area/f13/building)
+/area/f13/caves)
 "cMk" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -4241,8 +4190,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "cPg" = (
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "exteriorgate2"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
+/area/f13/building)
 "cPn" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -4369,7 +4321,9 @@
 /obj/item/seeds/wheat,
 /obj/item/seeds/wheat,
 /obj/item/seeds/wheat,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
 /area/f13/legion)
 "cTP" = (
 /obj/machinery/light/small{
@@ -4431,16 +4385,16 @@
 	},
 /area/f13/building)
 "cVF" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
+/obj/effect/decal/riverbank{
+	dir = 1
 	},
-/area/f13/building)
+/turf/closed/indestructible/f13/matrix,
+/area/f13/wasteland)
 "cWq" = (
 /obj/structure/closet/crate/freezer/blood{
 	pixel_y = -5
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "cWy" = (
 /obj/structure/destructible/tribal_torch/lit,
@@ -4530,11 +4484,12 @@
 	},
 /area/f13/building)
 "cYz" = (
-/obj/item/target,
-/turf/open/floor/f13{
-	icon_state = "redmark"
+/obj/effect/decal/riverbankcorner,
+/obj/effect/decal/riverbankcorner{
+	dir = 4
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "cYL" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -4724,8 +4679,12 @@
 	},
 /area/f13/wasteland)
 "deX" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin,
+/obj/item/pen,
+/obj/item/pen,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "dfo" = (
@@ -4747,9 +4706,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "dgB" = (
-/obj/structure/car,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building)
+/obj/machinery/smartfridge/bottlerack,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "dgK" = (
 /obj/effect/landmark/start/f13/shaman,
 /turf/open/indestructible/ground/inside/mountain,
@@ -4856,11 +4815,16 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "djh" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
+/mob/living/simple_animal/hostile/stalkeryoung{
+	aggro_vision_range = 0;
+	desc = "A juvenile genetic hybrid of rattlesnake and coyote DNA, this one seems to be tamed by the local tribe and likes to lay around and do nothing.";
+	faction = list("neutral");
+	health = 200;
+	maxHealth = 200;
+	name = "Sniffs-the-earth";
+	tame = 1
 	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "djI" = (
 /obj/machinery/workbench,
@@ -4906,41 +4870,29 @@
 	},
 /area/f13/wasteland)
 "dkW" = (
-/obj/item/ammo_casing/shotgun/buckshot,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/riverbankcorner{
+	dir = 4
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "dlc" = (
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "dld" = (
-/obj/structure/rack,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/tomato,
-/obj/item/seeds/tomato,
-/obj/item/seeds/sugarcane,
-/obj/item/seeds/sugarcane,
-/obj/machinery/light/small/broken{
-	dir = 1
+/obj/structure/pondlily_big,
+/obj/effect/decal/riverbankcorner{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "dlp" = (
-/obj/structure/closet/fridge,
-/obj/item/reagent_containers/food/condiment/yeast,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/barricade/wooden/strong{
+	obj_integrity = 500
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "dlw" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -4966,14 +4918,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "dlS" = (
-/obj/structure/fence{
-	dir = 8
-	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
-	icon_state = "dirtcorner"
+	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/legion)
 "dlX" = (
 /obj/structure/chair/wood,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5005,16 +4954,12 @@
 /obj/effect/decal/fakelattice{
 	pixel_x = -17
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
+/turf/closed/wall/r_wall/rust,
+/area/f13/building)
 "dnq" = (
-/obj/structure/window/fulltile/house{
-	dir = 2
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "dnA" = (
 /obj/structure/window/fulltile/house,
@@ -5035,12 +4980,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"dop" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
-	},
-/area/f13/wasteland)
 "doB" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood{
@@ -5109,7 +5048,7 @@
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "dpO" = (
 /obj/structure/table/wood,
@@ -5180,12 +5119,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "dsW" = (
-/obj/item/flag/legion,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerborder"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "dte" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
@@ -5261,6 +5198,14 @@
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"dve" = (
+/obj/machinery/shower{
+	pixel_y = 23
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/legion)
 "dvg" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -5588,9 +5533,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"dFn" = (
-/turf/open/floor/wood/f13/oakbroken3,
-/area/f13/legion)
 "dFs" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -5622,6 +5564,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"dHl" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 7
+	},
+/obj/item/soap/homemade,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "dHq" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/dirt{
@@ -5668,6 +5618,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"dJw" = (
+/obj/structure/simple_door/wood,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/legion)
 "dJF" = (
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -5732,10 +5688,10 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "dLm" = (
-/obj/item/candle/infinite,
-/obj/structure/table/wood,
-/turf/open/floor/carpet/airless,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
+	},
+/area/f13/building)
 "dLB" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag,
@@ -5815,15 +5771,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"dOf" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/legion)
 "dOg" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
@@ -5870,6 +5817,7 @@
 /area/f13/wasteland)
 "dPe" = (
 /obj/structure/barricade/bars,
+/obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "dPv" = (
@@ -5901,10 +5849,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "dRs" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/chair/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "dRx" = (
 /obj/machinery/light{
@@ -5925,13 +5871,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "dRT" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2";
-	pixel_y = 7
+/obj/structure/chair/f13chair2{
+	dir = 8
 	},
-/obj/item/soap/homemade,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "dSb" = (
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/indestructible/ground/outside/road{
@@ -5939,10 +5883,13 @@
 	},
 /area/f13/wasteland)
 "dSY" = (
-/obj/structure/decoration/rag,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/pen,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "dTl" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
@@ -5958,10 +5905,16 @@
 "dUv" = (
 /turf/open/floor/carpet/black,
 /area/f13/legion)
-"dUx" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/meatsalted,
-/turf/open/floor/wood/f13/oak,
+"dUz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/soap/deluxe,
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/legion)
 "dUU" = (
 /obj/structure/table/reinforced,
@@ -6123,7 +6076,7 @@
 "eaA" = (
 /obj/structure/closet/crate/large,
 /obj/item/stack/sheet/mineral/wood/fifty,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "eaO" = (
 /obj/item/ammo_casing/a50MG,
@@ -6171,7 +6124,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/caves)
+/area/f13/tunnel)
 "ebV" = (
 /obj/structure/wreck/trash/machinepiletwo{
 	layer = 3
@@ -6183,20 +6136,9 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "ecb" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/clothing_middle,
-/obj/item/clothing/shoes/singery,
-/obj/item/clothing/under/singery,
-/obj/item/clothing/under/f13/bartenderalt,
-/obj/item/clothing/shoes/f13/fancy,
-/obj/item/reagent_containers/food/drinks/flask,
-/obj/item/toy/clockwork_watch,
-/obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
-/obj/effect/spawner/lootdrop/minor/bowler_or_that,
-/obj/machinery/light/small/broken{
-	dir = 1
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2top"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "ecg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6239,7 +6181,7 @@
 "edD" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "edF" = (
 /obj/machinery/light/small,
 /obj/structure/bed/mattress{
@@ -6320,10 +6262,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/building)
-"ehf" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/airless,
-/area/f13/legion)
 "ehx" = (
 /obj/effect/spawner/lootdrop/trash,
 /mob/living/simple_animal/hostile/ghoul/reaver,
@@ -6462,10 +6400,6 @@
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
 	layer = 6
-	},
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
-	pixel_y = 12
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "hole"
@@ -6640,7 +6574,15 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "epF" = (
-/obj/structure/fence,
+/obj/item/clothing/under/f13/police,
+/obj/item/clothing/head/f13/police,
+/obj/item/clothing/shoes/combat,
+/obj/structure/closet,
+/obj/item/clothing/head/beret,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -6710,6 +6652,11 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"esc" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/legion)
 "esz" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6743,10 +6690,13 @@
 	},
 /area/f13/wasteland)
 "etv" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/landmark/start/f13/settler,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
 /area/f13/building)
 "etG" = (
 /obj/structure/rack,
@@ -6768,11 +6718,6 @@
 	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
-"eub" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "euj" = (
 /obj/structure/fence{
 	dir = 4
@@ -6880,6 +6825,7 @@
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
 	},
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "exd" = (
@@ -6955,9 +6901,8 @@
 	},
 /area/f13/wasteland)
 "ezt" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "ezv" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6965,7 +6910,13 @@
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
 	},
-/turf/open/floor/wood/f13/oak,
+/obj/item/radio/headset/headset_legion,
+/obj/item/radio/headset/headset_legion,
+/obj/item/radio/headset/headset_legion,
+/obj/item/radio/headset/headset_legion,
+/obj/item/radio/headset/headset_legion,
+/obj/item/radio/headset/headset_legion,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "ezx" = (
 /obj/structure/rack,
@@ -7028,6 +6979,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"eBm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/decanrec,
+/turf/open/floor/carpet/black,
+/area/f13/legion)
 "eBu" = (
 /obj/structure/table/wood/fancy/royalblack,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7069,10 +7026,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eCK" = (
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/machinery/light/small{
+	dir = 1
 	},
+/obj/structure/table/wood,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "eCM" = (
 /obj/structure/barricade/sandbags,
@@ -7107,7 +7065,7 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "eEz" = (
-/obj/structure/destructible/tribal_torch,
+/obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
@@ -7164,12 +7122,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"eGn" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/oakbroken2,
-/area/f13/legion)
 "eGs" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -7207,16 +7159,15 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "eHH" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/landmark/start/f13/auxilia,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/settler,
 /turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/area/f13/building)
 "eHQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/structure/simple_door/wood,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "eIg" = (
 /obj/structure/table/wood,
@@ -7374,11 +7325,9 @@
 	},
 /area/f13/building)
 "eLl" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
+/obj/effect/landmark/start/f13/settler,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "eLo" = (
 /obj/item/clothing/under/jabroni,
 /turf/open/floor/f13{
@@ -7437,7 +7386,15 @@
 /area/f13/building)
 "eNb" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oakbroken4,
+/mob/living/simple_animal/hostile/wolf{
+	desc = "Legion mongrels are dogs owned and bred by the Houndmasters of Caesar's Legion. Mongrels are mainly used in combat and scouting missions by the Legion.";
+	faction = list("neutral");
+	health = 200;
+	maxHealth = 200;
+	name = "Lupa";
+	tame = 1
+	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
 "eNT" = (
 /obj/machinery/light/small{
@@ -7508,11 +7465,10 @@
 	},
 /area/f13/wasteland)
 "eQb" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
+/obj/machinery/light/small,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland)
 "eQc" = (
@@ -7556,12 +7512,6 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
-"eQY" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "eRe" = (
@@ -7636,10 +7586,13 @@
 /area/f13/building)
 "eTW" = (
 /obj/effect/decal/cleanable/generic,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Gatehouse";
+	req_one_access_txt = "62"
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "eUg" = (
 /obj/structure/campfire/stove,
 /obj/effect/decal/cleanable/dirt,
@@ -7697,10 +7650,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"eVq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oakbroken3,
-/area/f13/legion)
 "eVJ" = (
 /obj/machinery/light/sign,
 /obj/structure/barricade/wooden,
@@ -7913,11 +7862,15 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
 "fbc" = (
-/obj/structure/chair/wood{
+/obj/machinery/shower{
 	dir = 8
 	},
-/obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/decoration/vent,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/legion)
 "fbi" = (
 /obj/structure/car/rubbish3,
@@ -7945,15 +7898,23 @@
 /area/f13/wasteland)
 "fbz" = (
 /obj/structure/closet/cabinet,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
-"fbD" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
+/obj/structure/curtain{
+	color = "#845f58"
 	},
-/area/f13/wasteland)
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "house1ladder";
+	layer = 2
+	},
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"fbD" = (
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "interiorgate"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "fbE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -7974,7 +7935,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "fcE" = (
 /obj/structure/reagent_dispensers/barrel/three{
 	pixel_x = -14
@@ -7987,12 +7948,6 @@
 /obj/effect/spawner/lootdrop/f13/attachments,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"fcI" = (
-/obj/structure/barricade/bars,
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/legion)
 "fcK" = (
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -8157,6 +8112,12 @@
 /obj/structure/bed,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"fhh" = (
+/obj/structure/bed,
+/obj/effect/landmark/start/f13/legionary,
+/obj/item/bedsheet/brown,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "fhG" = (
 /obj/structure/simple_door/metal/fence{
 	door_type = "fence_wood";
@@ -8164,11 +8125,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
-"fhS" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "fiB" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -8223,10 +8179,6 @@
 /obj/item/kitchen/knife/butcher,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"fjT" = (
-/obj/item/flag/legion,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "fjY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -8238,11 +8190,12 @@
 	},
 /area/f13/ncr)
 "fkf" = (
-/obj/structure/fence/corner,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleftbottom"
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -10
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "fkj" = (
 /obj/structure/barricade/bars,
 /obj/structure/window/fulltile/house,
@@ -8278,10 +8231,10 @@
 /area/f13/radiation)
 "fmn" = (
 /obj/structure/chair/wood{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/landmark/start/f13/campfollower,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "fmr" = (
 /obj/structure/toilet{
@@ -8294,8 +8247,11 @@
 /area/f13/village)
 "fmw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	req_one_access_txt = "25"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "fmz" = (
 /mob/living/simple_animal/hostile/raider/baseball,
@@ -8372,12 +8328,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "fpg" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/statue/sandstone/mars{
+	anchored = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/turf/open/floor/carpet/red,
 /area/f13/legion)
 "fph" = (
 /obj/structure/rack,
@@ -8485,12 +8439,14 @@
 	},
 /area/f13/followers)
 "frY" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
+/obj/effect/decal/fakelattice{
+	density = 0;
+	pixel_x = 17
 	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "fsl" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8502,13 +8458,6 @@
 	icon_state = "verticalrightborderright3"
 	},
 /area/f13/wasteland)
-"fsA" = (
-/obj/item/ammo_casing/c10mm,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
 "fsN" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/water,
@@ -8518,19 +8467,20 @@
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/bar)
 "fsV" = (
-/obj/structure/dresser,
-/obj/item/pda,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
 /turf/open/floor/carpet/black,
 /area/f13/legion)
 "ftu" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress6"
+/obj/structure/chair/f13chair2{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "ftz" = (
 /obj/structure/table,
-/obj/item/kitchen/knife,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -8715,6 +8665,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
+"fzt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/decanvet,
+/turf/open/floor/carpet/black,
+/area/f13/legion)
 "fzB" = (
 /obj/structure/table/wood/poker,
 /obj/item/radio/intercom{
@@ -8855,7 +8811,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "fDA" = (
-/obj/item/ammo_casing/shotgun/buckshot,
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "fDE" = (
@@ -8864,13 +8821,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
-"fDG" = (
-/obj/structure/fence/wooden{
-	dir = 1;
-	icon_state = "post_wood"
-	},
-/turf/open/floor/wood/f13/stage_br,
-/area/f13/wasteland)
 "fFu" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/desert,
@@ -8910,20 +8860,11 @@
 	},
 /area/f13/wasteland)
 "fGh" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 10
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/mirror{
-	pixel_x = 32
-	},
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "fGr" = (
 /obj/structure/decoration/rag,
@@ -9012,13 +8953,12 @@
 	},
 /area/f13/wasteland)
 "fKN" = (
+/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/wolf/alpha{
-	desc = "Legion mongrels are dogs owned and bred by the Houndmasters of Caesar's Legion. Mongrels are mainly used in combat and scouting missions by the Legion.";
-	faction = list("neutral");
-	name = "Brutus"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/indestructible/ground/inside/mountain,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "fKU" = (
 /obj/structure/table,
@@ -9036,16 +8976,9 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "fLB" = (
+/obj/structure/decoration/rag,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/wolf{
-	desc = "Legion mongrels are dogs owned and bred by the Houndmasters of Caesar's Legion. Mongrels are mainly used in combat and scouting missions by the Legion.";
-	faction = list("neutral");
-	health = 200;
-	maxHealth = 200;
-	name = "Lupa";
-	tame = 1
-	},
-/turf/open/indestructible/ground/inside/mountain,
+/turf/closed/wall/f13/wood,
 /area/f13/legion)
 "fLC" = (
 /obj/structure/reagent_dispensers/barrel/three,
@@ -9095,7 +9028,9 @@
 "fNB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
 /area/f13/legion)
 "fNN" = (
 /obj/structure/bed/mattress{
@@ -9135,16 +9070,15 @@
 	},
 /area/f13/building)
 "fOx" = (
-/obj/structure/fence/wooden{
-	dir = 1
-	},
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "fOC" = (
-/obj/structure/sign/poster/prewar/poster90,
-/turf/closed/wall/r_wall/rust,
-/area/f13/ncr)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "fOG" = (
 /obj/machinery/light/broken,
 /turf/open/floor/wood/f13/carpet,
@@ -9161,8 +9095,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "fPc" = (
-/turf/open/floor/wood/f13/oakbroken2,
-/area/f13/legion)
+/obj/effect/landmark/start/f13/deputy,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "fPv" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/pill/patch/turbo,
@@ -9170,11 +9105,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fPH" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "interiorgate"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
+/area/f13/building)
 "fPK" = (
 /obj/effect/decal/fakelattice{
 	density = 0;
@@ -9186,7 +9120,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "fPL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/hydroponics{
@@ -9303,8 +9237,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fSk" = (
-/obj/structure/decoration/rag,
-/turf/closed/wall/f13/store,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
+	},
 /area/f13/building)
 "fSq" = (
 /obj/machinery/door/poddoor/gate{
@@ -9424,6 +9360,12 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
+"fWS" = (
+/obj/effect/landmark/start/f13/slave,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/legion)
 "fXs" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile,
@@ -9484,7 +9426,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "fZm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -9625,13 +9567,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gcy" = (
-/obj/effect/decal/remains/human,
-/obj/item/clothing/suit/armor/f13/slavelabor,
-/obj/item/clothing/under/f13/legslavef,
-/obj/item/clothing/shoes/f13/rag,
-/obj/effect/landmark/start/f13/slave,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/building)
 "gcK" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
@@ -9699,13 +9639,10 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "gfY" = (
-/obj/structure/simple_door/tentflap_cloth{
-	pixel_y = -3
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft1"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/legion)
+/area/f13/building)
 "ggb" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -9793,13 +9730,13 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
 "giq" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Sheriff Office";
+	req_one_access_txt = "62"
 	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "giD" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/ammo,
@@ -9815,14 +9752,9 @@
 	},
 /area/f13/wasteland)
 "giO" = (
-/obj/structure/table/reinforced,
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters{
-	id = "frontgateshut";
-	name = "gate shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "giP" = (
 /obj/structure/sink/kitchen{
@@ -9920,6 +9852,20 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"gkn" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
+	},
+/obj/structure/mirror{
+	dir = 8;
+	pixel_y = 28
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/legion)
 "gkv" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/closet/crate/bin,
@@ -9952,6 +9898,11 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"glt" = (
+/obj/structure/destructible/tribal_torch/wall/lit,
+/obj/structure/dresser,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "glu" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/light/small{
@@ -10023,11 +9974,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gnI" = (
-/obj/structure/fence/corner/wooden{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/dresser,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "gnU" = (
 /obj/structure/decoration/clock/active,
 /turf/closed/wall/f13/wood,
@@ -10070,7 +10020,7 @@
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "gpp" = (
 /obj/machinery/microwave/stove,
 /obj/machinery/light{
@@ -10227,9 +10177,10 @@
 	},
 /area/f13/village)
 "gtj" = (
-/obj/structure/simple_door/metal/fence{
-	dir = 8
+/obj/effect/decal/remains{
+	icon_state = "remains"
 	},
+/obj/item/storage/backpack/satchel/leather,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -10355,15 +10306,6 @@
 /obj/structure/sink/puddle,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"gws" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/structure/decoration/vent,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/legion)
 "gwJ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -10377,15 +10319,10 @@
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"gxn" = (
-/obj/effect/mob_spawn/human/corpse,
-/obj/structure/cross,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "gxt" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "gxO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -10475,10 +10412,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gAZ" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/clothing_middle,
-/obj/item/clothing/under/f13/classdress,
-/turf/open/floor/f13/wood,
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "exteriorgate"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "gBd" = (
 /obj/structure/fence/wooden{
@@ -10549,13 +10486,15 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
 "gDn" = (
-/obj/structure/fence{
-	dir = 8
+/obj/machinery/door/poddoor/gate{
+	id = "legiongate";
+	name = "gate"
 	},
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
+	dir = 4;
+	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/legion)
 "gDs" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road,
@@ -10776,12 +10715,11 @@
 	},
 /area/f13/brotherhood)
 "gNo" = (
-/obj/item/flag/oasis,
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
+/obj/structure/sign/poster/contraband/pinup_ride{
+	pixel_x = -32
 	},
-/area/f13/wasteland)
+/turf/closed/wall/r_wall/rust,
+/area/f13/building)
 "gNA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 10;
@@ -10795,10 +10733,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gNG" = (
-/obj/structure/destructible/tribal_torch,
+/obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
-	icon_state = "dirt"
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "gOf" = (
@@ -10897,9 +10835,11 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "gQL" = (
-/obj/machinery/light,
-/turf/open/floor/carpet/black,
-/area/f13/ncr)
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "gQQ" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -10922,10 +10862,8 @@
 	},
 /area/f13/wasteland)
 "gRq" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/decoration/rag,
+/turf/closed/wall/f13/store,
 /area/f13/building)
 "gRr" = (
 /obj/structure/simple_door/house,
@@ -10960,9 +10898,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gSG" = (
-/obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
+/obj/structure/closet/crate/bin,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gTz" = (
@@ -11019,11 +10956,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gVQ" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress3"
+/obj/structure/table/wood,
+/obj/item/documents{
+	desc = "Secret documents and maps concerning the Legion presence"
 	},
-/obj/item/instrument/harmonica,
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/legion)
+"gVR" = (
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/legion)
 "gWo" = (
 /turf/open/indestructible/ground/outside/road{
@@ -11134,7 +11076,7 @@
 	name = "wasteland jail key"
 	},
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "gYA" = (
 /obj/structure/rack,
 /obj/item/cultivator,
@@ -11147,6 +11089,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"gYM" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "gZi" = (
 /obj/structure/mirelurkegg,
 /turf/open/water,
@@ -11226,7 +11172,8 @@
 "hcr" = (
 /obj/structure/table/wood,
 /obj/item/pickaxe,
-/turf/open/floor/wood/f13/oak,
+/obj/item/pickaxe,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "hcI" = (
 /obj/structure/disposalpipe/segment{
@@ -11566,6 +11513,13 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"hlA" = (
+/obj/structure/simple_door/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/legion)
 "hlI" = (
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -11577,10 +11531,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "hlX" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/item/flag/legion,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 5;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "hmd" = (
 /obj/structure/car/rubbish4,
 /obj/effect/decal/cleanable/glass,
@@ -11619,8 +11575,10 @@
 /area/f13/building)
 "hnq" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "hom" = (
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
@@ -11630,11 +11588,12 @@
 	},
 /area/f13/tunnel)
 "hoy" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/item/flag/legion,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 9;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "hpc" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/f13/wood,
@@ -11680,6 +11639,11 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"hqf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/legion)
 "hqr" = (
 /obj/machinery/vending/games,
 /turf/open/floor/f13/wood,
@@ -11898,10 +11862,6 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
-"hvk" = (
-/obj/structure/table,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "hvp" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -11982,7 +11942,7 @@
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
 /obj/item/storage/bag/ore,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "hyf" = (
 /obj/structure/chair/stool,
@@ -12043,10 +12003,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hzr" = (
-/obj/structure/table/wood,
-/obj/structure/table/wood,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland)
 "hzt" = (
 /obj/structure/bed/pod,
 /obj/structure/lattice/catwalk,
@@ -12083,7 +12042,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hAT" = (
-/obj/effect/decal/remains/human,
+/obj/structure/closet/cardboard,
+/obj/item/crowbar,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "hAV" = (
@@ -12133,6 +12093,12 @@
 /obj/machinery/button/door{
 	id = "interiorgate2";
 	name = "Interior door button";
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/obj/machinery/button/door{
+	id = "exteriorgate2";
+	name = "Exterior door button";
 	pixel_x = 6;
 	pixel_y = 32
 	},
@@ -12229,13 +12195,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hFW" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/obj/structure/chair/bench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "hFY" = (
 /obj/structure/holohoop{
@@ -12279,16 +12240,18 @@
 	},
 /area/f13/wasteland)
 "hHi" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain{
-	color = "#c40e0e"
-	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/meatsalted,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "hHk" = (
-/obj/structure/simple_door/fakeglass,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/obj/item/ammo_casing/c9mm/ap,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "hHm" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -12365,8 +12328,11 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "hJf" = (
-/obj/structure/bed/dogbed,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/bed/dogbed{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "hJg" = (
 /obj/structure/campfire/barrel,
@@ -12382,11 +12348,12 @@
 	},
 /area/f13/wasteland)
 "hJt" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 4
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavementcorner"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "hJv" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -12552,15 +12519,6 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
-"hOs" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/legion)
 "hOJ" = (
 /obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/f13/wood,
@@ -12642,11 +12600,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hSQ" = (
-/obj/structure/fence/corner,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermainleft"
-	},
-/area/f13/wasteland)
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hSR" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -12691,8 +12648,8 @@
 /area/f13/building)
 "hUf" = (
 /obj/structure/chair/comfy/brown,
-/obj/effect/landmark/start/f13/vetlegionary,
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "hUk" = (
 /obj/item/shard,
@@ -12793,8 +12750,13 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"hXb" = (
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/legion)
 "hXj" = (
-/obj/structure/chair/stool/bar,
+/mob/living/simple_animal/hostile/raider,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "hXk" = (
@@ -12869,7 +12831,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
+	dir = 5;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
@@ -12979,12 +12941,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "icU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/ncr)
+/obj/effect/decal/remains/human,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "icW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -13003,10 +12962,6 @@
 	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland)
-"idC" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/legion)
 "idE" = (
 /obj/structure/table/wood/fancy/black,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -13119,11 +13074,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"igU" = (
-/obj/structure/barricade/sandbags,
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "iic" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink/kitchen{
@@ -13227,14 +13177,11 @@
 	},
 /area/f13/wasteland)
 "ilG" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowright"
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2top"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/area/f13/wasteland)
 "ilL" = (
 /obj/structure/fence{
 	dir = 4
@@ -13243,11 +13190,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"ime" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "imk" = (
 /obj/item/ammo_casing/a50MG,
 /turf/open/indestructible/ground/outside/road{
@@ -13258,15 +13200,8 @@
 /turf/closed/indestructible/f13/matrix,
 /area/f13/wasteland)
 "imv" = (
-/obj/structure/fence/wooden,
-/obj/structure/flora/grass/wasteland{
-	pixel_x = 9;
-	pixel_y = 14
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
-	},
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "imz" = (
 /obj/structure/closet/crate/trashcart{
@@ -13352,11 +13287,6 @@
 /obj/structure/stacklifter,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"ioC" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/breadhard,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "ioP" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -13487,10 +13417,11 @@
 	},
 /area/f13/caves)
 "isv" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "isy" = (
 /obj/structure/table/wood/settler,
@@ -13498,12 +13429,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"isJ" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
 "isO" = (
 /obj/item/radio/intercom{
 	frequency = 1891;
@@ -13540,13 +13465,6 @@
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"itL" = (
-/obj/structure/bed/dogbed{
-	pixel_x = -1;
-	pixel_y = 7
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "itM" = (
 /obj/structure/wreck/trash/brokenvendor,
 /obj/effect/decal/fakelattice{
@@ -13626,13 +13544,12 @@
 	},
 /area/f13/bunker)
 "iwa" = (
-/obj/structure/table,
-/obj/item/paper,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "iwm" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/floorgrime,
@@ -13771,10 +13688,7 @@
 	},
 /area/f13/wasteland)
 "iBF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
+/obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "iBK" = (
@@ -13812,7 +13726,9 @@
 /obj/structure/rack,
 /obj/item/flashlight/lantern,
 /obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
 /area/f13/legion)
 "iEg" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -13862,12 +13778,16 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "iFF" = (
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/obj/structure/table/wood/fancy,
-/obj/effect/spawner/lootdrop/three_course_meal,
+/obj/structure/rack,
+/obj/item/kitchen/fork{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/area/f13/building)
 "iFI" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/brotherhood)
@@ -14074,6 +13994,12 @@
 /obj/item/clothing/under/f13/raiderharness,
 /turf/open/floor/f13,
 /area/f13/building)
+"iJG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/legion)
 "iJJ" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/small/broken{
@@ -14099,18 +14025,15 @@
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
-/obj/effect/landmark/start/f13/vetlegionary,
-/turf/open/floor/carpet/black,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "iKm" = (
 /obj/machinery/workbench,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "iKD" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/closed/wall/f13/tentwall,
+/area/f13/legion)
 "iKG" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -14126,6 +14049,13 @@
 /obj/item/clothing/under/f13/female/tribal,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"iKQ" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 7
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "iLc" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/city)
@@ -14134,11 +14064,11 @@
 /turf/open/floor/wood/f13/oakbroken3,
 /area/f13/building)
 "iLg" = (
-/obj/structure/chair/wood/fancy{
-	dir = 8
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "iLo" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -14174,9 +14104,12 @@
 	},
 /area/f13/village)
 "iLQ" = (
-/obj/structure/simple_door/metal/fence,
+/obj/structure/simple_door/metal/fence{
+	door_type = "fence_wood";
+	icon_state = "fence_wood"
+	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/legion)
 "iMc" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -14187,6 +14120,12 @@
 "iMm" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/caves)
+"iMo" = (
+/obj/structure/simple_door/wood,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/legion)
 "iNb" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -14235,12 +14174,14 @@
 	},
 /area/f13/wasteland)
 "iNI" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
 	},
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "iNQ" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood{
@@ -14292,7 +14233,10 @@
 	},
 /area/f13/ncr)
 "iOY" = (
-/obj/item/shovel,
+/obj/structure/barricade/sandbags,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "iPf" = (
@@ -14302,11 +14246,9 @@
 	},
 /area/f13/building)
 "iPm" = (
-/obj/item/ammo_casing/c9mm/ap,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
+/obj/structure/barricade/sandbags,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "iPp" = (
 /obj/structure/fence/corner{
@@ -14542,9 +14484,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "iTX" = (
-/obj/machinery/door/unpowered/wooddoor,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/ncr)
+/obj/item/ammo_casing/shotgun/improvised,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "iUW" = (
 /obj/structure/chair/f13chair2,
 /turf/open/indestructible/ground/outside/dirt,
@@ -14609,6 +14554,12 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"iXP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/legion)
 "iYv" = (
 /obj/structure/chair/stool{
 	icon_state = "bench_center"
@@ -14673,7 +14624,10 @@
 /area/f13/wasteland)
 "iZE" = (
 /obj/structure/table/wood,
-/obj/item/instrument/guitar,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -6
+	},
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "jae" = (
@@ -14777,12 +14731,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "jbW" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	pixel_y = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "jcg" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -14799,28 +14751,26 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jco" = (
-/obj/item/flag/oasis,
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/machinery/light/small,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "jcp" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "jcB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office{
-	dir = 8
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/ncr)
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "jcJ" = (
 /obj/effect/spawner/lootdrop/trash,
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "jdg" = (
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/indestructible/ground/outside/ruins{
@@ -14873,12 +14823,9 @@
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/brotherhood)
 "jeV" = (
-/obj/structure/table,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/simple_door/room,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "jfj" = (
 /obj/structure/closet/crate{
@@ -14930,12 +14877,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "jgx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/ncr)
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "jgE" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -14986,10 +14932,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jhx" = (
-/obj/structure/kitchenspike,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
 	},
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "jhW" = (
 /obj/structure/barricade/sandbags,
@@ -15032,11 +14978,8 @@
 /turf/closed/wall/rust,
 /area/f13/caves)
 "jjn" = (
-/obj/machinery/light/small,
-/obj/structure/table/wood/settler,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/f13/wood,
+/obj/structure/simple_door/room,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "jjq" = (
 /obj/structure/flora/wasteplant/wild_punga,
@@ -15109,6 +15052,16 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"jme" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "jmq" = (
 /obj/item/clothing/head/f13/rastacap,
 /obj/structure/closet/cabinet,
@@ -15133,17 +15086,9 @@
 	},
 /area/f13/brotherhood)
 "jmv" = (
-/obj/structure/chair/stool{
-	dir = 1;
-	icon_state = "bench"
-	},
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/structure/table/wood,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "jmO" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/radio/intercom{
@@ -15265,23 +15210,27 @@
 	},
 /area/f13/wasteland)
 "jpW" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/button/door{
+	id = "legiongate";
+	name = "Gate button";
+	pixel_x = 7;
+	pixel_y = 32
+	},
+/obj/machinery/button/door{
+	id = "legionlock";
+	name = "Legion shutters";
+	pixel_x = -6;
+	pixel_y = 32
+	},
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "jqe" = (
+/obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+	dir = 8;
+	icon_state = "outerpavement"
 	},
-/area/f13/building)
-"jqp" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowleft"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/area/f13/wasteland)
 "jqX" = (
 /obj/machinery/hydroponics/constructable{
 	pixel_y = 6
@@ -15314,7 +15263,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jrS" = (
-/obj/structure/closet/crate/coffin,
+/obj/item/flag/legion,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "jrU" = (
@@ -15432,6 +15381,11 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"jwG" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/flare/torch,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "jwM" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 8
@@ -15525,11 +15479,12 @@
 	},
 /area/f13/wasteland)
 "jxO" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/landmark/start/f13/decanvet,
+/obj/structure/table/wood/poker,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/area/f13/building)
 "jxY" = (
 /obj/item/stack/sheet/mineral/wood/five,
 /turf/open/floor/f13/wood,
@@ -15540,6 +15495,10 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
+"jyM" = (
+/obj/structure/bonfire/prelit,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "jzn" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
@@ -15680,10 +15639,16 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "jFE" = (
-/obj/structure/chair/wood/fancy{
-	dir = 4
+/obj/structure/table/wood,
+/obj/item/trash/sosjerky{
+	icon_state = "plate"
 	},
-/turf/open/floor/f13/wood,
+/obj/item/kitchen/fork{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "jGe" = (
 /mob/living/simple_animal/hostile/retaliate/goat/bighorn,
@@ -15724,10 +15689,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "jIn" = (
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/carpet/red,
 /area/f13/legion)
 "jIB" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -15747,9 +15709,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "jIV" = (
-/obj/structure/reagent_dispensers/barrel/explosive,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/legion)
 "jJa" = (
 /obj/structure/table/wood,
 /obj/item/phone,
@@ -15864,11 +15829,8 @@
 	},
 /area/f13/wasteland)
 "jMT" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/structure/table/wood,
+/obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "jNh" = (
@@ -15901,12 +15863,11 @@
 	},
 /area/f13/ncr)
 "jNu" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/bedsheet/brown,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "jNJ" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -16003,9 +15964,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "jRy" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13/wood,
+/obj/structure/table/wood/poker,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "jRJ" = (
 /obj/structure/table,
@@ -16424,6 +16385,13 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kcT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/legion)
 "kcX" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -16484,16 +16452,11 @@
 	},
 /area/f13/wasteland)
 "kfc" = (
-/obj/structure/mirror{
-	pixel_x = -32
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "kfo" = (
 /obj/structure/closet,
@@ -16846,8 +16809,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "krA" = (
-/obj/structure/bookcase/random/adult,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "krJ" = (
 /obj/structure/tires,
@@ -16877,12 +16844,11 @@
 	},
 /area/f13/wasteland)
 "kuo" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2";
-	pixel_y = 7
+/obj/structure/chair/wood/modern{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/turf/open/floor/wood/f13/oakbroken3,
+/area/f13/building)
 "kur" = (
 /obj/structure/table/wood/fancy,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
@@ -16890,15 +16856,10 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "kut" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
+/obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
+	dir = 4;
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "kuI" = (
@@ -16999,12 +16960,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "kxY" = (
-/obj/item/clothing/suit/armor/f13/slavelabor,
-/obj/item/clothing/under/f13/legslave,
-/obj/item/clothing/shoes/f13/rag,
-/obj/effect/landmark/start/f13/slave,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/obj/item/ammo_casing/shotgun/buckshot,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "kyc" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -17308,7 +17268,7 @@
 	pixel_x = 17
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
+/area/f13/building)
 "kGy" = (
 /obj/machinery/grill,
 /turf/open/indestructible/ground/outside/road{
@@ -17374,8 +17334,7 @@
 /area/f13/building)
 "kIs" = (
 /obj/machinery/workbench,
-/obj/item/instrument/trumpet,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "kJn" = (
 /obj/structure/fence/wooden{
@@ -17419,9 +17378,12 @@
 	},
 /area/f13/wasteland)
 "kKs" = (
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "kLv" = (
 /obj/machinery/light/small{
@@ -17448,6 +17410,12 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
+"kMl" = (
+/obj/structure/decoration/vent,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/legion)
 "kMm" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17469,8 +17437,12 @@
 	},
 /area/f13/village)
 "kMS" = (
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/turf/closed/wall/f13/store,
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "kNh" = (
 /obj/machinery/mineral/wasteland_vendor/clothing,
@@ -17540,12 +17512,11 @@
 /turf/open/water,
 /area/f13/brotherhood)
 "kQC" = (
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
+/obj/structure/filingcabinet,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "kQJ" = (
 /obj/structure/closet/crate/large,
 /obj/item/stack/sheet/metal{
@@ -17554,7 +17525,7 @@
 /obj/item/stack/sheet/glass{
 	amount = 50
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "kRD" = (
 /obj/structure/decoration/rag{
@@ -17565,9 +17536,6 @@
 "kRR" = (
 /obj/effect/decal/fakelattice{
 	pixel_x = -17
-	},
-/obj/structure/fence{
-	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
@@ -17623,7 +17591,9 @@
 /obj/item/restraints/legcuffs/bola,
 /obj/item/restraints/legcuffs/bola,
 /obj/item/restraints/legcuffs/bola,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
 /area/f13/legion)
 "kUd" = (
 /obj/structure/barricade/wooden,
@@ -17652,11 +17622,22 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "kUA" = (
-/obj/structure/statue/sandstone/mars{
-	pixel_x = -1
+/obj/structure/decoration/clock{
+	pixel_y = 30
 	},
-/turf/open/floor/carpet/black,
+/obj/structure/rack,
+/obj/item/binoculars,
+/obj/item/binoculars,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
+"kUM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kUP" = (
 /obj/structure/barricade/tentclothcorner,
 /turf/open/indestructible/ground/outside/dirt{
@@ -17737,14 +17718,16 @@
 	},
 /area/f13/wasteland)
 "kXv" = (
-/obj/structure/fence{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/obj/structure/noticeboard{
+	layer = 2.5;
+	pixel_y = 32
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "kXy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/booth{
@@ -17919,7 +17902,7 @@
 /obj/structure/fireplace{
 	dir = 4
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "leu" = (
 /turf/open/indestructible/ground/outside/road{
@@ -17961,7 +17944,7 @@
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "lfb" = (
 /obj/structure/chair/wood/modern{
@@ -18047,6 +18030,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"lgP" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress6"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "lgX" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb,
@@ -18069,12 +18058,13 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "lhW" = (
-/obj/structure/chair/wood/modern{
-	dir = 1
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/obj/effect/decal/remains/human,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "liv" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
@@ -18115,15 +18105,23 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
-"lkp" = (
-/obj/structure/chair/wood/modern{
-	dir = 1
-	},
-/obj/machinery/light/small{
+"lkc" = (
+/obj/structure/chair/wood{
 	dir = 4
 	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
+"lkp" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence/corner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "lks" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18142,6 +18140,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"lli" = (
+/obj/item/clothing/suit/armor/f13/slavelabor,
+/obj/item/clothing/under/f13/legslave,
+/obj/item/clothing/shoes/f13/rag,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/legion)
 "llj" = (
 /obj/structure/closet,
 /obj/item/clothing/head/helmet/f13/raider/supafly,
@@ -18201,8 +18207,7 @@
 	},
 /area/f13/wasteland)
 "lmP" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "lmY" = (
@@ -18334,16 +18339,7 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "lqp" = (
-/obj/structure/bed/mattress/pregame,
-/obj/item/restraints/handcuffs{
-	icon_state = "handcuffGag"
-	},
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/structure/closet/crate/bin,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -18520,7 +18516,10 @@
 /obj/structure/chair/wood/modern{
 	dir = 1
 	},
-/turf/open/floor/wood/f13/oakbroken3,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "lvh" = (
 /obj/structure/table/wood,
@@ -18613,9 +18612,17 @@
 	},
 /area/f13/building)
 "lww" = (
-/obj/item/toy/cattoy,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/obj/structure/fence{
+	dir = 8
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "lxe" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18692,9 +18699,11 @@
 	},
 /area/f13/village)
 "lAo" = (
-/obj/item/ammo_casing/shotgun/improvised,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "lAw" = (
@@ -18704,11 +18713,17 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"lAC" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "lAD" = (
 /obj/structure/table/wood,
 /obj/item/smelling_salts,
 /obj/item/smelling_salts,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "lAJ" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -18727,19 +18742,27 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "lBS" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Sheriff Office";
-	req_one_access_txt = "62"
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"lBY" = (
-/obj/structure/weightlifter,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
+	},
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"lBY" = (
+/obj/structure/bed/dogbed{
+	pixel_x = -10;
+	pixel_y = 13
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "lCc" = (
 /obj/effect/decal/riverbank{
 	dir = 8
@@ -18766,7 +18789,7 @@
 "lCw" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "lCM" = (
 /obj/machinery/light/small{
@@ -18818,6 +18841,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"lDN" = (
+/obj/structure/curtain{
+	color = "#c40e0e"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/legion)
 "lDR" = (
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife,
@@ -18890,7 +18919,7 @@
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "lGH" = (
 /mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/wood/f13/old,
@@ -18965,11 +18994,9 @@
 	},
 /area/f13/ncr)
 "lIW" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/kitchen/fork,
+/obj/item/toy/cattoy,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/legion)
 "lJg" = (
 /obj/structure/table,
 /obj/item/paper,
@@ -19067,14 +19094,11 @@
 	},
 /area/f13/ncr)
 "lMr" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/item/storage/backpack/satchel/leather,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit,
+/obj/effect/landmark/start/f13/slavemaster,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "lMA" = (
 /obj/item/weldingtool,
 /turf/open/floor/f13/wood{
@@ -19088,6 +19112,13 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/building)
+"lMO" = (
+/obj/effect/decal/remains/human,
+/obj/item/clothing/suit/armor/f13/slavelabor,
+/obj/item/clothing/under/f13/legslavef,
+/obj/item/clothing/shoes/f13/rag,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "lNa" = (
 /obj/structure/closet/fridge/standard,
 /turf/open/floor/f13/wood,
@@ -19102,10 +19133,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "lNv" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "lNA" = (
 /obj/machinery/light{
@@ -19120,17 +19149,14 @@
 	},
 /area/f13/ncr)
 "lOl" = (
-/obj/effect/landmark/start/f13/deputy,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "lOz" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/car,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "lOY" = (
 /obj/effect/turf_decal/stripes/white/box,
@@ -19200,9 +19226,13 @@
 	},
 /area/f13/wasteland)
 "lRd" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/ncr)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/building)
 "lRo" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -19259,10 +19289,15 @@
 	},
 /area/f13/wasteland)
 "lSQ" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/obj/effect/decal/remains{
+	icon_state = "remains"
 	},
-/turf/closed/wall/f13/store,
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "lTk" = (
 /obj/machinery/light/small/broken{
@@ -19364,7 +19399,7 @@
 	icon_state = "skin"
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/area/f13/legion)
 "lVn" = (
 /obj/item/clothing/under/f13/rag,
 /turf/open/indestructible/ground/inside/mountain,
@@ -19449,7 +19484,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "lZl" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/machinery/light{
@@ -19545,7 +19580,7 @@
 	icon_state = "1-10"
 	},
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "mco" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/inside/mountain,
@@ -19563,7 +19598,8 @@
 	},
 /area/f13/building)
 "mcF" = (
-/mob/living/simple_animal/hostile/raider,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "mcI" = (
@@ -19591,12 +19627,12 @@
 	},
 /area/f13/building)
 "mdD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office{
-	dir = 1
+/obj/item/ammo_casing/shotgun/buckshot,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/ncr)
+/area/f13/building)
 "mdF" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/radio/intercom{
@@ -19613,7 +19649,6 @@
 /area/f13/village)
 "med" = (
 /obj/structure/chair/stool/retro,
-/obj/effect/landmark/start/f13/settler,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mee" = (
@@ -19690,8 +19725,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mfz" = (
-/obj/structure/statue/sandstone/mars,
-/turf/open/floor/carpet/airless,
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "mfD" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -19727,17 +19763,16 @@
 /area/f13/wasteland)
 "mgg" = (
 /obj/machinery/autolathe,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "mgO" = (
-/obj/structure/fence{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "mgV" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -19788,11 +19823,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "miA" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "miT" = (
 /obj/structure/decoration/hatch,
 /turf/open/indestructible/ground/outside/road{
@@ -19969,10 +20004,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "moX" = (
-/obj/structure/closet/crate{
-	anchored = 1;
-	can_be_unanchored = 1
-	},
+/obj/structure/dresser,
+/obj/item/pda,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
 "mpc" = (
@@ -19988,6 +20021,12 @@
 	},
 /turf/open/water,
 /area/f13/caves)
+"mpu" = (
+/obj/structure/sign/poster/prewar/poster89{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/black,
+/area/f13/legion)
 "mpz" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
@@ -20350,12 +20389,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"mBP" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "mCf" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -20363,14 +20396,13 @@
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
 "mCG" = (
-/obj/structure/table/wood,
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
 /area/f13/wasteland)
-"mCH" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "mDn" = (
 /obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/dirt{
@@ -20460,10 +20492,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "mHy" = (
-/obj/structure/closet/cabinet,
-/obj/item/instrument/trumpet,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "mHS" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/plasteel/barber{
@@ -20512,13 +20543,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "mIW" = (
-/obj/effect/decal/remains/human,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/fence{
+	dir = 1
 	},
-/area/f13/building)
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "mJb" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/syringe/medx,
@@ -20580,9 +20612,7 @@
 	},
 /area/f13/wasteland)
 "mLc" = (
-/obj/structure/fence/corner/wooden{
-	dir = 8
-	},
+/obj/item/claymore/machete/training,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mLj" = (
@@ -20660,10 +20690,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "mOv" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "mOx" = (
 /obj/item/stack/f13Cash/aureus,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20811,7 +20842,7 @@
 /obj/item/flashlight/lantern,
 /obj/item/flashlight/lantern,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "mTT" = (
 /obj/structure/table/wood,
@@ -20834,11 +20865,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "mUx" = (
-/obj/item/ammo_casing/c10mm,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 6;
-	icon_state = "outerpavement"
+/obj/structure/fence{
+	dir = 1
 	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mUM" = (
 /obj/structure/filingcabinet,
@@ -20889,7 +20919,7 @@
 /area/f13/village)
 "mVR" = (
 /obj/structure/reagent_dispensers/compostbin,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "mVV" = (
 /obj/structure/table/reinforced,
@@ -20899,10 +20929,11 @@
 	},
 /area/f13/village)
 "mVW" = (
-/obj/structure/chair/bench,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "mVY" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -21016,19 +21047,20 @@
 	},
 /area/f13/building)
 "mZE" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"mZH" = (
-/obj/structure/closet,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/restraints/handcuffs,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/item/pet_carrier{
+	pixel_x = 4;
+	pixel_y = 7
 	},
-/area/f13/building)
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"mZH" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "mZX" = (
 /obj/structure/toilet{
 	dir = 1
@@ -21103,12 +21135,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"nbD" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "nbH" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/cleaner,
@@ -21132,13 +21158,6 @@
 /obj/machinery/light,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"ncb" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavementcorner"
-	},
-/area/f13/wasteland)
 "ncX" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -21279,28 +21298,19 @@
 	},
 /area/f13/building)
 "ngX" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
+/obj/structure/chair/wood/modern{
+	dir = 1
 	},
-/area/f13/caves)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "nhd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/personal{
-	anchored = 1;
-	name = "Equipment Closet";
-	req_access_txt = "121"
-	},
-/obj/effect/turf_decal/stripes/white/box,
-/obj/item/melee/classic_baton/telescopic,
-/obj/item/melee/classic_baton/telescopic,
-/obj/item/gun/ballistic/shotgun/hunting,
-/obj/item/gun/ballistic/shotgun/hunting,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/ncr)
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "nhf" = (
 /obj/structure/table/wood,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -21408,9 +21418,9 @@
 	},
 /area/f13/building)
 "nlN" = (
-/obj/structure/window/fulltile/wood_window,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/table/wood,
+/obj/item/instrument/guitar,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "nlO" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -21458,11 +21468,8 @@
 	},
 /area/f13/building)
 "nnP" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "noo" = (
 /obj/machinery/light/small/broken{
@@ -21549,13 +21556,11 @@
 	},
 /area/f13/followers)
 "nrB" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/pen,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "nrS" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -21736,9 +21741,12 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "nyc" = (
-/obj/structure/table/wood/poker,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/structure/window/fulltile/wood,
+/obj/structure/curtain{
+	color = "#c40e0e"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "nyM" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -21809,23 +21817,6 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/tunnel)
-"nAR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/money_stack/legion,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
-"nAW" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/fence{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "nBn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -21860,11 +21851,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "nDd" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerpavementcorner"
-	},
-/area/f13/wasteland)
+/obj/structure/chair/wood,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "nDe" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -21887,12 +21876,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "nDY" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Prison Management";
-	req_access_txt = "121"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/ncr)
+/obj/machinery/vending/nukacolavend,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "nEn" = (
 /obj/structure/holohoop{
 	dir = 8
@@ -21988,6 +21974,11 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"nHT" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/meatsalted,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "nIp" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/wasteland)
@@ -22045,6 +22036,14 @@
 /obj/item/clothing/mask/bandana/gold,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"nKs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "nKw" = (
 /mob/living/simple_animal/hostile/cazador/young,
 /turf/open/indestructible/ground/outside/road{
@@ -22098,10 +22097,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "nMk" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/landmark/start/f13/legionary,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "nMl" = (
 /obj/structure/window/fulltile/house,
@@ -22294,6 +22291,12 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"nSl" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/legion)
 "nSC" = (
 /obj/machinery/smartfridge/bottlerack/seedbin,
 /obj/item/seeds/agave,
@@ -22339,7 +22342,7 @@
 	},
 /area/f13/ncr)
 "nTm" = (
-/obj/machinery/microwave/stove,
+/obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -22347,7 +22350,7 @@
 "nTO" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/legion)
 "nTP" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/f13/wood{
@@ -22509,9 +22512,9 @@
 /turf/closed/wall/f13/wood,
 /area/f13/bar)
 "oaw" = (
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "oay" = (
 /obj/structure/barricade/sandbags,
@@ -22551,10 +22554,8 @@
 	},
 /area/f13/wasteland)
 "ock" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/turf/closed/wall/f13/store,
 /area/f13/building)
 "ocx" = (
 /obj/structure/chair/stool{
@@ -22636,15 +22637,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "oeg" = (
-/obj/structure/closet,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/restraints/handcuffs,
-/obj/item/instrument/guitar,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "oei" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/wood,
@@ -22679,8 +22674,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ofW" = (
-/obj/structure/barricade/bars,
 /obj/structure/table/reinforced,
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
 /obj/machinery/door/poddoor/shutters{
 	id = "frontgateshut";
 	name = "gate shutters"
@@ -22706,11 +22702,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
 "ohf" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain{
-	color = "#c40e0e"
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
 "ohk" = (
 /obj/structure/table/wood,
@@ -22775,10 +22768,12 @@
 	},
 /area/f13/tunnel)
 "okj" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "okr" = (
 /obj/structure/chair/stool,
@@ -22832,11 +22827,12 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "okZ" = (
-/obj/structure/fence{
-	dir = 4
+/obj/structure/fence/wooden{
+	dir = 4;
+	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/legion)
 "olD" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -22963,7 +22959,7 @@
 "ooh" = (
 /obj/structure/table/wood,
 /obj/item/roller,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "oom" = (
 /obj/machinery/light/small{
@@ -23171,7 +23167,7 @@
 	},
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "ouJ" = (
 /obj/structure/decoration/hatch{
 	dir = 8
@@ -23257,12 +23253,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "oxP" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/wood/f13/oak,
+/turf/closed/wall/f13/wood,
 /area/f13/legion)
 "oxT" = (
 /obj/structure/rack,
@@ -23270,10 +23262,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "oxU" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/turf/open/floor/f13/wood,
+/obj/structure/window/fulltile/house,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "oyf" = (
 /obj/item/clothing/gloves/boxing/blue,
@@ -23349,16 +23339,21 @@
 	},
 /area/f13/village)
 "ozI" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/obj/item/clothing/under/f13/police,
+/obj/item/clothing/head/f13/police,
+/obj/item/clothing/shoes/combat,
+/obj/structure/closet,
+/obj/item/clothing/head/beret,
+/obj/item/restraints/handcuffs/fake/kinky,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "oAe" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
+/area/f13/caves)
 "oAB" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -23505,11 +23500,13 @@
 	},
 /area/f13/ncr)
 "oGB" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft2"
+/obj/structure/table,
+/obj/item/paper,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "oGS" = (
 /obj/machinery/light{
 	pixel_x = -16
@@ -23564,23 +23561,17 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"oHR" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/carpet/airless,
-/area/f13/legion)
 "oHS" = (
 /obj/structure/table,
 /obj/machinery/processor/chopping_block,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "oHT" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "oIm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/barber{
@@ -23663,8 +23654,9 @@
 	},
 /area/f13/followers)
 "oJF" = (
-/obj/structure/chair/bench,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/fireplace,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/legion)
 "oJR" = (
 /obj/structure/table,
@@ -23720,10 +23712,6 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
-"oMY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "oMZ" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13/wood,
@@ -23777,20 +23765,16 @@
 	},
 /area/f13/clinic)
 "oPd" = (
-/obj/structure/chair/bench,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/pinup_ride{
-	pixel_x = -32
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/simple_door/metal/fence,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/legion)
 "oPB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/fence{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/ncr)
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/legion)
 "oPO" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23924,6 +23908,16 @@
 /area/f13/building)
 "oTT" = (
 /obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Business"
+	},
+/obj/machinery/light/fo13colored/Red{
+	desc = "A lighting fixture.";
+	dir = 8;
+	light_color = "#008000";
+	name = "light tube"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "oUo" = (
@@ -23991,7 +23985,12 @@
 	},
 /area/f13/brotherhood)
 "oVH" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -24024,17 +24023,16 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "oWU" = (
-/obj/structure/chair/wood,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/bed/dogbed,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "oXi" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
+/obj/structure/table/wood,
+/obj/item/kitchen/knife/bowie,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "oXV" = (
-/obj/structure/destructible/tribal_torch/wall/lit,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -24142,9 +24140,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "pck" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "pcm" = (
 /obj/effect/decal/remains/human,
@@ -24209,13 +24207,11 @@
 /area/f13/building)
 "pea" = (
 /obj/structure/decoration/rag{
-	icon_state = "skin"
+	icon_state = "skulls"
 	},
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/decoration/rag,
+/turf/closed/wall/f13/wood,
+/area/f13/legion)
 "pek" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -24312,14 +24308,10 @@
 /area/f13/bar)
 "pfX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
-/obj/machinery/light{
-	dir = 4
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/ncr)
+/area/f13/legion)
 "pgl" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -24343,9 +24335,6 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
-"phd" = (
-/turf/open/floor/wood/f13/oakbroken4,
-/area/f13/legion)
 "phu" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -24397,7 +24386,7 @@
 "piw" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/legion)
 "piy" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -24445,14 +24434,11 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "pkf" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
+/obj/structure/fence/corner{
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "pku" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib6-old";
@@ -24482,6 +24468,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"pkS" = (
+/obj/structure/curtain{
+	color = "#c40e0e"
+	},
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
+	},
+/area/f13/legion)
 "plq" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermainleft"
@@ -24590,10 +24584,21 @@
 	},
 /area/f13/ncr)
 "poX" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/landmark/start/f13/decanrec,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
+	},
+/obj/structure/mirror{
+	dir = 8;
+	pixel_y = 28
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/legion)
 "ppg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24696,11 +24701,13 @@
 /obj/effect/decal/remains{
 	icon_state = "remains"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 10;
-	icon_state = "outerpavement"
+/obj/structure/table/wood,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters{
+	id = "legionlock"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "prI" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -24712,14 +24719,11 @@
 	},
 /area/f13/brotherhood)
 "prP" = (
-/obj/structure/table,
-/obj/item/ammo_box/c10mm,
-/obj/item/clothing/ears/earmuffs,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
+/obj/structure/fence{
+	dir = 8
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "prR" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1;
@@ -24917,11 +24921,13 @@
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
 "pyf" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavementcorner"
+/obj/structure/fence{
+	dir = 8
 	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pyk" = (
 /obj/item/radio/intercom{
@@ -24934,14 +24940,6 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
-"pyq" = (
-/obj/structure/fence{
-	dir = 4;
-	icon_state = "post_wood"
-	},
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "pyL" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -25035,15 +25033,8 @@
 	},
 /area/f13/building)
 "pBp" = (
-/mob/living/simple_animal/hostile/wolf{
-	aggro_vision_range = 0;
-	desc = "The dogs that survived the Great War are a larger, and tougher breed, size of a wolf.<br>This one seems to be a very good boy.";
-	faction = list("neutral");
-	health = 200;
-	maxHealth = 200;
-	name = "Sniffs-the-earth";
-	tame = 1
-	},
+/obj/structure/simple_door/metal/fence,
+/obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pBq" = (
@@ -25063,8 +25054,11 @@
 	},
 /area/f13/wasteland)
 "pBM" = (
-/obj/effect/landmark/start/f13/venator,
-/turf/open/floor/wood/f13/oakbroken,
+/obj/structure/dresser,
+/obj/structure/sign/poster/prewar/poster89{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/black,
 /area/f13/legion)
 "pBO" = (
 /mob/living/simple_animal/hostile/handy/protectron,
@@ -25101,7 +25095,7 @@
 	icon_state = "cutters"
 	},
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "pDI" = (
 /obj/structure/chair/booth{
 	dir = 4
@@ -25131,10 +25125,7 @@
 /area/f13/building)
 "pEk" = (
 /obj/item/ammo_casing/c10mm,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerpavementcorner"
-	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "pEs" = (
 /obj/machinery/light{
@@ -25206,7 +25197,7 @@
 "pGM" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "pHa" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -25292,9 +25283,6 @@
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"pIz" = (
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
 "pIL" = (
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/floor/wood/f13/oak,
@@ -25315,9 +25303,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "pIX" = (
-/obj/structure/barricade/tentclothcorner,
+/obj/structure/fence/corner{
+	dir = 6
+	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "pJd" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -25559,17 +25549,22 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "pPF" = (
-/obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/strong{
+	obj_integrity = 500
+	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "pPG" = (
-/obj/structure/stacklifter,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowleft"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "pPX" = (
 /obj/machinery/mineral/unloading_machine,
 /turf/open/floor/plasteel/barber{
@@ -25582,10 +25577,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "pQL" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/landmark/start/f13/decan,
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/decoration/vent,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/legion)
 "pQX" = (
 /obj/structure/fence/post{
@@ -25609,10 +25607,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "pRl" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/landmark/start/f13/recleg,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/turf/open/floor/carpet/black,
 /area/f13/legion)
 "pRo" = (
 /obj/structure/table/wood/settler,
@@ -25648,17 +25647,14 @@
 	},
 /area/f13/wasteland)
 "pSp" = (
-/obj/structure/table/wood,
-/obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
-"pSu" = (
-/obj/structure/closet{
-	pixel_y = 10
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowright"
 	},
-/obj/item/restraints/handcuffs,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "pSC" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/dirt,
@@ -25899,10 +25895,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "pYr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/taperecorder,
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Gatehouse";
+	req_one_access_txt = "62"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "pYz" = (
@@ -25960,7 +25957,7 @@
 /area/f13/building)
 "qal" = (
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "qaq" = (
 /obj/machinery/button/door{
 	id = "bosgarage";
@@ -25974,12 +25971,14 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "qbe" = (
-/obj/structure/table,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
 	},
-/area/f13/legion)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "qbl" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26058,6 +26057,10 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"qdG" = (
+/obj/effect/landmark/start/f13/centurion,
+/turf/open/floor/carpet/black,
+/area/f13/legion)
 "qdH" = (
 /obj/structure/table/wood,
 /obj/item/paper,
@@ -26126,7 +26129,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/caves)
+/area/f13/tunnel)
 "qfV" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
@@ -26153,7 +26156,7 @@
 /obj/item/restraints/handcuffs/cable,
 /obj/item/restraints/legcuffs/bola,
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "qgZ" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26202,9 +26205,7 @@
 	},
 /area/f13/farm)
 "qip" = (
-/obj/structure/fence/corner{
-	dir = 6
-	},
+/obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirtcorner"
@@ -26357,7 +26358,7 @@
 /obj/item/claymore/machete/training,
 /obj/item/claymore/machete/training,
 /obj/item/claymore/machete/training,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "qnR" = (
 /obj/effect/decal/remains{
@@ -26489,6 +26490,9 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"qrR" = (
+/turf/closed/wall/f13/ruins,
+/area/f13/tunnel)
 "qsp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -26616,9 +26620,12 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "qxA" = (
-/obj/structure/toilet{
-	pixel_y = 13
-	},
+/obj/item/clothing/under/f13/police,
+/obj/item/clothing/head/f13/police,
+/obj/item/clothing/shoes/combat,
+/obj/structure/closet,
+/obj/item/clothing/head/beret,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -26632,18 +26639,16 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2left"
 	},
-/area/f13/caves)
+/area/f13/tunnel)
 "qyt" = (
-/obj/structure/fence{
-	dir = 8;
-	icon_state = "straight"
+/obj/structure/closet/crate/bin,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/fence/corner{
-	dir = 8;
-	icon_state = "corner"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/building)
 "qyA" = (
 /obj/structure/chair/stool/retro/backed{
 	dir = 8
@@ -26666,8 +26671,11 @@
 	},
 /area/f13/wasteland)
 "qyZ" = (
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/wasteland)
+/obj/structure/punching_bag,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/legion)
 "qzr" = (
 /obj/structure/rack,
 /obj/item/storage/pill_bottle/chem_tin/radx,
@@ -26691,11 +26699,11 @@
 /area/f13/brotherhood)
 "qzF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/area/f13/wasteland)
+/turf/closed/wall/f13/wood,
+/area/f13/legion)
 "qzL" = (
 /obj/machinery/light{
 	dir = 1
@@ -26740,11 +26748,17 @@
 /turf/open/floor/wood,
 /area/f13/building)
 "qBu" = (
-/obj/structure/closet/crate{
-	anchored = 1;
-	can_be_unanchored = 1
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
 	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "qCb" = (
 /obj/structure/closet/crate/medical,
@@ -26765,12 +26779,6 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"qCv" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "qCN" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -26788,10 +26796,10 @@
 /turf/open/floor/wood/f13/stage_r,
 /area/f13/building)
 "qCO" = (
-/obj/structure/simple_door/metal/fence{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
 	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "qDe" = (
 /obj/item/flashlight/lamp,
@@ -26865,19 +26873,11 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "qEU" = (
-/obj/item/clothing/under/f13/police,
-/obj/item/clothing/head/f13/police,
-/obj/item/clothing/shoes/combat,
-/obj/structure/closet,
-/obj/item/clothing/head/beret,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/statue/sandstone/gravestone{
+	desc = "Here lay the body of Articulus Martialis. Proud centurion of the migthy Legion, he slayed hundreds of enemies in the name of Caesar and fell in battle figthing to the end. Some say his life would have been saved if the surviving legionare had stopped digging in the trash piles and actually bothered to provide aid. May he rest well in the hall of Mars."
 	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "qFk" = (
 /turf/closed/wall/f13/wood,
 /area/f13/village)
@@ -26911,36 +26911,27 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland)
 "qGI" = (
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/structure/table/wood/fancy,
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_y = 10
+/obj/structure/bed/mattress{
+	icon_state = "mattress4";
+	pixel_y = -2
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_y = 10
-	},
-/obj/effect/spawner/lootdrop/three_course_meal,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "qGZ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outermaincornerinner"
 	},
 /area/f13/wasteland)
 "qHc" = (
-/obj/structure/chair{
-	dir = 1
+/obj/item/reagent_containers/glass/bucket{
+	desc = "It smells awful.";
+	name = "waste bucket"
 	},
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "qHu" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -27059,17 +27050,17 @@
 	},
 /area/f13/village)
 "qKD" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/glass/bucket{
+	desc = "It smells awful.";
+	name = "waste bucket"
 	},
-/area/f13/building)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "qKU" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
-/obj/effect/landmark/start/f13/centurion,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
 "qLa" = (
@@ -27150,7 +27141,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2right"
 	},
-/area/f13/caves)
+/area/f13/tunnel)
 "qNn" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -27169,15 +27160,11 @@
 	},
 /area/f13/wasteland)
 "qNs" = (
-/obj/structure/fence/wooden{
-	dir = 4;
-	icon_state = "post_wood"
+/obj/structure/bed/mattress{
+	icon_state = "mattress2"
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "qNB" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -27246,11 +27233,13 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "qON" = (
-/obj/structure/reagent_dispensers/barrel/two,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+/obj/structure/table/wood,
+/obj/structure/barricade/bars,
+/obj/structure/curtain{
+	color = "#c40e0e"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "qOR" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -27334,14 +27323,11 @@
 	},
 /area/f13/wasteland)
 "qQo" = (
-/obj/structure/fence{
+/obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
+	dir = 4;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
@@ -27428,6 +27414,7 @@
 "qSM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/bars,
+/obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "qSN" = (
@@ -27443,14 +27430,6 @@
 	},
 /turf/open/water,
 /area/f13/caves)
-"qSR" = (
-/obj/structure/curtain{
-	color = "#c40e0e"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/legion)
 "qTe" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
@@ -27477,13 +27456,6 @@
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"qTI" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
 "qTK" = (
 /obj/item/flag/ncr,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -27525,6 +27497,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"qVh" = (
+/obj/structure/simple_door/wood,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/legion)
 "qWp" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -27536,11 +27512,6 @@
 /obj/structure/fluff/fokoff_sign,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"qWU" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/breadhard,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "qWX" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -27599,17 +27570,16 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "qZe" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/clothing_middle,
+/obj/machinery/chem_master/primitive,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/legion)
 "qZy" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/f13/tunnel,
 /area/f13/wasteland)
 "qZD" = (
 /obj/structure/statue/wood/headstonewood,
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "qZN" = (
 /obj/structure/chair/office/dark,
@@ -27689,10 +27659,16 @@
 	},
 /area/f13/tunnel)
 "rbE" = (
-/obj/structure/simple_door/metal/fence,
-/obj/structure/decoration/rag,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/bed/mattress/pregame,
+/obj/item/clothing/head/fedora,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "rck" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -27798,11 +27774,12 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
 "rfd" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/toilet{
+	pixel_y = 13
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "rfI" = (
 /obj/structure/closet/cabinet,
@@ -27864,27 +27841,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "riB" = (
-/obj/structure/table,
-/obj/machinery/light/fo13colored/Red{
-	bulb_colour = "#008000";
-	desc = "A lighting fixture.";
-	dir = 4;
-	light_color = "#008000";
-	name = "light tube"
+/obj/structure/fence,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Secret"
-	},
-/obj/machinery/light/fo13colored/Red{
-	bulb_colour = "#008000";
-	desc = "A lighting fixture.";
-	dir = 4;
-	light_color = "#008000";
-	name = "light tube"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "riF" = (
 /obj/structure/sign/poster/contraband/pinup_couch,
@@ -27928,10 +27888,10 @@
 /area/f13/wasteland)
 "rjP" = (
 /obj/machinery/button/door{
-	id = "interiorgate";
-	name = "Interior door button";
+	id = "exteriorgate";
+	name = "Exterior door button";
 	pixel_x = 6;
-	pixel_y = 32
+	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
@@ -27939,6 +27899,12 @@
 	id = "frontgateshut";
 	name = "gate shutters";
 	pixel_x = -5;
+	pixel_y = 32
+	},
+/obj/machinery/button/door{
+	id = "interiorgate";
+	name = "Interior door button";
+	pixel_x = 6;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -28129,17 +28095,14 @@
 	},
 /area/f13/village)
 "rrc" = (
-/obj/structure/table/wood,
-/obj/item/melee/curator_whip{
-	desc = "It stings like hell to be hit by.";
-	name = "Slave whip"
+/obj/effect/decal/remains{
+	icon_state = "remains"
 	},
-/obj/item/melee/curator_whip{
-	desc = "It stings like hell to be hit by.";
-	name = "Slave whip"
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/area/f13/building)
 "rrl" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -28220,12 +28183,10 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "ruE" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outermaincornerouter"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "ruF" = (
 /obj/structure/table,
 /obj/item/storage/belt/medical,
@@ -28240,6 +28201,14 @@
 	icon_state = "verticalleftborderleft2bottom"
 	},
 /area/f13/village)
+"rvl" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/legion)
 "rvr" = (
 /turf/open/floor/wood,
 /area/f13/building)
@@ -28267,10 +28236,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "rwO" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters{
+	id = "legionlock"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "rxa" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -28422,8 +28394,8 @@
 	},
 /area/f13/radiation)
 "rAY" = (
-/obj/structure/closet/cardboard,
-/obj/item/crowbar,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/f13/doctor,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "rBs" = (
@@ -28448,12 +28420,7 @@
 /area/f13/wasteland)
 "rCC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Gatehouse";
-	req_one_access_txt = "62"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/closed/wall/f13/wood,
 /area/f13/building)
 "rCQ" = (
 /obj/structure/grille,
@@ -28502,10 +28469,12 @@
 "rEd" = (
 /obj/structure/table/wood,
 /obj/item/pda,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/carpet/black,
 /area/f13/legion)
 "rEe" = (
-/obj/effect/spawner/lootdrop/trash,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "rEi" = (
@@ -28514,11 +28483,8 @@
 	},
 /area/f13/tunnel)
 "rEk" = (
-/obj/structure/fermenting_barrel{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "rEB" = (
 /obj/structure/simple_door/interior,
@@ -28541,7 +28507,7 @@
 "rFk" = (
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "rFx" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -28574,9 +28540,13 @@
 	},
 /area/f13/building)
 "rGC" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "rGE" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -28600,6 +28570,19 @@
 /obj/item/storage/box/drinkingglasses,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"rHT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 10
+	},
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/legion)
 "rIl" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -28745,6 +28728,11 @@
 	icon_state = "shadowright"
 	},
 /area/f13/wasteland)
+"rND" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/decan,
+/turf/open/floor/carpet/black,
+/area/f13/legion)
 "rNT" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/cowboyt,
@@ -28829,7 +28817,7 @@
 /area/f13/building)
 "rQI" = (
 /obj/structure/closet/crate/large,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "rQR" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -29027,11 +29015,10 @@
 	},
 /area/f13/building)
 "rXv" = (
-/obj/structure/simple_door/metal/fence{
-	door_type = "fence_wood";
-	icon_state = "fence_wood"
+/obj/structure/statue/sandstone/gravestone{
+	desc = "Here lies Sydney Blackhawk. A hero to the republic, she sacrificed much in her life  and died for the republic, may her burial be a reminder of valor and heroism to those who love freedom."
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "rXF" = (
 /obj/machinery/light/small{
@@ -29041,6 +29028,11 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"rYn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/vetlegionary,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "rYG" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/dirt{
@@ -29080,11 +29072,9 @@
 	},
 /area/f13/building)
 "saf" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/legion)
+/obj/dugpit,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "sav" = (
 /obj/structure/fence/handrail{
 	dir = 1;
@@ -29198,6 +29188,9 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/ncr)
+"sem" = (
+/turf/closed/wall/f13/wood,
+/area/f13/tunnel)
 "sew" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29226,10 +29219,16 @@
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"seU" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/tunnel)
 "seY" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "sfc" = (
 /obj/structure/chair{
@@ -29328,7 +29327,9 @@
 	pixel_x = -7;
 	pixel_y = 5
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
 /area/f13/legion)
 "sgL" = (
 /obj/item/mop,
@@ -29397,8 +29398,9 @@
 	},
 /area/f13/wasteland)
 "sij" = (
-/obj/structure/campfire/stove,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table/wood,
+/obj/structure/bedsheetbin,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "sim" = (
 /obj/structure/car/rubbish1,
@@ -29483,16 +29485,16 @@
 /area/f13/building)
 "skE" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/item/flashlight/lantern,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"skZ" = (
+/obj/structure/simple_door/metal/fence{
+	dir = 8
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building)
-"skZ" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "slr" = (
 /obj/structure/chair/wood/modern,
@@ -29522,10 +29524,6 @@
 /obj/item/clothing/suit/armor/f13/rustedcowboy,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"sme" = (
-/obj/structure/bookcase/random/fiction,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "smi" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -29674,6 +29672,12 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/village)
+"sqy" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "sqA" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/desert,
@@ -29857,10 +29861,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "swB" = (
-/obj/structure/simple_door/room,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/bars,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "swH" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -29919,10 +29927,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "szi" = (
-/obj/machinery/photocopier,
-/obj/effect/turf_decal/stripes/white/box,
+/obj/structure/window/fulltile/wood,
+/obj/structure/curtain{
+	color = "#c40e0e"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/ncr)
+/area/f13/legion)
 "szm" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/barber{
@@ -30005,7 +30015,7 @@
 /obj/structure/chair/wood/modern{
 	dir = 1
 	},
-/obj/machinery/light/small,
+/obj/effect/decal/remains/human,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "sBR" = (
@@ -30117,13 +30127,12 @@
 	},
 /area/f13/wasteland)
 "sGp" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/simple_door/metal/fence{
+	door_type = "fence_wood";
+	icon_state = "fence_wood"
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "sGG" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/turf_decal/stripes/white/line{
@@ -30192,9 +30201,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "sIO" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
 	},
 /area/f13/building)
 "sIW" = (
@@ -30256,6 +30264,9 @@
 /obj/effect/decal/riverbankcorner{
 	dir = 1
 	},
+/obj/effect/decal/riverbankcorner{
+	dir = 8
+	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "sLi" = (
@@ -30315,14 +30326,10 @@
 	},
 /area/f13/building)
 "sMs" = (
-/obj/structure/decoration/clock/old{
-	pixel_y = 32
-	},
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/item/shovel,
+/obj/structure/table,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "sMP" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/recharger,
@@ -30407,13 +30414,15 @@
 	},
 /area/f13/building)
 "sPC" = (
-/obj/structure/filingcabinet,
-/obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/closet,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/restraints/handcuffs,
+/obj/item/instrument/guitar,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/ncr)
+/area/f13/building)
 "sPE" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -30437,7 +30446,7 @@
 	id = "campd"
 	},
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "sPZ" = (
 /obj/structure/simple_door/tentflap_cloth,
 /turf/open/indestructible/ground/outside/dirt,
@@ -30526,7 +30535,7 @@
 "sUl" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/legion)
 "sUm" = (
 /obj/effect/landmark/start/f13/barkeep,
 /obj/effect/decal/cleanable/dirt,
@@ -30554,7 +30563,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "sUv" = (
 /obj/structure/fence/corner{
 	dir = 4;
@@ -30638,20 +30647,16 @@
 	},
 /area/f13/ncr)
 "sWC" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "ncrlockdown";
-	name = "Lockdown";
-	req_access_txt = "121"
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/ncr)
-"sWE" = (
-/obj/structure/table/wood/poker,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/mirror{
+	pixel_x = 32
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
 "sWF" = (
 /obj/item/stack/ore/iron,
@@ -30660,6 +30665,15 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"sWG" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/legion)
 "sWI" = (
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
@@ -30682,6 +30696,13 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"sXU" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress3"
+	},
+/obj/item/instrument/harmonica,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "sYe" = (
 /obj/structure/closet/cabinet,
 /obj/machinery/light{
@@ -30724,9 +30745,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "sZt" = (
-/obj/item/picket_sign,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "sZA" = (
 /obj/structure/tires/half,
 /turf/open/indestructible/ground/outside/desert,
@@ -30736,7 +30760,7 @@
 	dir = 1;
 	icon_state = "post_wood"
 	},
-/turf/open/floor/wood/f13/stage_bl,
+/turf/open/floor/wood/f13/old,
 /area/f13/wasteland)
 "sZT" = (
 /obj/structure/table/wood,
@@ -30746,10 +30770,9 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "sZU" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/simple_door/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "tae" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -30789,11 +30812,10 @@
 /turf/open/water,
 /area/f13/caves)
 "tba" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft2top"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/bench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "tbd" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/outside/dirt,
@@ -30836,15 +30858,10 @@
 	},
 /area/f13/wasteland)
 "tci" = (
-/obj/structure/rack,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/storage/bag/plants,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/obj/structure/statue/sandstone/gravestone{
+	desc = "Therein lay Lucy, born into a simple farming life and captured and forced to fight by raiders, she would battle her own struggles in life against her own mental problems and lose the fight as she commited suicide in her own home. May Lucy Fire-Fly rest well and find peace in death."
 	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "tck" = (
 /obj/effect/decal/waste{
@@ -30863,14 +30880,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "tcs" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/turf/open/floor/carpet/black,
-/area/f13/ncr)
-"tct" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oakbroken2,
-/area/f13/legion)
+/obj/structure/closet/crate/coffin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "tcX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
@@ -30900,14 +30912,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "tec" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "tep" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_tiled,
@@ -31087,14 +31100,40 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "tkY" = (
-/obj/item/paper,
+/obj/structure/bed/mattress/pregame,
+/obj/item/restraints/handcuffs{
+	icon_state = "handcuffGag"
+	},
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "tlh" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/light/fo13colored/Red{
+	bulb_colour = "#008000";
+	desc = "A lighting fixture.";
+	dir = 4;
+	light_color = "#008000";
+	name = "light tube"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Secret"
+	},
+/obj/machinery/light/fo13colored/Red{
+	bulb_colour = "#008000";
+	desc = "A lighting fixture.";
+	dir = 4;
+	light_color = "#008000";
+	name = "light tube"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
@@ -31185,7 +31224,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "tnd" = (
-/turf/open/floor/wood/f13/oakbroken2,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "tnf" = (
 /obj/structure/ladder/unbreakable{
@@ -31195,13 +31235,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "tnu" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
+/obj/effect/decal/remains{
+	icon_state = "remains"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "tom" = (
 /obj/structure/toilet{
 	dir = 1
@@ -31465,13 +31505,9 @@
 	},
 /area/f13/tunnel)
 "tvp" = (
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/obj/item/candle/infinite,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "tvA" = (
 /obj/structure/rack,
@@ -31493,26 +31529,13 @@
 	},
 /area/f13/village)
 "tvL" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
+/obj/effect/decal/riverbank{
+	dir = 5
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "twe" = (
-/obj/item/trash/sosjerky{
-	pixel_x = -6
-	},
-/obj/item/trash/sosjerky{
-	pixel_x = 1;
-	pixel_y = 10
-	},
-/obj/item/trash/sosjerky{
-	icon_state = "dr_gibb";
-	pixel_x = 4;
-	pixel_y = -3
-	},
+/mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "twq" = (
@@ -31575,7 +31598,6 @@
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "txC" = (
@@ -31627,12 +31649,7 @@
 	},
 /area/f13/wasteland)
 "tzf" = (
-/obj/item/clothing/under/f13/police,
-/obj/item/clothing/head/f13/police,
-/obj/item/clothing/shoes/combat,
-/obj/structure/closet,
-/obj/item/clothing/head/beret,
-/obj/item/restraints/handcuffs/fake/kinky,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -31895,10 +31912,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"tHw" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "tIa" = (
 /obj/machinery/mineral/wasteland_vendor/bank,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -31921,6 +31934,11 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/village)
+"tJn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "tJv" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -31987,11 +32005,14 @@
 	},
 /area/f13/ncr)
 "tLE" = (
-/obj/machinery/light/small,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft1"
+/obj/structure/closet,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "tLI" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/dirt{
@@ -32124,12 +32145,6 @@
 	icon_state = "horizontalinnermain3"
 	},
 /area/f13/wasteland)
-"tQk" = (
-/obj/structure/table/wood,
-/obj/item/stack/f13Cash/aureus,
-/obj/effect/spawner/lootdrop/three_course_meal,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "tQl" = (
 /obj/structure/chair/wood/modern{
 	dir = 1
@@ -32161,9 +32176,10 @@
 /area/f13/bar)
 "tQV" = (
 /obj/structure/chair/wood{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/wood/f13/oak,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "tQW" = (
 /obj/structure/cargocrate,
@@ -32230,21 +32246,20 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "tTV" = (
-/obj/structure/flora/wasteplant/wild_agave,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "tUb" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2bottom"
 	},
 /area/f13/wasteland)
 "tUc" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/legion)
 "tUf" = (
 /obj/structure/safe,
@@ -32293,9 +32308,10 @@
 	},
 /area/f13/ncr)
 "tUp" = (
-/obj/structure/table/wood/settler,
-/obj/item/toy/cards/deck,
-/turf/open/floor/f13/wood,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
 "tUr" = (
 /obj/structure/table/wood,
@@ -32368,11 +32384,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tWv" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
 	},
-/area/f13/wasteland)
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
+"tXb" = (
+/obj/structure/simple_door/tent,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "tXe" = (
 /obj/structure/weightmachine/stacklifter,
 /obj/effect/turf_decal/stripes/white/full,
@@ -32404,9 +32428,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tXK" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/table/wood,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "tXY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
@@ -32531,7 +32565,7 @@
 /obj/machinery/workbench/forge,
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "udt" = (
 /obj/machinery/autolathe/ammo,
@@ -32548,7 +32582,7 @@
 /obj/item/stack/medical/suture,
 /obj/item/reagent_containers/food/snacks/grown/pungafruit,
 /obj/item/reagent_containers/food/snacks/grown/pungafruit,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "udY" = (
 /obj/structure/sign/poster/prewar/poster67{
@@ -32630,6 +32664,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"ugj" = (
+/obj/structure/destructible/tribal_torch/wall/lit,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/legion)
 "ugm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -32663,7 +32704,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottomright"
 	},
-/area/f13/wasteland)
+/area/f13/tunnel)
 "uhk" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -32694,21 +32735,11 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/f13/caves)
-"uhW" = (
-/obj/structure/table/wood,
-/obj/item/pickaxe,
-/obj/item/clothing/suit/f13/robe_liz,
-/obj/item/clothing/suit/f13/robe_liz,
-/obj/item/clothing/suit/f13/robe_liz,
-/obj/item/clothing/suit/f13/robe_liz,
-/obj/machinery/light/small,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
+/area/f13/tunnel)
 "uhY" = (
-/obj/structure/bonfire,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/effect/landmark/start/f13/venator,
+/turf/open/floor/carpet/black,
+/area/f13/legion)
 "uij" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood,
@@ -32755,12 +32786,11 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/wasteland)
 "ulc" = (
-/obj/structure/fence/wooden,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
+/obj/effect/decal/riverbank{
+	dir = 1
 	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "ulf" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -32815,11 +32845,13 @@
 	},
 /area/f13/building)
 "ulU" = (
-/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/wolf/alpha{
+	desc = "Legion mongrels are dogs owned and bred by the Houndmasters of Caesar's Legion. Mongrels are mainly used in combat and scouting missions by the Legion.";
+	faction = list("neutral");
+	name = "Brutus"
+	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/legion)
-"umy" = (
-/turf/open/floor/carpet/airless,
 /area/f13/legion)
 "umD" = (
 /turf/open/floor/f13{
@@ -32845,12 +32877,12 @@
 	},
 /area/f13/building)
 "unp" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavement"
+/obj/effect/decal/riverbankcorner{
+	dir = 4
 	},
-/area/f13/wasteland)
+/obj/effect/decal/riverbankcorner,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "unF" = (
 /obj/machinery/light{
 	dir = 8;
@@ -32877,19 +32909,9 @@
 	},
 /area/f13/wasteland)
 "unJ" = (
-/obj/structure/fermenting_barrel{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/obj/structure/fermenting_barrel{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
+/obj/structure/statue/sandstone/mars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "unW" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -32905,12 +32927,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/brotherhood)
-"uow" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/wall/lit,
-/obj/effect/landmark/start/f13/vexillarius,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "uoK" = (
 /obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/road{
@@ -33000,11 +33016,8 @@
 	},
 /area/f13/ncr)
 "uqW" = (
-/obj/structure/simple_door/metal/fence,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
 "urg" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -33034,11 +33047,19 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "ury" = (
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/obj/structure/rack,
+/obj/item/electropack/shockcollar,
+/obj/item/electropack/shockcollar,
+/obj/item/electropack/shockcollar,
+/obj/item/electropack/shockcollar/explosive,
+/obj/item/key/bcollar,
+/obj/item/key/collar,
+/obj/item/key/collar,
+/obj/item/key/collar,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "urA" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -33046,8 +33067,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "urN" = (
-/turf/open/floor/carpet/black,
-/area/f13/ncr)
+/obj/structure/closet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/f13/legslavef,
+/obj/item/clothing/under/f13/legslavef,
+/obj/item/clothing/under/f13/legslavef,
+/obj/item/clothing/suit/armor/f13/slavelabor,
+/obj/item/clothing/suit/armor/f13/slavelabor,
+/obj/item/clothing/suit/armor/f13/slavelabor,
+/obj/item/clothing/under/f13/legslavef,
+/obj/item/clothing/under/f13/legslavef,
+/obj/item/clothing/under/f13/legslavef,
+/obj/item/clothing/suit/armor/f13/slavelabor,
+/obj/item/clothing/suit/armor/f13/slavelabor,
+/obj/item/clothing/suit/armor/f13/slavelabor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "urW" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /mob/living/simple_animal/cow/brahmin,
@@ -33096,6 +33132,15 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"uuc" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "uug" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/f13{
@@ -33122,6 +33167,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"uvp" = (
+/obj/structure/bed,
+/obj/effect/landmark/start/f13/legionary,
+/obj/item/bedsheet/brown,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "uvq" = (
 /obj/structure/closet/crate/large,
 /obj/effect/decal/cleanable/glass,
@@ -33247,7 +33302,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uzO" = (
-/obj/machinery/vending/nukacolavend,
+/obj/structure/closet/crate/bin,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "uzU" = (
@@ -33260,15 +33315,20 @@
 	},
 /area/f13/ncr)
 "uAk" = (
-/obj/item/pet_carrier{
-	pixel_x = 4;
-	pixel_y = 7
-	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor5-old"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/closet,
+/obj/item/clothing/under/f13/legslave,
+/obj/item/clothing/under/f13/legslave,
+/obj/item/clothing/under/f13/legslave,
+/obj/item/clothing/suit/armor/f13/slavelabor,
+/obj/item/clothing/suit/armor/f13/slavelabor,
+/obj/item/clothing/suit/armor/f13/slavelabor,
+/obj/item/clothing/under/f13/legslave,
+/obj/item/clothing/under/f13/legslave,
+/obj/item/clothing/under/f13/legslave,
+/obj/item/clothing/suit/armor/f13/slavelabor,
+/obj/item/clothing/suit/armor/f13/slavelabor,
+/obj/item/clothing/suit/armor/f13/slavelabor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "uAm" = (
 /obj/item/ammo_casing/c10mm/ap,
@@ -33429,9 +33489,10 @@
 /area/f13/clinic)
 "uFt" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 1
+	dir = 1;
+	pixel_y = 12
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "uFB" = (
 /obj/machinery/light/small{
@@ -33481,7 +33542,8 @@
 /area/f13/wasteland)
 "uGF" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "uGH" = (
 /obj/structure/table/wood,
@@ -33569,10 +33631,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "uIU" = (
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/structure/table/wood,
+/obj/item/melee/curator_whip{
+	desc = "It stings like hell to be hit by.";
+	name = "Slave whip"
+	},
+/obj/item/melee/curator_whip{
+	desc = "It stings like hell to be hit by.";
+	name = "Slave whip"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "uJd" = (
 /obj/structure/decoration/clock/old{
 	pixel_x = -32
@@ -33752,23 +33821,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uOr" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/table/wood,
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "uOt" = (
-/obj/structure/bed/dogbed{
-	pixel_x = -10;
-	pixel_y = 13
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "uOu" = (
 /obj/machinery/light/small/broken{
@@ -33874,9 +33936,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "uSj" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal,
-/turf/open/floor/carpet/black,
+/obj/structure/sign/poster/prewar/poster90,
+/turf/closed/wall/r_wall/rust,
 /area/f13/ncr)
 "uSm" = (
 /obj/structure/flora/tree/tall,
@@ -34059,6 +34120,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"uVX" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/effect/landmark/start/f13/recleg,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "uWs" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -34109,6 +34176,11 @@
 "uXj" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"uXs" = (
+/obj/structure/destructible/tribal_torch/wall/lit,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "uXV" = (
 /obj/item/stack/sheet/mineral/wood/five,
 /turf/open/indestructible/ground/outside/ruins{
@@ -34153,6 +34225,15 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"uYC" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "uYP" = (
 /obj/structure/chair/comfy{
 	dir = 8
@@ -34208,14 +34289,10 @@
 /turf/closed/wall/f13/tunnel,
 /area/f13/caves)
 "vaH" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/obj/structure/destructible/tribal_torch/wall/lit,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/legion)
 "vaP" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -34358,17 +34435,9 @@
 /area/f13/building)
 "vfn" = (
 /obj/structure/rack,
-/obj/item/electropack/shockcollar,
-/obj/item/electropack/shockcollar,
-/obj/item/electropack/shockcollar,
-/obj/item/electropack/shockcollar/explosive,
-/obj/item/key/bcollar,
-/obj/item/key/collar,
-/obj/item/key/collar,
-/obj/item/key/collar,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "vfs" = (
 /obj/structure/rack,
@@ -34618,11 +34687,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "vmX" = (
-/obj/structure/chair/office/dark{
-	dir = 1
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
 	},
-/turf/open/floor/carpet/black,
-/area/f13/ncr)
+/turf/open/floor/carpet/red,
+/area/f13/legion)
 "vnc" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -34686,10 +34755,9 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "vpJ" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
-	},
-/area/f13/caves)
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/floor/carpet/red,
+/area/f13/legion)
 "vpM" = (
 /obj/structure/flora/rock/jungle,
 /turf/closed/indestructible/rock,
@@ -34878,24 +34946,23 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "vwz" = (
-/obj/structure/fence{
-	dir = 1
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "vwG" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "vwL" = (
-/obj/machinery/light/small/broken{
-	dir = 1
+/obj/effect/decal/riverbank,
+/obj/effect/decal/riverbankcorner{
+	dir = 8
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "vwM" = (
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/indestructible/ground/outside/desert{
@@ -34957,10 +35024,14 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "vyw" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/decal/riverbank{
+	dir = 1
+	},
+/obj/effect/decal/riverbankcorner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "vzb" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/trash,
@@ -35041,8 +35112,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vAv" = (
-/obj/structure/barricade/tentclothedge,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "vAM" = (
 /obj/machinery/vending/dinnerware,
@@ -35125,7 +35198,6 @@
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/obj/effect/landmark/start/f13/vetlegionary,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
 "vDq" = (
@@ -35234,7 +35306,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "vHe" = (
-/turf/open/floor/wood/f13/oakbroken,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
 /area/f13/legion)
 "vHh" = (
 /obj/machinery/vending/hydroseeds,
@@ -35289,7 +35363,7 @@
 	pixel_x = 4
 	},
 /obj/machinery/iv_drip,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "vIb" = (
 /obj/structure/chair/wood/worn{
@@ -35352,14 +35426,13 @@
 	},
 /area/f13/building)
 "vIB" = (
-/obj/item/ammo_casing/c10mm,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+/obj/effect/decal/riverbank{
+	dir = 10
 	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "vIX" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/wood/f13/oakbroken2,
 /area/f13/building)
 "vJb" = (
 /obj/structure/closet/cabinet,
@@ -35378,14 +35451,11 @@
 	},
 /area/f13/city)
 "vJM" = (
-/obj/structure/fence/corner{
-	dir = 1
+/obj/effect/decal/riverbank{
+	dir = 6
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "vJP" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/indestructible/ground/outside/desert,
@@ -35393,9 +35463,10 @@
 "vKl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 1
+	dir = 1;
+	pixel_y = 12
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "vKm" = (
 /obj/structure/window/fulltile/house/broken,
@@ -35558,9 +35629,8 @@
 	pixel_x = 9;
 	pixel_y = 14
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "vPY" = (
 /turf/open/indestructible/ground/inside/dirt,
@@ -35604,13 +35674,20 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "vRb" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/structure/simple_door/wood,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/legion)
 "vRo" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"vRG" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "vRR" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/mountain,
@@ -35633,13 +35710,9 @@
 /area/f13/building)
 "vSk" = (
 /obj/structure/fence/corner/wooden{
-	dir = 8
+	dir = 4
 	},
-/obj/structure/fence/wooden{
-	dir = 4;
-	icon_state = "post_wood"
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "vSq" = (
 /obj/item/instrument/guitar,
@@ -35734,9 +35807,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"vVR" = (
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "vVT" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/inside/mountain,
@@ -35761,14 +35831,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "vWo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/light/fo13colored/Red{
+	desc = "A lighting fixture.";
+	dir = 8;
+	light_color = "#008000";
+	name = "light tube"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0"
+	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "vWw" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/window/fulltile/house{
@@ -35778,10 +35850,7 @@
 /area/f13/building)
 "vWC" = (
 /obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/item/bedsheet/hos,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
 "vWK" = (
@@ -35823,7 +35892,7 @@
 "vXs" = (
 /obj/machinery/power/smes,
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "vXv" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /obj/item/clothing/under/f13/shiny,
@@ -35894,8 +35963,7 @@
 	},
 /area/f13/building)
 "vZr" = (
-/obj/structure/table/wood,
-/obj/item/ammo_casing/shotgun/buckshot,
+/obj/structure/chair/stool/bar,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "vZI" = (
@@ -35907,11 +35975,11 @@
 	},
 /area/f13/building)
 "wag" = (
-/obj/structure/table/wood/fancy,
-/obj/item/restraints/handcuffs,
-/obj/item/melee/chainofcommand/tailwhip/kitty,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/decal/riverbank{
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "wbd" = (
 /obj/structure/table/wood,
 /obj/machinery/processor/chopping_block,
@@ -35925,7 +35993,7 @@
 /area/f13/wasteland)
 "wcu" = (
 /obj/structure/barricade/bars,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/strong,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "wcA" = (
@@ -35999,9 +36067,19 @@
 	},
 /area/f13/building)
 "wfv" = (
-/obj/structure/window/fulltile/house,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/structure/rack,
+/obj/item/storage/bag/plants,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"wfG" = (
+/obj/structure/bonfire,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/legion)
 "wgr" = (
 /obj/machinery/mineral/wasteland_vendor/mining,
 /turf/open/indestructible/ground/inside/mountain,
@@ -36099,10 +36177,11 @@
 	},
 /area/f13/ncr)
 "wjS" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "wjU" = (
 /obj/structure/reagent_dispensers/barrel/old,
 /turf/open/indestructible/ground/inside/mountain,
@@ -36222,7 +36301,7 @@
 /turf/open/floor/holofloor/carpet,
 /area/f13/building)
 "wom" = (
-/turf/closed/indestructible/f13/matrix,
+/turf/closed/indestructible/rock,
 /area/f13/legion)
 "woC" = (
 /obj/structure/flora/grass/wasteland{
@@ -36293,9 +36372,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "wpk" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
@@ -36321,28 +36399,16 @@
 	},
 /area/f13/wasteland)
 "wqz" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetblue"
-	},
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/legion)
 "wqJ" = (
-/obj/structure/closet/cabinet,
-/obj/structure/curtain{
-	color = "#845f58"
+/obj/machinery/microwave/stove,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "house1ladder";
-	layer = 2
-	},
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/legion)
 "wqO" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -36585,12 +36651,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"wxR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/instrument/trumpet,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "wya" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
@@ -36771,7 +36831,7 @@
 	id = "interiorgate2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
+/area/f13/building)
 "wDc" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -36793,13 +36853,15 @@
 	},
 /area/f13/building)
 "wDP" = (
-/obj/machinery/light/small/broken{
-	dir = 1
+/obj/structure/table,
+/obj/item/storage/box/drinkingglasses,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building)
+/area/f13/legion)
 "wDW" = (
 /obj/structure/bed,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -36846,7 +36908,7 @@
 /area/f13/building)
 "wFo" = (
 /obj/machinery/autolathe/ammo,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "wFp" = (
 /obj/structure/chair{
@@ -36870,10 +36932,9 @@
 	},
 /area/f13/wasteland)
 "wFT" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/caves)
+/obj/structure/table,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "wGc" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_north_middle"
@@ -36889,13 +36950,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "wGq" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Gatehouse";
-	req_one_access_txt = "62"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/ketchup,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "wGz" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -36925,14 +36983,12 @@
 	},
 /area/f13/radiation)
 "wHJ" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
+/obj/effect/landmark/start/f13/campfollower,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "wHR" = (
 /obj/structure/fluff/rails{
 	dir = 4
@@ -37007,15 +37063,22 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "wLb" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain{
-	color = "#845f58"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1;
+	name = "Equipment Closet";
+	req_access_txt = "121"
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "ncrlockdown";
-	name = "Lockdown Shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/obj/effect/turf_decal/stripes/white/box,
+/obj/item/melee/classic_baton/telescopic,
+/obj/item/melee/classic_baton/telescopic,
+/obj/item/gun/ballistic/shotgun/hunting,
+/obj/item/gun/ballistic/shotgun/hunting,
+/obj/item/storage/fancy/ammobox/beanbag,
+/obj/item/storage/fancy/ammobox/beanbag,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "wLi" = (
 /mob/living/simple_animal/hostile/radroach,
@@ -37036,7 +37099,7 @@
 	},
 /obj/item/storage/trash_stack,
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "wLw" = (
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt{
@@ -37103,14 +37166,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
-"wNu" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "wNK" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -37202,6 +37257,9 @@
 /obj/effect/decal/riverbankcorner{
 	dir = 1
 	},
+/obj/effect/decal/riverbankcorner{
+	dir = 8
+	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "wPl" = (
@@ -37285,8 +37343,9 @@
 	},
 /area/f13/building)
 "wRm" = (
-/obj/structure/table/wood/poker,
-/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/structure/chair/wood/modern{
+	dir = 8
+	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "wRG" = (
@@ -37350,6 +37409,17 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"wSA" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
+"wSF" = (
+/obj/effect/landmark/start/f13/slave,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "wSJ" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
@@ -37374,7 +37444,12 @@
 	dir = 4;
 	icon_state = "innermaincornerinner"
 	},
-/area/f13/wasteland)
+/area/f13/tunnel)
+"wTX" = (
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "wUc" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -37466,9 +37541,14 @@
 	},
 /area/f13/wasteland)
 "wWI" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/ncr)
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/legion)
 "wWN" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -37509,6 +37589,13 @@
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland)
+"wXo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/legion)
 "wXv" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood,
@@ -37583,14 +37670,12 @@
 /obj/structure/weightlifter,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"wZA" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oakbroken,
-/area/f13/legion)
 "wZT" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet/black,
-/area/f13/ncr)
+/obj/effect/landmark/start/f13/auxilia,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/legion)
 "xae" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -37746,12 +37831,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "xdP" = (
-/obj/structure/fence/corner,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
 	},
-/area/f13/wasteland)
+/area/f13/legion)
 "xed" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -37775,8 +37861,12 @@
 	},
 /area/f13/brotherhood)
 "xes" = (
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "xeG" = (
 /obj/structure/chair{
 	dir = 8
@@ -37790,12 +37880,9 @@
 /turf/closed/wall/f13/wood/interior,
 /area/f13/ncr)
 "xeQ" = (
-/obj/structure/bed/mattress/pregame,
-/obj/item/clothing/head/fedora,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -37853,6 +37940,15 @@
 	dir = 5
 	},
 /area/f13/building)
+"xgk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/legion)
 "xgn" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/white/box,
@@ -37916,16 +38012,11 @@
 	},
 /area/f13/wasteland)
 "xih" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/fence/corner{
+/obj/structure/chair/wood{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "xiq" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road{
@@ -37978,7 +38069,7 @@
 	pixel_x = 9;
 	pixel_y = 14
 	},
-/obj/structure/destructible/tribal_torch,
+/obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt"
@@ -37996,7 +38087,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "xks" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/plasteel/floorgrime,
@@ -38143,16 +38234,16 @@
 	},
 /area/f13/village)
 "xow" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress3"
-	},
-/obj/item/soap/homemade,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/table/wood,
+/obj/item/pen,
+/obj/item/pen,
+/obj/item/pen,
+/obj/item/pen,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/legion)
 "xox" = (
-/obj/item/twohanded/required/kirbyplants,
 /obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "xpg" = (
 /obj/structure/barricade/tentclothedge,
@@ -38239,12 +38330,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "xqQ" = (
-/obj/item/flag/legion,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerborder"
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
 	},
-/area/f13/wasteland)
+/turf/open/floor/carpet/black,
+/area/f13/legion)
 "xrd" = (
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
@@ -38283,6 +38373,15 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"xsj" = (
+/obj/structure/decoration/vent,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/legion)
 "xsl" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
@@ -38320,9 +38419,8 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "xsI" = (
-/obj/structure/table/wood,
-/obj/item/candle/infinite,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/dresser,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "xta" = (
 /obj/structure/flora/grass/jungle/b,
@@ -38367,11 +38465,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xuh" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/ketchup,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "xus" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/road{
@@ -38490,9 +38583,15 @@
 /area/f13/brotherhood)
 "xwW" = (
 /obj/structure/table/wood,
-/obj/item/kitchen/knife/cosmicdirty,
+/obj/item/clothing/suit/f13/robe_liz,
+/obj/item/clothing/suit/f13/robe_liz,
+/obj/item/clothing/suit/f13/robe_liz,
+/obj/item/clothing/suit/f13/robe_liz,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/legion)
 "xxf" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/dirt{
@@ -38545,7 +38644,7 @@
 "xzk" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/tunnel)
 "xzn" = (
 /obj/structure/stone_tile/center,
 /turf/open/indestructible/ground/inside/mountain,
@@ -38581,12 +38680,14 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
 "xBC" = (
-/obj/structure/table,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building)
+/area/f13/legion)
 "xBM" = (
 /obj/machinery/door/window{
 	dir = 4
@@ -38610,11 +38711,9 @@
 	},
 /area/f13/bar)
 "xDE" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
 	},
-/obj/effect/landmark/start/f13/explorer,
-/turf/open/floor/wood/f13/oakbroken,
 /area/f13/legion)
 "xDH" = (
 /obj/structure/table/wood,
@@ -38631,12 +38730,10 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/ncr)
 "xEk" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/breadhard,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "xEs" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -38955,8 +39052,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xNm" = (
-/obj/structure/dresser,
-/turf/open/floor/wood/f13/oak,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "xNI" = (
 /obj/structure/table/wood/settler,
@@ -39018,16 +39115,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "xPI" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -10
-	},
-/obj/structure/mirror{
-	pixel_x = -32
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
 /area/f13/legion)
 "xPO" = (
 /obj/structure/flora/stump,
@@ -39069,9 +39158,13 @@
 	},
 /area/f13/bunker)
 "xRp" = (
-/obj/structure/barricade/wooden,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "xRv" = (
 /obj/structure/chair/wood/fancy{
 	dir = 1
@@ -39237,13 +39330,13 @@
 	},
 /area/f13/followers)
 "xXa" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/landmark/start/f13/campfollower,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/legion)
 "xXh" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -39254,10 +39347,7 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "xXm" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "xXo" = (
 /obj/structure/table/wood,
@@ -39276,26 +39366,21 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "xXq" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress3"
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/legion)
 "xXM" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "xXP" = (
-/obj/item/clothing/under/f13/police,
-/obj/item/clothing/head/f13/police,
-/obj/item/clothing/shoes/combat,
-/obj/structure/closet,
-/obj/item/clothing/head/beret,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/area/f13/building)
+/obj/effect/landmark/start/f13/campfollower,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "xXX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -39330,10 +39415,11 @@
 	},
 /area/f13/ncr)
 "xZo" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/ketchup,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/legion)
 "xZA" = (
 /obj/structure/chair,
 /turf/open/floor/f13/wood,
@@ -39418,7 +39504,7 @@
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "ybg" = (
 /obj/structure/closet/cabinet,
@@ -39635,6 +39721,10 @@
 /obj/structure/table_frame,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"yin" = (
+/obj/structure/simple_door/fakeglass,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/legion)
 "yiq" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -39647,7 +39737,6 @@
 "yir" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/three_course_meal,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
 "yjt" = (
@@ -39688,6 +39777,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"yky" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ykz" = (
 /obj/structure/window/fulltile/ruins,
 /obj/structure/curtain{
@@ -39742,7 +39837,7 @@
 "ylR" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oakbroken3,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "ymi" = (
 /obj/structure/table/wood/settler,
@@ -40120,8 +40215,8 @@ gcK
 gcK
 gcK
 ims
-syr
-rpf
+ims
+cVF
 ims
 gcK
 gcK
@@ -43719,7 +43814,7 @@ gbL
 gbL
 mvv
 hNC
-uXj
+cYz
 mRD
 mvv
 cos
@@ -45263,7 +45358,7 @@ qLC
 lwj
 lwj
 lCc
-uXj
+imR
 mRD
 rjE
 rjE
@@ -45521,7 +45616,7 @@ xGH
 aBH
 gaV
 hNC
-uXj
+imR
 lpL
 lpL
 lpL
@@ -45787,7 +45882,7 @@ lCc
 lCc
 lwj
 lwj
-uXj
+imR
 mRD
 gcK
 gcK
@@ -48614,7 +48709,7 @@ qFk
 qFk
 iyy
 lwj
-uXj
+dkW
 uXj
 uXj
 uXj
@@ -48871,8 +48966,8 @@ cWG
 cWG
 daU
 mvv
-uXj
-lqV
+hNC
+dld
 uXj
 uXj
 uXj
@@ -49129,10 +49224,10 @@ mfD
 xGH
 mvv
 mvv
+hNC
 lCc
 lCc
-lCc
-uXj
+dkW
 uXj
 uXj
 uXj
@@ -51635,7 +51730,7 @@ sVF
 cpK
 dMW
 fyf
-vUA
+rhr
 fyf
 fyf
 fyf
@@ -51690,7 +51785,7 @@ uRJ
 mnC
 dLB
 tBN
-pBp
+mvv
 mvv
 mvv
 mvv
@@ -51892,7 +51987,7 @@ ptf
 ptf
 edA
 gcK
-vUA
+rhr
 fyf
 fyf
 fyf
@@ -52149,7 +52244,7 @@ fyf
 fyf
 gcK
 gcK
-vUA
+rhr
 fyf
 fyf
 fyf
@@ -52406,7 +52501,7 @@ fyf
 fyf
 fyf
 gcK
-vUA
+rhr
 fyf
 fyf
 fyf
@@ -52663,7 +52758,7 @@ fyf
 fyf
 gcK
 gcK
-vUA
+rhr
 fyf
 fyf
 fyf
@@ -52920,7 +53015,7 @@ fyf
 fyf
 gcK
 gcK
-vUA
+rhr
 fyf
 fyf
 fyf
@@ -53177,7 +53272,7 @@ fyf
 fyf
 gcK
 gcK
-vUA
+rhr
 fyf
 fyf
 fyf
@@ -53228,7 +53323,7 @@ otr
 gVt
 uRJ
 uRJ
-iWc
+dgB
 uRJ
 gVt
 tBN
@@ -53257,7 +53352,7 @@ fyf
 gcK
 gcK
 gcK
-gcK
+dlp
 wpk
 ggK
 aUY
@@ -53434,7 +53529,7 @@ fyf
 fyf
 gcK
 gcK
-vUA
+rhr
 fyf
 fyf
 fyf
@@ -53691,7 +53786,7 @@ fyf
 fyf
 gcK
 gcK
-vUA
+rhr
 fyf
 fyf
 fyf
@@ -53754,7 +53849,7 @@ mvv
 vVU
 mvv
 bpD
-nxY
+fyf
 akA
 lmk
 fjs
@@ -53948,7 +54043,7 @@ fyf
 fyf
 gcK
 gcK
-vUA
+rhr
 fyf
 fyf
 fyf
@@ -54205,7 +54300,7 @@ fyf
 fyf
 gcK
 gcK
-vUA
+rhr
 fyf
 fyf
 fyf
@@ -54462,7 +54557,7 @@ fyf
 fyf
 gcK
 gcK
-vUA
+rhr
 fyf
 fyf
 fyf
@@ -54719,7 +54814,7 @@ fyf
 gcK
 gcK
 gcK
-vUA
+rhr
 fyf
 fyf
 fyf
@@ -54976,7 +55071,7 @@ fyf
 gcK
 gcK
 gcK
-vUA
+rhr
 fyf
 fyf
 fyf
@@ -55032,7 +55127,7 @@ uRJ
 jMN
 tBN
 mvv
-mvv
+djh
 mvv
 mvv
 hxO
@@ -55233,7 +55328,7 @@ gcK
 gcK
 gcK
 gcK
-pMI
+ezX
 fyf
 fyf
 fyf
@@ -55490,7 +55585,7 @@ gcK
 gcK
 gcK
 gcK
-pMI
+ezX
 fyf
 fyf
 fyf
@@ -55715,7 +55810,7 @@ wVT
 fFC
 eXE
 wVT
-eUk
+fFO
 ezX
 gcK
 gcK
@@ -55747,7 +55842,7 @@ gcK
 gcK
 gcK
 gcK
-pMI
+ezX
 fyf
 fyf
 fyf
@@ -55964,11 +56059,11 @@ gcK
 gcK
 gcK
 ezX
-eFW
+ajN
+aJh
+aVY
 wVT
-opW
 wVT
-fFC
 wVT
 opW
 fFC
@@ -56004,7 +56099,7 @@ ktB
 gcK
 gcK
 gcK
-pMI
+ezX
 fyf
 fyf
 fyf
@@ -56221,12 +56316,12 @@ gcK
 gcK
 gcK
 ezX
-fFO
-oyE
-eXE
-fFC
+auH
 wVT
-mOD
+ezX
+bkT
+bkT
+bkT
 ezX
 ezX
 ezX
@@ -56261,7 +56356,7 @@ gcK
 ktB
 gcK
 gcK
-pMI
+ezX
 fyf
 fyf
 fyf
@@ -56478,15 +56573,15 @@ gcK
 gcK
 gcK
 ezX
-ezX
-ezX
-ezX
-rXb
-wVT
+aDX
 fFC
-eXE
-wVT
-fFO
+bal
+blZ
+bnn
+bnn
+ezX
+bPj
+cEV
 ezX
 gcK
 ktB
@@ -56518,7 +56613,7 @@ gcK
 gcK
 gcK
 gcK
-pMI
+ezX
 fyf
 fyf
 fyf
@@ -56735,15 +56830,15 @@ gcK
 gcK
 gcK
 ezX
-icU
-oPB
-nDY
 wVT
 wVT
-wVT
-opW
 fFC
-mZX
+wVT
+fFC
+fFC
+bAo
+bQm
+cIL
 ezX
 gcK
 ktB
@@ -56775,7 +56870,7 @@ ktB
 ktB
 gcK
 gcK
-pMI
+ezX
 fyf
 fyf
 fyf
@@ -56993,46 +57088,46 @@ gcK
 gcK
 ezX
 iBF
-wVT
-ezX
+aQT
+bcj
 wLb
-wLb
-wLb
+brE
+btj
 ezX
+chA
+cLP
 ezX
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+gcK
 ezX
-ezX
-gcK
-gcK
-gcK
-gcK
-ktB
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-ktB
-gcK
-pMI
 fyf
 fyf
 fyf
@@ -57249,15 +57344,15 @@ gcK
 gcK
 gcK
 ezX
-jgx
-fFC
-wWI
-sWC
-jcB
-jcB
+ezX
+ezX
+ezX
+ezX
+ezX
+ezX
 ezX
 uSj
-vmX
+ezX
 ezX
 gcK
 gcK
@@ -57289,7 +57384,7 @@ gcK
 gcK
 gcK
 gcK
-pMI
+ezX
 fyf
 fyf
 fyf
@@ -57505,48 +57600,48 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
 ezX
-wVT
-wVT
-fFC
-wVT
-fFC
-fFC
-iTX
-urN
-gQL
-ezX
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-ktB
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-pMI
 fyf
 fyf
 fyf
@@ -57762,17 +57857,17 @@ ktB
 gcK
 gcK
 gcK
-ezX
-lRd
-pfX
-mdD
-nhd
-sPC
-szi
-ezX
-tcs
-wZT
-ezX
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -57803,7 +57898,7 @@ gcK
 gcK
 ktB
 gcK
-pMI
+ezX
 fyf
 fyf
 fyf
@@ -58019,24 +58114,10 @@ ktB
 gcK
 gcK
 gcK
-ezX
-ezX
-ezX
-ezX
-ezX
-ezX
-ezX
-ezX
-fOC
-ezX
-ezX
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-ktB
 gcK
 gcK
 gcK
@@ -58055,12 +58136,26 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
 ktB
 gcK
 ktB
 gcK
 gcK
-pMI
+ezX
 fyf
 fyf
 fyf
@@ -58317,7 +58412,7 @@ gcK
 gcK
 gcK
 gcK
-pMI
+ezX
 igz
 igz
 igz
@@ -58574,7 +58669,7 @@ gcK
 gcK
 gcK
 gcK
-pMI
+ezX
 cpK
 cpK
 cpK
@@ -58898,7 +58993,7 @@ fyf
 qTY
 hAC
 fyf
-fyf
+tOH
 fyf
 fyf
 fyf
@@ -59418,8 +59513,8 @@ fyf
 fyf
 ulH
 tBN
-mvv
-bpD
+aBH
+hCg
 fyf
 fyf
 fyf
@@ -59666,21 +59761,21 @@ fyf
 fyf
 fyf
 fyf
-tlD
-uxC
-uxC
-uxC
-uxC
-sUv
 fyf
 fyf
-tBN
-mvv
-bpD
 fyf
 fyf
-sND
 fyf
+fyf
+fyf
+fyf
+nlO
+hCg
+fyf
+fyf
+fyf
+fyf
+sqA
 fyf
 fyf
 fyf
@@ -59923,17 +60018,6 @@ cWG
 cWG
 cWG
 wDc
-thG
-aDX
-cWG
-cWG
-cWG
-bPj
-cWG
-cWG
-daU
-mvv
-bpD
 fyf
 fyf
 fyf
@@ -59941,6 +60025,17 @@ fyf
 fyf
 fyf
 fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+nPu
 fyf
 nJW
 ptf
@@ -60180,17 +60275,17 @@ mvv
 mvv
 mvv
 bpD
-thG
-tBN
-mvv
-mvv
-mvv
-iWi
-mvv
-mvv
-mvv
-mvv
-bpD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -60437,17 +60532,17 @@ mfD
 mfD
 mfD
 hCg
-thG
-ury
-mvv
-aBH
-mfD
-kXv
-mfD
-mfD
-xGH
-mvv
-bpD
+fyf
+fyf
+fyf
+fyf
+sqA
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -60694,18 +60789,18 @@ fyf
 fyf
 fyf
 fyf
-thG
-tBN
-mvv
-kQC
-sYX
-sYX
-fGS
-sYX
-sYX
-wpx
-sYX
-sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -60951,18 +61046,18 @@ fyf
 sND
 fyf
 fyf
-thG
-nlO
-mfD
-hCg
-sYX
-bQm
-bcb
-csO
-uCO
-rpu
-rpu
-sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+tOH
+fyf
 fyf
 fyf
 fyf
@@ -61208,22 +61303,22 @@ fyf
 fyf
 fyf
 fyf
-sYX
-wpx
-sYX
-sYX
-sYX
-urA
-qfV
-rpu
-uCO
-rpu
-aug
-sYX
-sYX
-sYX
-sYX
-sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -61465,22 +61560,22 @@ fyf
 fyf
 fyf
 fyf
-sYX
-rpu
-rpu
-mZE
-uCO
-qZe
-rpu
-gAZ
-uCO
-wDP
-rpu
-uCO
-uZy
-rpu
-uZy
-sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+trW
+fyf
 fyf
 fyf
 fyf
@@ -61722,22 +61817,22 @@ fyf
 fyf
 fyf
 fyf
-sYX
-vwL
-sKH
-nfp
-uCO
-wqz
-rpu
-ccF
-uCO
-rpu
-vXh
-uCO
-rpu
-cVF
-vXh
-sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -61979,22 +62074,22 @@ fyf
 fyf
 fyf
 uey
-fGS
-rpu
-rpu
-xwW
-uCO
-uCO
-sDp
-uCO
-uCO
-sDp
-uCO
-uCO
-uZy
-aug
-uZy
-sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+trW
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -62088,11 +62183,11 @@ gbL
 gbL
 gcK
 gcK
-vaA
+mGC
 gcK
-uAs
+gYM
 gcK
-vaA
+mGC
 gcK
 gcK
 gcK
@@ -62236,22 +62331,22 @@ fyf
 fyf
 fyf
 fyf
-sYX
-oxU
-rpu
-vyw
-uCO
-rpu
-rpu
-rpu
-rpu
-rpu
-rpu
-sDp
-rpu
-vXh
-cVF
-sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -62345,11 +62440,11 @@ gbL
 gbL
 gcK
 gcK
-vaA
-ggK
-rGC
-uAs
-vaA
+mGC
+mwp
+aVn
+gYM
+mGC
 gcK
 gcK
 gcK
@@ -62493,22 +62588,22 @@ fyf
 fyf
 fyf
 fyf
-sYX
-btj
-aug
-rpu
-sDp
-qfV
-vXh
-gvW
-skZ
-bcb
-rpu
-uCO
-bxl
-rpu
-rpu
-sYX
+fyf
+sqA
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -62602,11 +62697,11 @@ gbL
 gbL
 gcK
 gcK
-vaA
+mGC
 gcK
 gcK
 gcK
-vaA
+mGC
 gcK
 gcK
 gcK
@@ -62750,22 +62845,22 @@ fyf
 fyf
 fyf
 fyf
-sYX
-dlp
-rpu
-ntB
-uCO
-sMs
-vUF
-lIW
-gvW
-vXh
-sLm
-uCO
-uZy
-rpu
-uZy
-sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -62859,11 +62954,11 @@ gbL
 gbL
 gcK
 gcK
-vaA
+mGC
 gcK
 gcK
 gcK
-vaA
+mGC
 gcK
 gcK
 gcK
@@ -63007,22 +63102,22 @@ cWG
 hpm
 cWG
 wDc
-sYX
-uCO
-uCO
-uCO
-uCO
-rpu
-vUF
-gvW
-gvW
-bcb
-rpu
-uCO
-uCO
-uCO
-uCO
-sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -63264,22 +63359,22 @@ mvv
 haP
 wUv
 bpD
-sYX
-jFE
-qfV
-rpu
-sDp
-rpu
-rpu
-rpu
-rpu
-rpu
-jRy
-uCO
-vib
-rpu
-xZo
-sYX
+fyf
+fyf
+trW
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -63373,11 +63468,11 @@ gcK
 gcK
 gcK
 gcK
-vaA
+mGC
 gcK
 gcK
 gcK
-vaA
+mGC
 gcK
 gcK
 gcK
@@ -63521,22 +63616,22 @@ mvv
 aBH
 mfD
 hCg
-sYX
-qGI
-aug
-krA
-uCO
-uCO
-uCO
-uCO
-uCO
-sDp
-uCO
-uCO
-aQT
-aug
-hlX
-sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -63630,11 +63725,11 @@ gcK
 gcK
 gcK
 gcK
-vaA
+mGC
 gcK
 gcK
 gcK
-vaA
+mGC
 gcK
 gcK
 gcK
@@ -63778,22 +63873,22 @@ mvv
 bpD
 fyf
 fyf
-sYX
-iLg
-rpu
-jjn
-uCO
-rpu
-vUF
-tUp
-bcb
-rpu
-sLm
-uCO
-sZU
-rpu
-qKD
-sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+trW
 fyf
 fyf
 fyf
@@ -63887,21 +63982,21 @@ gcK
 gcK
 gcK
 gcK
-vaA
+mGC
 gcK
 gcK
-vpJ
-vaA
-pLw
-pLw
-pLw
-pLw
-pLw
-pLw
-pLw
-pLw
-pLw
-pLw
+nAz
+mGC
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 gcK
 gcK
 gcK
@@ -64035,22 +64130,22 @@ mfD
 hCg
 fyf
 fyf
-sYX
-rpu
-rpu
-urA
-uCO
-rpu
-rpu
-rpu
-vXh
-rpu
-rpu
-sDp
-rpu
-qfV
-vib
-sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+nPu
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -64125,6 +64220,7 @@ fyf
 fyf
 fyf
 fyf
+fyf
 gcK
 gcK
 gcK
@@ -64143,11 +64239,10 @@ gcK
 gcK
 gcK
 gcK
-gcK
-vaA
-ngX
-vpJ
-vpJ
+mGC
+rEi
+nAz
+nAz
 edD
 qal
 qal
@@ -64158,7 +64253,7 @@ qal
 pGM
 uhH
 sPR
-pLw
+qrR
 gcK
 gcK
 gcK
@@ -64292,22 +64387,22 @@ fyf
 fyf
 fyf
 fyf
-sYX
-ecb
-rpu
-vXh
-uCO
-dld
-rpu
-sKH
-aug
-rpu
-rIF
-uCO
-xXa
-rpu
-vib
-sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+sqA
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -64382,6 +64477,8 @@ fyf
 fyf
 fyf
 fyf
+fyf
+fyf
 gcK
 gcK
 gcK
@@ -64399,23 +64496,21 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-vaA
-ngX
-wFT
-vpJ
-vaA
+mGC
+rEi
+vDP
+nAz
+mGC
 aXA
 fck
-pLw
+qrR
 qgP
 qal
 jcJ
 pGM
 vwG
 qal
-pLw
+qrR
 gcK
 gcK
 gcK
@@ -64549,22 +64644,22 @@ jJb
 qOV
 gjB
 fyf
-sYX
-bcj
-rpu
-wag
-uCO
-bal
-rpu
-rpu
-qfV
-rpu
-cyx
-uCO
-hlX
-rpu
-hlX
-sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -64639,6 +64734,9 @@ fyf
 fyf
 fyf
 fyf
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
@@ -64655,24 +64753,21 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-vaA
+mGC
 qfp
-wFT
+vDP
 ebS
-vaA
-pLw
-pLw
-pLw
+mGC
+qrR
+qrR
+qrR
 pDi
 qal
 oub
 pGM
 qal
 gxt
-pLw
+qrR
 gcK
 gcK
 gcK
@@ -64806,22 +64901,22 @@ fyf
 nlO
 hCg
 fyf
-sYX
-sYX
-sYX
-sYX
-sYX
-sYX
-dnq
-dnq
-sYX
-wpx
-sYX
-sYX
-sYX
-dnq
-sYX
-sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -64890,16 +64985,16 @@ mvv
 dON
 mvv
 bpD
-qyt
-gtU
-gtU
-gtU
-gtU
-gtU
-gtU
-gtU
-gtU
-gcK
+pPg
+qOV
+cWG
+cWG
+cWG
+cWG
+cWG
+wDc
+upX
+fyf
 gcK
 gcK
 gcK
@@ -64915,11 +65010,11 @@ gcK
 gcK
 gcK
 gcK
-vaA
+mGC
 qyb
-wFT
-erY
-vaA
+vDP
+vDP
+mGC
 lYX
 xzk
 qal
@@ -64927,9 +65022,9 @@ wLv
 mbo
 qal
 pGM
-mTd
+sem
 cnB
-pLw
+qrR
 gcK
 gcK
 gcK
@@ -65105,7 +65200,7 @@ dCV
 gts
 okV
 lCc
-uXj
+dkW
 uXj
 vpx
 imR
@@ -65148,18 +65243,18 @@ bnT
 akI
 bpD
 pPg
+tBN
+qEU
+mvv
+qZD
+mvv
+qZD
+bpD
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+wfv
 wBL
 cWG
 ifW
@@ -65172,11 +65267,11 @@ gcK
 gcK
 gcK
 gcK
-vaA
+mGC
 qNh
-cdc
-erY
-vaA
+nAz
+vDP
+mGC
 vXs
 rFk
 gYu
@@ -65186,7 +65281,7 @@ qal
 qal
 qal
 qal
-pLw
+qrR
 gcK
 gcK
 gcK
@@ -65405,19 +65500,19 @@ mYO
 mvv
 bpD
 pPg
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tci
+tBN
+mvv
+mvv
+mvv
+mvv
+mvv
+doX
+cWG
+cWG
+cWG
+cWG
+cWG
+daU
 mvv
 mvv
 mvv
@@ -65429,21 +65524,21 @@ gcK
 gcK
 gcK
 gcK
-vaA
-hbW
-cdc
-gmX
-vaA
-pLw
-pLw
-pLw
-pLw
-pLw
-pLw
-pLw
-pLw
-pLw
-pLw
+mGC
+rEi
+nAz
+qAM
+mGC
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
+qrR
 gcK
 gcK
 gcK
@@ -65662,19 +65757,19 @@ bBk
 mvv
 bpD
 pPg
-fyf
-qZD
-fyf
-qZD
-fyf
-qZD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 tBN
+qZD
+mvv
+qZD
+mvv
+tci
+aBH
+mfD
+mfD
+mfD
+mfD
+mfD
+xGH
 mvv
 mvv
 mvv
@@ -65686,12 +65781,12 @@ fyf
 fyf
 gcK
 gcK
-vaA
+mGC
 uhi
 wTH
-ybA
-vaA
-vaA
+seU
+mGC
+mGC
 fyf
 fyf
 fyf
@@ -65886,8 +65981,8 @@ rpf
 cmA
 mvv
 doX
+cWG
 wDc
-fyf
 fyf
 fyf
 cuv
@@ -65919,13 +66014,13 @@ mfD
 mfD
 hCg
 pPg
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+tBN
+mvv
+mvv
+mvv
+mvv
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -66143,8 +66238,8 @@ gts
 gts
 gts
 gts
+gts
 bpD
-fyf
 fyf
 fyf
 sYX
@@ -66176,13 +66271,13 @@ gtU
 gtU
 gtU
 ccz
-fyf
+tBN
 qZD
-fyf
+mvv
+rXv
+mvv
 qZD
-fyf
-qZD
-fyf
+bpD
 lPT
 uqa
 uqa
@@ -66399,9 +66494,9 @@ dCV
 dCV
 dCV
 dCV
+dCV
 gts
 bpD
-fyf
 fyf
 fyf
 cuv
@@ -66417,19 +66512,7 @@ dXy
 cdc
 gmX
 koD
-jkJ
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-sYX
-sYX
-sYX
-sYX
-sYX
+dMW
 fyf
 fyf
 fyf
@@ -66439,7 +66522,19 @@ fyf
 fyf
 fyf
 fyf
-jrS
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+tBN
+mvv
+mvv
+mvv
+mvv
+mvv
+bpD
 uqa
 cSH
 rpu
@@ -66655,10 +66750,10 @@ eYz
 uqa
 gLY
 nTa
+aRl
 dCV
 gts
 bpD
-fyf
 fyf
 fyf
 sYX
@@ -66674,29 +66769,29 @@ rQh
 cdc
 gmX
 koD
-bFJ
-uaf
-uaf
-uaf
-uaf
-uCW
-mzs
-uaf
-tKZ
-kfc
-cMg
-dhC
-sYX
+jkJ
+igz
+igz
+iTX
+bEw
 fyf
 fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+tBN
 qZD
-fyf
+mvv
+saf
+mvv
 qZD
-fyf
-qZD
-fyf
-fyf
-fyf
+bpD
 uqa
 sIm
 rpu
@@ -66912,10 +67007,10 @@ aRl
 omT
 aRl
 gLY
+aRl
 dCV
 gts
 bpD
-fyf
 fyf
 sND
 sYX
@@ -66932,28 +67027,28 @@ apk
 gmX
 koD
 uCW
-uCW
 uaf
-lAo
-qON
-dbt
-bKv
+bFJ
 uCW
-tKZ
-aJe
-gCU
-mIW
+sYX
+ewO
+ewO
+sYX
+sYX
+sYX
+sYX
+sYX
 sYX
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+nlO
+mfD
+mfD
+mfD
+mfD
+mfD
+hCg
 uqa
 xpR
 aug
@@ -67169,10 +67264,10 @@ emC
 uqa
 aRl
 tQo
+aRl
 dCV
 gts
 bpD
-fyf
 fyf
 fyf
 tKZ
@@ -67188,29 +67283,29 @@ hbW
 erY
 gmX
 koD
-uCW
-uaf
+hHk
 bFJ
-uCW
+dbt
+bFJ
 sYX
-ewO
-ewO
+aRl
+eJo
+jxO
+jRy
+jRy
+ngX
+aRl
 sYX
-sYX
-sYX
-sYX
-aaN
-sYX
-fyf
-fyf
-qZD
-fyf
-qZD
-fyf
-qZD
 fyf
 fyf
 fyf
+fyf
+fyf
+fyf
+skE
+sMs
+tcs
+tcs
 uqa
 uqa
 uqa
@@ -67426,10 +67521,10 @@ cNo
 uqa
 fqD
 aRl
+aRl
 dCV
 gts
 gts
-fyf
 fyf
 fyf
 xRM
@@ -67445,22 +67540,22 @@ hbW
 erY
 gmX
 koD
-iPm
-bFJ
-dbt
-bFJ
-sYX
+uaf
+uaf
+iwa
+uaf
+mZu
 aRl
-eJo
-sWE
+aRl
+vIX
 wRm
-nyc
-chq
 aRl
-sYX
+tnd
+aRl
+txs
 fyf
 fyf
-fyf
+upX
 fyf
 fyf
 fyf
@@ -67683,10 +67778,10 @@ cCh
 uqa
 gfS
 pVD
+aRl
 dCV
 dCV
 gts
-fyf
 fyf
 fyf
 tKZ
@@ -67702,22 +67797,22 @@ hbW
 erY
 gmX
 koD
+bFJ
 uaf
-uaf
-jNu
-uaf
-mZu
-aRl
-aRl
+dbt
+hHk
+sYX
 tnd
-ciq
 aRl
-rEe
 aRl
-ewO
+hXj
+aaN
+aRl
+nDY
+sYX
 fyf
 fyf
-qZD
+fyf
 fyf
 fyf
 fyf
@@ -67920,7 +68015,7 @@ ghr
 vMc
 gGz
 gGz
-gGz
+eHH
 gGz
 aRl
 mcI
@@ -67936,6 +68031,7 @@ oFP
 oFP
 oFP
 gZG
+oFP
 uqa
 uqa
 uqa
@@ -67943,7 +68039,6 @@ uqa
 uqa
 dCV
 gts
-fyf
 fyf
 fyf
 sYX
@@ -67959,19 +68054,19 @@ hbW
 erY
 gmX
 koD
-bFJ
+uaf
 uaf
 dbt
-iPm
-sYX
-rEe
+uCW
+aVg
 aRl
 aRl
-mcF
-vIX
-aRl
+nTa
+kfc
+lOl
+tQo
 uzO
-sYX
+oxU
 fyf
 fyf
 fyf
@@ -68177,7 +68272,7 @@ wCI
 sHm
 qPx
 gGz
-aRl
+eLl
 aRl
 xbN
 qPx
@@ -68197,10 +68292,10 @@ mvv
 mEy
 nbB
 fyf
+fyf
 lYu
 dCV
 gts
-fyf
 fyf
 fyf
 fyf
@@ -68216,22 +68311,22 @@ hbW
 erY
 gmX
 koD
-uaf
-uaf
-dbt
-uCW
-aVg
-aRl
-aRl
-nTa
-rfd
-chA
-tQo
-aJh
-wfv
+sYX
+sYX
+sYX
+sYX
+sYX
+jjn
+sYX
+sYX
+sYX
+tKZ
+tKZ
+sYX
+sYX
 fyf
 fyf
-qZD
+fyf
 fyf
 fyf
 fyf
@@ -68454,10 +68549,10 @@ mvv
 mvv
 lgI
 fyf
+fyf
 tdv
 dCV
 gts
-fyf
 fyf
 fyf
 fyf
@@ -68474,17 +68569,17 @@ erY
 gmX
 koD
 sYX
-sYX
-sYX
-sYX
+hSQ
+iFF
+jbW
 sYX
 aaN
-sYX
-sYX
-sYX
-tKZ
-tKZ
-sYX
+nTa
+hXj
+krA
+aRl
+aRl
+aRl
 sYX
 fyf
 fyf
@@ -68712,9 +68807,9 @@ rjH
 qJv
 fyf
 fyf
+fyf
 dCV
 gts
-fyf
 fyf
 fyf
 fyf
@@ -68730,24 +68825,24 @@ hbW
 erY
 gmX
 koD
-sYX
-uIU
+tKZ
+tQo
 aqL
-wjS
+aRl
 sYX
 vIX
-nTa
+iZE
 mcF
 jMT
-aRl
-aRl
+iZE
+nhd
 aRl
 sYX
 fyf
 fyf
-qZD
 fyf
 fyf
+upX
 fyf
 uqa
 nfp
@@ -68955,7 +69050,7 @@ dCV
 dCV
 xkt
 dkg
-qzF
+lEG
 dkg
 eUh
 qot
@@ -68968,10 +69063,10 @@ rjH
 rjH
 iSE
 fyf
+fyf
 tdv
 dCV
 gts
-fyf
 fyf
 uey
 fyf
@@ -68987,19 +69082,19 @@ hbW
 erY
 gmX
 koD
-tKZ
-tQo
+ewO
+icU
 twe
 aRl
-sYX
+jeV
 tnd
-arq
+vZr
 lmP
 vZr
-arq
-fhS
-aRl
-sYX
+lmP
+vZr
+fRk
+ewO
 fyf
 fyf
 fyf
@@ -69201,9 +69296,9 @@ fyf
 gts
 dCV
 oTT
-oTT
+dSY
 vmi
-dCV
+vgw
 dng
 kRR
 mjR
@@ -69225,10 +69320,10 @@ rjH
 rjH
 kJn
 fyf
+fyf
 lYu
 dCV
 gts
-fyf
 fyf
 fyf
 fyf
@@ -69246,24 +69341,24 @@ gmX
 cUk
 txs
 hAT
-mCH
-aRl
-swB
+tnd
+jco
+tKZ
 rEe
 hXj
+aRl
+aRl
 fDA
-hXj
-fDA
-hXj
-fRk
+aRl
+oaw
 ewO
 fyf
 fyf
-qZD
 fyf
-qZD
 fyf
-qZD
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -69457,12 +69552,12 @@ upX
 fyf
 gts
 dCV
-tVQ
+dRT
 vgw
 vgw
-wGq
+vgw
 eTW
-bAo
+qGZ
 uMt
 kdJ
 dkg
@@ -69483,9 +69578,9 @@ mEy
 ryz
 cWG
 cWG
+cWG
 dCV
 gts
-fyf
 fyf
 dva
 fyf
@@ -69501,19 +69596,19 @@ hbW
 erY
 gmX
 koD
-ewO
-rAY
-rEe
-hoy
 tKZ
-miA
-mcF
+rAY
+eJo
+nTa
+tKZ
 aRl
-aRl
-ezt
-aRl
+eJo
+jFE
+kuo
+eJo
+nlN
 bof
-ewO
+sYX
 fyf
 fyf
 fyf
@@ -69717,8 +69812,8 @@ dCV
 hCC
 vgw
 vgw
+ezt
 dCV
-dkg
 nPX
 fyf
 fGT
@@ -69739,10 +69834,10 @@ gCh
 agX
 uSz
 agX
-fOx
+agX
+gCh
 dCV
 gts
-fyf
 fyf
 fyf
 fyf
@@ -69758,12 +69853,12 @@ hbW
 erY
 gmX
 koD
-tKZ
+sYX
 bqm
-eJo
+iLf
 nTa
-tKZ
-aRl
+sYX
+vMc
 eJo
 aHo
 lvb
@@ -69773,13 +69868,13 @@ sBH
 sYX
 fyf
 fyf
-qZD
 fyf
-qZD
 fyf
-qZD
 fyf
-iOY
+sqA
+fyf
+fyf
+fyf
 fyf
 uqa
 bMJ
@@ -69975,8 +70070,8 @@ vpY
 vpY
 vpY
 pZw
-pgl
-fkf
+dCV
+rRR
 nKC
 wIK
 ybI
@@ -69996,10 +70091,10 @@ xIM
 ybI
 ybI
 wbu
+ybI
 dCV
 dCV
 gts
-fyf
 fyf
 fyf
 fyf
@@ -70016,17 +70111,17 @@ erY
 gmX
 koD
 sYX
-vRb
-iLf
-nTa
 sYX
-vMc
-eJo
-eub
-lkp
-eJo
-arq
-lhW
+sYX
+tKZ
+tKZ
+tKZ
+sYX
+ewO
+sYX
+sYX
+ewO
+sYX
 sYX
 fyf
 fyf
@@ -70226,11 +70321,11 @@ rnx
 aJb
 aJb
 aJb
-aJb
+dnq
 cPg
-aJb
-hBN
-aJb
+dnq
+ecb
+dnq
 wCT
 tUb
 pWN
@@ -70252,11 +70347,11 @@ aJb
 tUb
 idu
 lKX
-xtl
+dCV
+dCV
 dCV
 dCV
 gts
-igz
 igz
 igz
 igz
@@ -70272,29 +70367,29 @@ hbW
 erY
 gmX
 koD
-sYX
-sYX
-sYX
-tKZ
-tKZ
-tKZ
-sYX
-ewO
-sYX
-sYX
-ewO
-sYX
-sYX
-hSQ
-osm
-osm
-osm
-osm
-osm
-osm
-osm
-ruE
-uxC
+jkJ
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+bEw
+fyf
 uqa
 uqa
 uqa
@@ -70483,12 +70578,12 @@ wKo
 dmL
 ehN
 hOl
-hOl
-cPg
-hOl
-hOl
-hOl
-cPg
+dsW
+vgw
+dsW
+dsW
+dsW
+vgw
 erY
 wGJ
 wGJ
@@ -70508,14 +70603,14 @@ wGJ
 wGJ
 erY
 erY
-erY
-pMI
 dCV
 dCV
-nGq
-gNo
+dCV
+dCV
+dCV
+gts
+pYN
 ybI
-koB
 ybI
 ybI
 ybI
@@ -70536,11 +70631,11 @@ ybI
 dkP
 sTa
 ybI
-epT
-epT
-tba
-sfU
-cEV
+ybI
+ybI
+dkP
+sTa
+hkW
 lQh
 ybI
 oqe
@@ -70740,11 +70835,11 @@ rlN
 btW
 kaM
 kaM
-kaM
-cPg
+dLm
+vgw
 fZe
 fPK
-wFs
+etv
 kGg
 wFs
 hOl
@@ -70765,12 +70860,12 @@ cdc
 wGJ
 erY
 erY
-kjQ
+fbD
 fPH
 vWo
-hBN
-cPg
-eAh
+fSk
+gAZ
+dsW
 idu
 idu
 idu
@@ -70998,7 +71093,7 @@ fsm
 gWt
 ees
 gts
-gts
+dCV
 pZw
 dCV
 dCV
@@ -71022,12 +71117,12 @@ apk
 wGJ
 erY
 erY
-erY
+vgw
 hnq
-dop
-hOl
-cPg
-hOl
+fPH
+gcy
+vgw
+dsW
 hOl
 hOl
 erY
@@ -71279,12 +71374,12 @@ erY
 apk
 lsn
 woS
-aKo
 kGg
-qoS
-qoS
-cPg
-qoS
+frY
+fPH
+gfY
+vgw
+dsW
 btW
 fvz
 erY
@@ -71536,13 +71631,13 @@ wGJ
 dza
 pZS
 dCV
+dCV
 ivQ
 ivQ
-giO
 ofW
+dCV
 gts
-jco
-ees
+gWt
 muk
 hbW
 erY
@@ -71795,10 +71890,10 @@ jEJ
 dCV
 rjP
 bgQ
-bgQ
 vgw
+bgQ
+dCV
 gts
-ptf
 gNA
 unI
 hbW
@@ -72050,12 +72145,12 @@ dza
 wGJ
 kzh
 lwg
+bgQ
+ftu
 vgw
 vgw
-vgw
-vgw
+dCV
 gts
-fyf
 kGc
 unI
 ucz
@@ -72309,10 +72404,10 @@ gmX
 lwg
 deX
 tlh
+fOC
 vgw
-bgQ
+dCV
 gts
-fyf
 kGc
 unI
 hbW
@@ -72563,13 +72658,13 @@ eJr
 wGJ
 wGJ
 gmX
-lwg
-nnP
-riB
-fmw
+dCV
+dCV
+dCV
+dCV
 pYr
+dCV
 gts
-fyf
 kGc
 unI
 hbW
@@ -72819,14 +72914,14 @@ etg
 eJr
 wGJ
 wGJ
-ubg
-dCV
-xfq
+eQb
 dCV
 vgw
+fGh
+vgw
+bgQ
 dCV
 gts
-fyf
 kGc
 unI
 hbW
@@ -73076,14 +73171,14 @@ bqa
 kGy
 qoS
 qoS
-tLE
-sYX
+qoS
+pYr
 vgw
-ock
 vgw
-lOl
+fPc
+vgw
+dCV
 gts
-fyf
 kGc
 unI
 hbW
@@ -73339,8 +73434,8 @@ bgQ
 bgQ
 vgw
 vgw
+dCV
 gts
-fyf
 kGc
 unI
 hbW
@@ -73585,7 +73680,7 @@ dkg
 dkg
 dkg
 bet
-jbW
+cpK
 dkg
 dkg
 dkg
@@ -73594,10 +73689,10 @@ tIa
 uqa
 uqa
 uqa
-lBS
 uqa
+giq
+dCV
 gts
-fyf
 kGc
 unI
 hbW
@@ -73851,10 +73946,10 @@ fCO
 uqa
 rtX
 uqa
+rpu
 vcM
-oPd
+gNo
 gts
-fyf
 kGc
 unI
 hbW
@@ -74108,10 +74203,10 @@ mxe
 uqa
 vTH
 xjA
+rpu
 vlz
-mVW
-lSQ
-fyf
+dCV
+gQL
 kGc
 unI
 hbW
@@ -74367,8 +74462,8 @@ ezO
 sxT
 rpu
 rpu
-fSk
-fyf
+dCV
+gRq
 kGc
 unI
 txb
@@ -74622,10 +74717,10 @@ dgU
 uqa
 vad
 rTQ
-vcM
+rpu
 gSG
+dCV
 gts
-fyf
 kGc
 unI
 hbW
@@ -74764,7 +74859,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+trF
 umD
 tSu
 tSu
@@ -74880,9 +74975,9 @@ uqa
 uqa
 uqa
 uqa
+uqa
 dCV
 gts
-fyf
 kGc
 unI
 hbW
@@ -75021,8 +75116,8 @@ ktB
 ktB
 ktB
 gcK
-gcK
-umD
+trF
+cMg
 qkO
 qkO
 uVE
@@ -75138,8 +75233,8 @@ dCV
 dCV
 dCV
 dCV
+dCV
 gts
-fyf
 kGc
 unI
 sif
@@ -75278,7 +75373,7 @@ xAZ
 xAZ
 ktB
 gcK
-gcK
+trF
 umD
 uyp
 uyp
@@ -75391,12 +75486,12 @@ dit
 bet
 uaf
 iEh
-rpu
+fkf
 cGV
-mOv
+nfp
+giO
 dCV
 gts
-fyf
 kGc
 unI
 hbW
@@ -75535,7 +75630,7 @@ nft
 xAZ
 ktB
 gcK
-gcK
+trF
 umD
 uVE
 uVE
@@ -75651,9 +75746,9 @@ hfe
 rpu
 vcM
 rpu
+rpu
 dCV
 gts
-fyf
 kGc
 unI
 hbW
@@ -75792,7 +75887,7 @@ nqw
 xAZ
 ktB
 ktB
-gcK
+trF
 umD
 fDE
 uVE
@@ -75907,10 +76002,10 @@ cam
 iEh
 med
 vcM
-vcM
+rpu
+gnI
 dCV
 gts
-upX
 kGc
 unI
 hbW
@@ -76164,10 +76259,10 @@ bet
 dCV
 uBC
 vcM
+rpu
 qkP
 dCV
 gts
-fyf
 kGc
 unI
 hbW
@@ -76423,8 +76518,8 @@ dCV
 dCV
 dCV
 dCV
+dCV
 gts
-fyf
 kGc
 unI
 hbW
@@ -76678,10 +76773,10 @@ cpK
 uCW
 uCW
 uCW
+uCW
 dCV
 gts
 gts
-fyf
 kGc
 unI
 hbW
@@ -76933,11 +77028,11 @@ dit
 uqa
 uqa
 uqa
-hfe
-iEh
 uqa
+iEh
+hfe
+dCV
 gts
-fyf
 fyf
 kGc
 unI
@@ -77187,14 +77282,14 @@ vgw
 vgw
 vgw
 dit
-etv
-wqJ
+qkP
+csO
+fbz
 uqa
+fOx
 rpu
-vcM
 dCV
 gts
-fyf
 fyf
 kGc
 unI
@@ -77446,12 +77541,12 @@ sZn
 dit
 kHg
 rpu
+rpu
 uqa
-sGp
-rkZ
+eBk
+rpu
 dCV
 gts
-fyf
 fyf
 kGc
 unI
@@ -77703,12 +77798,12 @@ dit
 dit
 qmf
 vcM
-ajN
 vcM
-rkZ
+fmw
+rpu
+rpu
 dCV
 gts
-fyf
 fyf
 kGc
 unI
@@ -77941,13 +78036,14 @@ fyf
 fyf
 gts
 dCV
-bxl
+eCK
 rpu
 rpu
 dCV
 dCV
 ids
 ids
+dCV
 dCV
 dCV
 dCV
@@ -77965,7 +78061,6 @@ dCV
 dCV
 dCV
 gts
-fyf
 fyf
 kGc
 unI
@@ -78222,7 +78317,7 @@ gts
 gts
 gts
 gts
-fyf
+gts
 fyf
 kGc
 unI
@@ -82115,8 +82210,12 @@ urt
 bIh
 gcK
 gcK
-gcK
-gcK
+ggK
+ggK
+ggK
+ggK
+ggK
+ggK
 fyf
 fyf
 fyf
@@ -82132,10 +82231,6 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-thG
 fyf
 fyf
 fyf
@@ -82371,16 +82466,14 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ggK
+ggK
+ggK
+ggK
+ggK
+ggK
+ggK
+ggK
 fyf
 fyf
 fyf
@@ -82391,11 +82484,13 @@ fyf
 fyf
 fyf
 fyf
-gcK
-gcK
-gcK
-gcK
-gcK
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -82628,6 +82723,17 @@ gcK
 gcK
 gcK
 gcK
+ggK
+ggK
+ggK
+ggK
+gcK
+gcK
+gcK
+gcK
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
@@ -82636,22 +82742,11 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gcK
+fyf
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
 fyf
@@ -82883,10 +82978,10 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+ggK
+ggK
+ggK
+ggK
 gcK
 gcK
 gcK
@@ -83135,14 +83230,14 @@ mvv
 mvv
 bpD
 gjN
+ggK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ggK
+ggK
+ggK
+ggK
+ggK
 gcK
 gcK
 gcK
@@ -83392,13 +83487,13 @@ mvv
 mvv
 bpD
 tBN
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ggK
+ggK
+ggK
+ggK
+ggK
+ggK
+ggK
 gcK
 gcK
 gcK
@@ -83649,12 +83744,12 @@ bGM
 mvv
 bpD
 tBN
-gcK
-gcK
-gbL
-gbL
-gbL
-gbL
+ggK
+ggK
+ggK
+ggK
+ggK
+ggK
 gbL
 gbL
 gcK
@@ -83907,8 +84002,8 @@ mvv
 bpD
 mfp
 gcK
-gcK
-gcK
+ggK
+ggK
 gbL
 gbL
 gbL
@@ -84427,8 +84522,8 @@ gcK
 gcK
 gcK
 gcK
-sYX
-sYX
+gcK
+gcK
 sYX
 sYX
 sYX
@@ -84684,8 +84779,8 @@ gcK
 gcK
 gcK
 gcK
-sYX
-tXK
+gcK
+gcK
 rpu
 oNH
 qDs
@@ -84706,7 +84801,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -84938,15 +85033,15 @@ mvv
 bpD
 fyf
 fyf
-fyf
 gcK
 gcK
-tKZ
+gcK
+gcK
 rpu
 mdv
 tWu
 gvW
-sYX
+tKZ
 gcK
 gcK
 gcK
@@ -84961,8 +85056,8 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -85195,9 +85290,9 @@ mfD
 hCg
 fyf
 fyf
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
 sYX
 pLn
 rpu
@@ -85208,6 +85303,12 @@ gcK
 gcK
 gcK
 gcK
+ktB
+gcK
+gcK
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -85216,15 +85317,9 @@ gcK
 gcK
 gcK
 gcK
+ktB
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
 gcK
 sYX
 vAu
@@ -85450,21 +85545,21 @@ fyf
 fyf
 fyf
 fyf
-jxH
 fyf
 fyf
-fyf
-fyf
-nlN
+gcK
+gcK
+gcK
+sYX
 jRV
 rpu
 qfV
 rpu
 sYX
 sYX
-sYX
-fyf
 gcK
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -85487,9 +85582,9 @@ sYX
 tKZ
 tKZ
 tKZ
-vde
 sYX
-fyf
+sYX
+gcK
 gcK
 gcK
 gcK
@@ -85706,13 +85801,13 @@ fyf
 fyf
 fyf
 fyf
-jxH
-igU
 fyf
 fyf
-fyf
-fyf
-nlN
+gcK
+gcK
+gcK
+gcK
+tKZ
 gvW
 wcO
 rpu
@@ -85720,15 +85815,6 @@ rpu
 wtp
 iGE
 sYX
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-upX
-fyf
 gcK
 gcK
 gcK
@@ -85740,13 +85826,22 @@ gcK
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -85965,46 +86060,46 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-nlN
+gcK
+gcK
+ktB
+gcK
+sYX
 gvW
 qDs
 rpu
 dOl
+tKZ
 sYX
 sYX
-sYX
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-mGC
+gcK
+gcK
+gcK
+ktB
+gcK
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 ktB
@@ -86219,52 +86314,52 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
 sYX
-sYX
-bkT
+gcK
+tKZ
 oAe
 sYX
 sYX
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-mGC
-mGC
-mGC
-mGC
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
+ktB
 "}
 (182,1,1) = {"
 ktB
@@ -86471,57 +86566,57 @@ igz
 igz
 igz
 igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-unp
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
 bEw
 fyf
-fyf
-gSt
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-bEw
-fyf
-fyf
-mwp
-mwp
-emz
-emz
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+ktB
 "}
 (183,1,1) = {"
 ktB
@@ -86717,7 +86812,7 @@ erY
 cdc
 gmX
 fLc
-ybI
+rNn
 ybI
 dkP
 ybI
@@ -86727,58 +86822,58 @@ ybI
 ybI
 ybI
 ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-hkW
-ybI
-ybI
-ybI
-ybI
-hkW
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-hkW
-hkW
-ybI
-ybI
-ybI
-ybI
 sJw
 rRR
 fyf
-fyf
-wIK
-hkW
-sTa
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-hkW
-hkW
-ybI
-ybI
-ybI
-nkp
-dMW
-fyf
-fyf
-fyf
-mwp
-emz
-emz
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
 "}
 (184,1,1) = {"
 ktB
@@ -86974,7 +87069,7 @@ erY
 erY
 erY
 ehN
-ehN
+vdg
 aJb
 aJb
 aJb
@@ -86984,58 +87079,58 @@ idu
 hBN
 aJb
 aJb
-aJb
-aJb
-aJb
-tUb
-idu
-hBN
-hBN
-hBN
-aJb
-idu
-idu
-idu
-eAh
-hBN
-aJb
-tUb
-rbe
-aJb
-idu
-idu
-hBN
-hBN
-hBN
-aJb
-idu
-idu
 aJb
 fJv
 fyf
-sZA
-hCs
-rnx
-aJb
-idu
-aJb
-aJb
-aJb
-hBN
-aJb
-idu
-idu
-aJb
-aJb
-aJb
-koD
-dMW
 fyf
-fyf
-fyf
-mwp
-emz
-emz
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
 "}
 (185,1,1) = {"
 ktB
@@ -87231,7 +87326,7 @@ liv
 erY
 erY
 ehN
-ehN
+kby
 hOl
 dmL
 dmL
@@ -87241,58 +87336,58 @@ ehN
 jni
 hOl
 dmL
-dmL
-sgz
-kjQ
-ehN
-ehN
-ehN
-ehN
-ehN
-hOl
-cdc
-ehN
-ehN
-hOl
-sgz
-dmL
-sgz
-kjQ
-dmL
-ehN
-ehN
-ehN
-ehN
-ehN
-hOl
-cdc
-ehN
 kjQ
 pWN
 uPP
 fyf
-mEL
-wKo
-dmL
-ehN
-hOl
-dmL
-dmL
-ehN
-hOl
-cdc
-rbe
-ehN
-ehN
-ehN
-koD
-djh
-fyf
-fyf
-hAC
-mwp
-emz
-emz
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
 "}
 (186,1,1) = {"
 ktB
@@ -87488,7 +87583,7 @@ erY
 erY
 erY
 kaM
-kaM
+goq
 btW
 btW
 btW
@@ -87498,58 +87593,58 @@ qoS
 btW
 btW
 btW
-oGB
-btW
-fvz
-kaM
-kaM
-btW
-btW
-btW
-btW
-kaM
-kaM
-kaM
-kaM
-qoS
-btW
-fvz
-kaM
-btW
-kaM
-kaM
-btW
-btW
-btW
-btW
-rbe
-kaM
 fvz
 gWo
 uit
 fyf
 fyf
-rlN
-btW
-kaM
-btW
-btW
-btW
-btW
-btW
-kaM
-kaM
-btW
-btW
-btW
-koD
-dMW
-fyf
-fyf
-fyf
-mwp
-emz
-emz
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+gcK
+ktB
 "}
 (187,1,1) = {"
 ktB
@@ -87745,38 +87840,12 @@ erY
 erY
 gmX
 geM
-ees
-ees
-ees
-gQv
-gQv
-gQv
-ees
-ees
-ees
-ees
-ees
-gQv
-gQv
-ees
-ees
-ees
-ees
+ocX
 ees
 ees
 gQv
 gQv
 gQv
-ees
-ees
-kKo
-ees
-ees
-ees
-ees
-gQv
-ees
-ees
 ees
 ees
 ees
@@ -87785,28 +87854,54 @@ fsm
 ubd
 fyf
 fyf
-fyf
-ars
-fsm
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-gQv
-gQv
-ees
-ees
-sVF
-dMW
-fyf
-fyf
-fyf
-mwp
-emz
-emz
+gcK
+gcK
+ktB
+ktB
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
 "}
 (188,1,1) = {"
 ktB
@@ -88002,68 +88097,68 @@ erY
 wGJ
 bWB
 koD
-sUX
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-blZ
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-edA
+nPg
+ybI
+ybI
+jps
+sTa
+sTa
+ybI
+nkp
+cpK
+cpK
+qGZ
+jMC
 fyf
-fyf
-fyf
-nJW
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
-edA
-fyf
-fyf
-mwp
-mwp
-emz
-emz
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
 "}
 (189,1,1) = {"
 ktB
@@ -88258,11 +88353,17 @@ wGJ
 wGJ
 cdc
 gmX
-eQb
-dMW
-jxH
-gdN
-gSt
+koD
+unI
+sQX
+sQX
+sQX
+sQX
+sQX
+sQX
+koD
+cpK
+cpK
 gts
 gts
 gts
@@ -88280,47 +88381,41 @@ gts
 gts
 gts
 gts
-hwC
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 gcK
-mGC
-mGC
-mGC
-mGC
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+gcK
+gcK
+gcK
+ktB
+ktB
+gcK
+ktB
 "}
 (190,1,1) = {"
 ktB
@@ -88516,67 +88611,67 @@ erY
 wGJ
 gmX
 nNn
-dMW
-nDd
-wHJ
-mUx
+unI
+sQX
+cdc
+sQX
+sQX
+gGp
+sQX
+koD
+cpK
+cpK
 gts
 ids
-jqe
-ids
-gts
-skE
-vYv
-gts
 sIO
-auU
+ids
 gts
 xeQ
-pkf
+vYv
 gts
 lqp
-pkf
+auU
 gts
-hwC
-hwC
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-fyf
-gcK
-gcK
-gcK
-fyf
-fyf
-gcK
-gcK
-gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+rbE
+qbe
+gts
+tkY
+qbe
+gts
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-mGC
 gcK
 gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
 ktB
 "}
 (191,1,1) = {"
@@ -88773,30 +88868,33 @@ erY
 wGJ
 gmX
 koD
-dMW
-jRX
+unI
+sQX
+sQX
+sQX
+qci
+qci
+qci
+koD
 cpK
-tWv
+cpK
 ids
 ids
-dgB
-jqe
+lOz
+sIO
 gts
-xXP
+qxA
 vYv
 mFe
 vYv
 vYv
 gts
-qxA
+rfd
 sVD
 gts
-qxA
+rfd
 vYv
 gts
-hwC
-hwC
-hwC
 gcK
 gcK
 gcK
@@ -88806,6 +88904,7 @@ gcK
 gcK
 gcK
 gcK
+ktB
 gcK
 gcK
 gcK
@@ -88814,15 +88913,11 @@ gcK
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+ktB
 gcK
 gcK
-fyf
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -89030,33 +89125,33 @@ erY
 erY
 gmX
 koD
-dMW
-jRX
-vIB
+unI
+sQX
+sQX
+sQX
+dFQ
+ubg
+ubg
+koD
 cpK
+xws
 ids
-jqe
+sIO
 ids
-cIL
+nnP
 gts
-qEU
-lMr
-jqp
+epF
+gtj
+pPG
 uHA
 lHK
 gts
-epF
-gtj
+riB
+skZ
 gts
-gtj
-epF
+skZ
+riB
 gts
-hwC
-hwC
-gcK
-gcK
-gcK
-gcK
 ktB
 ktB
 ktB
@@ -89072,9 +89167,9 @@ gcK
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -89286,19 +89381,25 @@ erY
 erY
 erY
 gmX
+fLc
+onk
+sQX
+sQX
+sQX
+dFQ
+sgz
+sgz
 koD
-dMW
-kGc
 cpK
-uaf
+cpK
 gts
 ids
-oHT
+lRd
 ids
 gts
-tzf
+ozI
 vYv
-ilG
+pSp
 vYv
 vYv
 gts
@@ -89306,14 +89407,8 @@ hJQ
 vYv
 uHA
 vYv
-oVH
+tzf
 gts
-hwC
-gcK
-gcK
-gcK
-ktB
-ktB
 gcK
 gcK
 gcK
@@ -89543,9 +89638,21 @@ erY
 erY
 erY
 gmX
+erY
+erY
+sQX
+sQX
+sQX
+ilG
+iLg
+iLg
 koD
-dMW
+cpK
+cpK
 gts
+gts
+gts
+mFe
 gts
 gts
 gts
@@ -89553,31 +89660,19 @@ gts
 gts
 mFe
 gts
-gts
-gts
-gts
-gts
-mFe
-gts
 vYv
 vYv
-oeg
+sPC
 vYv
-mZH
+tLE
 gts
+gcK
+gcK
+gcK
 gcK
 ktB
-gcK
 ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -89800,34 +89895,34 @@ erY
 erY
 erY
 gmX
+sQX
+sQX
+sQX
+sQX
+sQX
+sQX
+bJB
+sgz
 koD
-dMW
+cpK
+cpK
 gts
-qfh
-tkY
-gts
-vYv
-tvL
-dkW
+uwQ
+lSQ
+kxY
 gts
 pjD
-xBC
-pkf
+auU
+qbe
 bKJ
 vYv
 gts
-tvL
+rrc
 gts
 gts
 gts
 gts
 gts
-ktB
-ktB
-ktB
-ktB
-gcK
-gcK
 ktB
 gcK
 gbL
@@ -89835,11 +89930,11 @@ gcK
 gcK
 gbL
 gcK
+ktB
 gcK
 gcK
 gcK
-gcK
-gcK
+ktB
 gcK
 gcK
 ktB
@@ -90057,14 +90152,20 @@ erY
 erY
 cdc
 gmX
+sQX
+sQX
+gGp
+sQX
+sQX
+sQX
+ybw
+sQX
 koD
-dMW
-gts
-cLP
-dhC
+xws
+cpK
 ljG
-dkW
-dkW
+kxY
+mdD
 vYv
 mFe
 vYv
@@ -90074,30 +90175,24 @@ vYv
 vYv
 mFe
 vYv
+mFe
+dhC
+tnu
+tTV
 gts
 gcK
 gcK
-gcK
 ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 gbL
 gcK
-gcK
+ktB
 gcK
 gcK
 ktB
 gcK
 gbL
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -90314,32 +90409,40 @@ erY
 erY
 erY
 gmX
+geM
+muk
+sQX
+sQX
+sQX
+qci
+qci
+qci
 koD
-dMW
+cpK
+cpK
 gts
-oXi
-fGh
-gts
-dkW
+kxY
 vYv
 vYv
-kMS
+ock
 uwQ
 vYv
 hJQ
 vYv
 jYn
 gts
-sIO
+lqp
+gts
+sWC
+gCU
+tUp
 gts
 gcK
-ktB
 gcK
 gcK
 ktB
 gcK
-gcK
-gcK
+gbL
 ktB
 gcK
 gcK
@@ -90348,15 +90451,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
 gcK
 gcK
 ktB
@@ -90572,45 +90667,45 @@ erY
 sCK
 gmX
 koD
-dMW
+unI
+sQX
+hzr
+sQX
+sQX
+rbe
+sQX
+koD
+cpK
+cpK
 gts
+xff
+fUb
+mFe
 gts
-gts
-gts
-prP
-eCK
-auH
-gts
-iwa
-qHc
+oGB
+oVH
 vYv
-lOz
+qyt
 vYv
 gts
 gts
 gts
+gts
+gts
+gts
+gts
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 ktB
 gcK
 ktB
-ktB
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-hom
-hom
-hom
-hom
-hom
-hom
-hom
-hom
 gcK
 gcK
 gcK
@@ -90829,47 +90924,47 @@ erY
 sCK
 gmX
 koD
-dMW
-jIV
-fyf
-fyf
-gts
-oaw
-oaw
-oaw
+unI
+sQX
+sQX
+rbe
+sQX
+sQX
+sQX
+koD
+cpK
+cpK
+lUk
+kMS
+iHj
+vYv
 gts
 gts
 lUk
-mFe
 gts
-mFe
 gts
-gcK
+gts
+gts
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
 ktB
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 hom
-iNI
-qbe
-uOr
-nrB
-nrB
-jhx
 hom
-qOV
-cWG
+hom
+hom
+hom
+hom
+hom
+hom
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -91085,51 +91180,49 @@ erY
 erY
 sCK
 gmX
-eQb
-dMW
-dDC
-fyf
-fyf
+koD
+sIf
+ees
+ees
+ees
+ees
+ees
+ees
+sVF
+cpK
+cpK
 gts
-cYz
-bnn
-cYz
+kQC
+mgO
+sVD
 gts
-gRq
-uwQ
-vYv
-gts
-vYv
-gts
+hom
+hom
+hom
+hom
+hom
+hom
+hom
+hom
+hom
+hom
+hom
+hom
+hom
 ktB
 gcK
-gcK
-gcK
-hom
-hom
-hom
-hom
-hom
-hom
-gcK
 ktB
-gcK
-gcK
-gcK
-gcK
 hom
 ftz
-hjc
-hjc
-hjc
-hjc
-hjc
+wDP
+wWI
+xBC
+xBC
+nSl
 hom
-tBN
-mvv
-bpD
-hom
-hom
+gcK
+gcK
+gcK
 hom
 hom
 hom
@@ -91139,6 +91232,8 @@ hom
 hom
 hom
 hom
+gcK
+gcK
 gcK
 gcK
 ktB
@@ -91343,59 +91438,59 @@ erY
 erY
 gmX
 koD
-dMW
-fyf
-fyf
-gSt
+sUX
+ptf
+ptf
+ptf
+ptf
+iNI
+ptf
+ptf
+ptf
+jqe
 gts
 gts
 gts
 gts
 gts
-gts
-xff
-jeV
-gts
-vYv
-gts
+hom
+jcB
+jhx
+qyZ
+kRD
+qGI
+xfy
+qSM
+sZt
+sZt
+tWv
+ury
+hom
+ktB
+gcK
 ktB
 hom
-hom
-hom
-hom
-cjV
-hbO
-qSM
-vVR
-hom
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-hom
 bRF
-hjc
-hjc
+oXV
 hjc
 hjc
 oXV
+oXV
 hom
-tBN
-mvv
-bpD
+fyf
+gcK
+gcK
 hom
 xsI
-vVR
-xsI
-umy
-umy
-hom
+vRG
 pck
-oWU
-iFF
 hom
+wTX
+jhx
+pck
+hom
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -91601,58 +91696,58 @@ erY
 gmX
 koD
 dMW
-sZt
 fyf
+hKz
 pEk
-gNA
-cpK
-cpK
-cpK
-gts
-vYv
-vYv
-vYv
-vYv
-vYv
-gts
+imv
+hom
+rwO
+rwO
+rwO
+rwO
+uNK
+hom
+hom
+hom
+hom
+hom
+oXi
+afj
+xNm
+mCf
+qHc
+ruE
+ata
+cjV
+upj
+hbO
+urN
+hom
+ktB
+gcK
 ktB
 hom
-afj
-uow
-hom
-cjV
-cjV
-ata
-vVR
-hom
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-hom
 nTm
-hjc
-hjc
-hjc
-hOs
-hjc
+oXV
+wZT
+oXV
+oXV
+ugj
 hom
-tBN
-mvv
-bpD
+qOV
+cWG
+gcK
 hom
 oJF
-vVR
-oJF
-umy
-ehf
+hqf
+vwz
 hom
-vVR
-vVR
-fbc
+dZE
+hqf
+xih
 hom
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -91860,56 +91955,56 @@ koD
 dMW
 fyf
 fyf
-jIV
-nJW
+fyf
+fyf
 prG
-caa
-cpK
-etf
-aha
-vYv
-vYv
-jYn
-vYv
-gts
-ktB
+xih
+xih
+xXm
+xXm
+uNK
+jmv
+jhx
+jcB
+xXm
 hom
-qCv
-oMY
+xih
+xNm
+xNm
 hom
-fcI
 wcu
-qSM
-cxH
+wcu
+swB
+hbO
+hbO
+hbO
+uAk
 hom
+ktB
 gcK
 gcK
-gcK
-gcK
-iiY
-sVl
 hom
-hom
-hvk
-hvk
-ioC
-hom
-dvo
+wqJ
+oXV
+hjc
+oXV
+sWG
+hjc
 hom
 tBN
 mvv
-frY
-ohf
-oJF
-vVR
-oJF
-umy
-dLm
+bpD
 hom
+mpu
+xys
 xNm
-vVR
-fbz
 hom
+xys
+xys
+xNm
+hom
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -92119,54 +92214,54 @@ fyf
 fyf
 fyf
 fyf
-nJW
-fsA
-ptf
-gts
-auU
-bzb
+rwO
+xXm
+jgx
+xXm
+xXm
+uNK
 jmv
-eQY
-sIO
-gts
-ktB
+xXm
+nrB
+fqL
 hom
 hom
-cde
 hom
-hbO
+dvo
+kRD
+qKD
 upj
 ata
-vHe
+cjV
+hbO
+hbO
+uIU
 hom
 gcK
 gcK
-gcK
-gcK
-iiY
-sVl
+cRh
 hom
-bDy
-vVR
-vVR
-vVR
-fPc
-vVR
-rgS
-dHq
+hom
+wFT
+wFT
+xEk
+hom
+dvo
+hom
+tBN
 mvv
-mvv
-cde
-vVR
-vVR
-vVR
-umy
+bpD
+hom
+lAC
+xNm
+xNm
+hom
 mfz
+xNm
+xNm
 hom
-hom
-cde
-hom
-hom
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -92374,56 +92469,56 @@ koD
 dMW
 fyf
 fyf
-sqA
 fyf
 fyf
-gxn
-fyf
-gts
-gts
-gts
-gts
-gts
-gts
-gts
-ktB
+rwO
+xXm
 hom
+jpW
+xXm
+uNK
+kUA
+vHe
+vwz
+xNm
+xXm
+xXm
 xDE
-oMY
-uGF
-cjV
+xNm
+qzF
+qNs
 hbO
 dPe
-vVR
+hbO
+hbO
+tXK
+uOr
 hom
 gcK
-gcK
-gcK
-gcK
-iiY
-sVl
+aPQ
+wPS
+dvo
+isv
+xXm
+uGF
+xNm
+nKs
+xNm
 hom
-isv
-isv
-isv
-isv
-vVR
-vVR
-rgS
-dHq
+tBN
 mvv
-goK
-ohf
-oJF
-vVR
-oJF
-umy
-dLm
+hgM
 hom
-sij
-vVR
-fbz
 hom
+hom
+dvo
+hom
+hom
+hom
+hlA
+hom
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -92630,57 +92725,57 @@ gmX
 eEz
 dMW
 fyf
-gxn
+siJ
 fyf
 fyf
-dhD
-fyf
-fyf
-jJb
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-ktB
-hom
-tQk
-cxH
-hom
-hom
-hom
-hom
-cde
-hom
-gcK
-gcK
-gcK
-gcK
-iiY
-sVl
-hHi
-qWU
-xuh
+rwO
 xXm
-tHw
-vVR
-vVR
+jhx
+xXm
+xXm
+dvo
+xXm
+xNm
+xXm
+fqL
+xXm
+pfX
+xXm
+xox
+hom
+wcu
+wcu
+hom
+sZU
+hom
+hom
+hom
+hom
+cRh
+wPS
+wPS
+hom
+xNm
+xNm
+xXm
+xNm
+xNm
+xNm
 rgS
 dHq
 mvv
 bpD
+nyc
+xNm
+vRG
+xNm
+xNm
+xXm
+vRG
+xDE
 hom
-oJF
-vVR
-oJF
-umy
-ehf
-hom
-vVR
-vHe
-cxH
-hom
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -92890,54 +92985,54 @@ fyf
 fyf
 fyf
 fyf
-igU
-fyf
-fyf
-fyf
-lPT
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+rwO
+jcB
+jcB
+xXm
+xXm
+uNK
+kXv
+xNm
+xXm
+xDE
+jgx
+xXm
+xXm
+xXm
+bbV
+jgx
+xNm
+fqL
+xXm
+xNm
+jhx
+uOt
 hom
-aof
-vVR
-vVR
-cde
-oMY
-vVR
-vVR
-hom
-gcK
-gcK
-gcK
-gcK
-iiY
-sVl
+wPS
+wPS
+wPS
 hom
 tQV
-bla
 tQV
-bla
-vVR
-vVR
-hom
-jEp
+tQV
+xRp
+tQV
+xXm
+rgS
+dHq
 mvv
 bpD
+dvo
+xNm
+xXm
+qCO
+xNm
+xXm
+xNm
+xNm
 hom
-xsI
-vVR
-xsI
-umy
-umy
-oHR
-vVR
-eHH
-eHH
-hom
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -93083,7 +93178,7 @@ uqa
 gts
 lNa
 hFM
-bMZ
+rpu
 tKk
 rpu
 csQ
@@ -93142,46 +93237,46 @@ wGJ
 cdc
 gmX
 koD
-jkJ
+hlX
 igz
 igz
-igz
-igz
-xEk
-ncb
-fyf
-fjT
+bEw
+imv
+hom
 rwO
-xLY
-gcK
-gcK
-gcK
-gcK
-gcK
+rwO
+rwO
+rwO
+uNK
+mCf
+dvo
+nyc
+nyc
 hom
-rgS
-rgS
+hom
+nyc
+nyc
 hom
 hom
-pSu
-wZA
-vVR
-hom
-gcK
-gcK
-gcK
-iiY
-sVl
-sVl
+xXm
+xNm
+xXm
+xXm
+xNm
+xXm
+vRb
+wPS
+wPS
+cRh
 hom
 bDy
-vVR
-vVR
-vVR
-vVR
-vVR
-saf
-mvv
+wGq
+xdP
+jmv
+nHT
+xNm
+rgS
+dHq
 mvv
 bpD
 hom
@@ -93193,8 +93288,8 @@ hom
 hom
 hom
 hom
-hom
-hom
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -93398,47 +93493,47 @@ erY
 erY
 wGJ
 gmX
-dsW
-ybI
-hkW
+fLc
 ybI
 ybI
-ybI
-xMm
+sJw
 rRR
 fyf
+iOY
 fyf
 fyf
+fyf
+vAe
 pea
-tFR
-lPT
-fyf
-fyf
-fyf
+tBN
+mvv
+tmA
+cWG
+cWG
 bea
 cWG
 cWG
-brE
-hom
-pSu
-vVR
-oMY
-hom
-hom
+cWG
+qON
+xDE
+xXm
+xNm
 hom
 hom
-syr
-sVl
-sVl
 hom
-eGn
+hom
+cRh
+gcK
+gcK
+hom
+vwz
 fmn
-isv
-fmn
-vVR
-vVR
+vwz
+xXa
+vwz
+uOt
 hom
-fbD
+jgY
 mvv
 bpD
 fyf
@@ -93659,43 +93754,43 @@ ehN
 ehN
 hBN
 aJb
-idu
-idu
-qeM
 fJv
 fyf
+jxH
 fyf
-fyf
+qOV
+cWG
+cWG
 gDn
-cWG
-cWG
-cWG
-cWG
-cWG
 daU
 mvv
 mvv
 mvv
-cde
-vVR
-vVR
-cxH
-hom
-tHw
+mvv
+mvv
+mvv
+mvv
+mvv
+dvo
+xXm
+xXm
+vHe
+jaV
+xys
 rEd
 hom
-syr
-uXj
-sVl
-hHi
-tHw
-dUx
-mBP
-xuh
-vVR
-dFn
-rgS
-tBN
+gcK
+gcK
+gcK
+hom
+vKl
+xNm
+xXm
+uGF
+xXm
+xNm
+dJw
+mvv
 mvv
 hgM
 hom
@@ -93915,14 +94010,14 @@ erY
 ehN
 ehN
 ehN
-hOl
-cdc
-ehN
 kjQ
 pWN
 uPP
+jxH
 fyf
-fyf
+nlO
+xGH
+mvv
 uqW
 mvv
 mvv
@@ -93933,33 +94028,33 @@ mvv
 mvv
 mvv
 goK
+qON
+xXm
+xNm
+xox
+mCf
+uhY
+vaH
 hom
-oWU
-wxR
-vVR
-cde
-vVR
-cxH
-hom
-syr
-uXj
-uXj
+gcK
+rpf
+gcK
 hom
 tQV
+wHJ
 tQV
+xXP
 tQV
-tQV
-vVR
-vVR
-rgS
-tBN
+xNm
+hom
+jme
 mvv
 bpD
 rgS
 hUf
 let
 iJW
-sme
+xNm
 hom
 gcK
 gcK
@@ -93967,7 +94062,7 @@ gcK
 gcK
 gcK
 gcK
-ktB
+gcK
 gcK
 gcK
 gcK
@@ -94172,56 +94267,56 @@ erY
 ehN
 ehN
 btW
-btW
-rbe
-kaM
 fvz
 gWo
 uit
+jxH
 fyf
 fyf
+nlO
+mfD
 dlS
-mfD
-mfD
-mfD
-mfD
-mfD
-mfD
 xGH
 mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 bpD
-rgS
-oWU
-tHw
-nbD
+hom
+xXm
+xXm
+xXm
 hom
 pBM
-vVR
+vWC
 hom
 syr
-uXj
-uXj
+rpf
+gcK
 hom
-hom
+pck
 hHi
-hHi
-hHi
-hHi
-hom
-hom
+xes
+xZo
+bDy
+xXm
+rgS
 tBN
 mvv
 doX
 hom
-dUv
+xXm
 vDg
-dUv
-vVR
+xys
+xNm
 hom
-hom
-hom
-hom
-hom
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -94426,59 +94521,59 @@ wGJ
 erY
 wGJ
 gmX
-xqQ
+geM
 ees
 ees
-ees
-jBH
-jBH
 fsm
 ubd
 fyf
+iPm
+jxH
 fyf
 fyf
-xLY
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-vPA
+vAe
+pea
+lhW
+miA
+miA
+miA
+miA
+miA
+juc
 mvv
 bpD
 hom
-oWU
-hzr
-nbD
+oxP
+dvo
+oxP
 hom
-xNm
-pck
+hom
+hom
 hom
 syr
-uXj
-gnI
-eLl
+rpf
+gcK
+hom
 tec
 xih
-nAW
 vwz
 vwz
-vwz
-vJM
-ozI
+uYC
+xNm
+rgS
+tBN
 mvv
 mvv
-cde
-vVR
-vVR
-vVR
+qVh
+xNm
+dUv
+dUv
 xox
 hom
-xNm
-oWU
-pSp
-hom
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -94684,58 +94779,58 @@ erY
 erY
 gmX
 koD
-sUX
+hoy
 ptf
 ptf
-eCM
-ptf
-ptf
-pyf
-fyf
-fjT
-fyf
-xLY
+hJt
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-tBN
+jrS
+uNK
+lkp
+mIW
+mUx
+mUx
+mUx
+pkf
+mvv
 mvv
 bpD
 hom
-hom
-hom
-hom
-hom
-hom
-hom
+rGC
+xPI
+hFW
+jIn
+hFW
+vmX
 hom
 syr
-uXj
-nRz
-lBY
-bpD
-wNu
-aFF
-mvv
-mvv
-mvv
-mgO
-ozI
+rpf
+hom
+hom
+hom
+hom
+hom
+hom
+hom
+hom
+hom
+tBN
 mvv
 aBH
 hom
-aPB
-vVR
-dFn
-vVR
-cde
-dFn
-vVR
-tQV
+xXm
+xNm
+xNm
+xNm
 hom
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -94944,43 +95039,43 @@ koD
 dMW
 jJb
 fyf
-jxH
 fyf
 fyf
 fyf
 fyf
+siJ
 fyf
-gxn
-xLY
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
+gcK
+jIV
+mCG
+mLc
+mvv
+mvv
+mvv
+prP
+mEy
 mvv
 bpD
 hom
 tvp
-gws
-gws
-hom
-agO
-agO
+xPI
+tba
+jIn
+hFW
+jIn
 hom
 syr
-uXj
+rpf
 nRz
-tBN
-bpD
-wNu
-mvv
-mvv
-mvv
-mvv
+xYS
+cWG
+wDc
+qOV
+cWG
+cWG
+cWG
 kut
-daU
+tBN
 mvv
 hgM
 hom
@@ -94990,11 +95085,11 @@ dvo
 hom
 hom
 mHy
-vVR
-jxO
-hom
+mHy
 gcK
-gcK
+mHy
+mHy
+mHy
 gcK
 gcK
 gcK
@@ -95201,56 +95296,56 @@ eEz
 dMW
 fyf
 fyf
-jxH
+fyf
 fyf
 trW
 fyf
 fyf
 fyf
-fyf
-xLY
+gcK
+pea
 mCG
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
+mvv
+mvv
+oeg
+mvv
+pyf
+mvv
 mvv
 bpD
 hom
 fpg
-kKs
-kKs
 jIn
-vVR
-cxH
+jIn
+jIn
+jIn
+jIn
 hom
 syr
-uXj
+rpf
 nRz
-pPG
+dHq
+pSC
+xkl
+tBN
+aFF
+mvv
+agd
 bpD
-wNu
-mvv
-mvv
-mvv
-mvv
-rbE
-mvv
+tBN
 mvv
 bpD
 hom
 sij
-vVR
-vVR
-cxH
+xNm
+xNm
+glt
+hom
+oxP
 hom
 hom
+oxP
 hom
-hom
-hom
-gcK
 gcK
 gcK
 gcK
@@ -95458,57 +95553,57 @@ koD
 dMW
 fyf
 fyf
-jxH
-jxH
-fyf
-fyf
-tTV
-fyf
-fyf
-xLY
-mCG
 fyf
 fyf
 fyf
 fyf
 fyf
-tnu
+gcK
+gcK
+uNK
+lww
+mvv
+mvv
+mvv
+mvv
+pBp
+mvv
 mvv
 bpD
 hom
-qSR
-hom
-hom
-hom
-dvo
-rgS
+tvp
+jIn
+hFW
+jIn
+hFW
+jIn
 hom
 syr
-uXj
+rpf
 nRz
 dHq
+pSC
+xkl
+tBN
+mvv
+mvv
+mvv
 bpD
-wNu
-mvv
-mvv
-mvv
-mvv
-qQo
-xGH
+tBN
 mvv
 bpD
 hom
 qBu
-vVR
-qBu
-vVR
-cde
-vVR
-oWU
-tHw
+dUv
+xys
+xXm
+pkS
+xsj
+xgk
+pQL
+dUz
 hom
-gcK
-gbL
+tJn
 gcK
 gcK
 gcK
@@ -95720,52 +95815,52 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-xLY
+gcK
+gcK
+uNK
 mCG
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
+mOv
+mvv
+mvv
+oHT
+pyf
+mvv
 mvv
 bpD
 hom
 kKs
 xPI
 hFW
+jIn
+hFW
+vpJ
 hom
-mvv
-mLN
-nRz
 syr
-uXj
+rpf
 nRz
 dHq
-bpD
-wNu
-mvv
-mvv
+pSC
+xkl
+tBN
+agd
 mvv
 aFF
-mgO
-ozI
+bpD
+tBN
 mvv
 bpD
 rgS
 nMk
-vVR
-pRl
-vVR
-hom
-vVR
-vVR
+xys
+dUv
+xNm
+pkS
+kMl
+iJG
 fbc
+kcT
 hom
-gcK
-gcK
+tJn
 gcK
 gcK
 gbL
@@ -95975,53 +96070,53 @@ sND
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-xLY
+gcK
+gcK
+gcK
+gcK
+uNK
 mCG
-fyf
-fyf
-fyf
-fyf
-fyf
+mvv
+mvv
+mvv
+mLc
+prP
 vPA
 mvv
 bpD
 hom
 hom
+szi
+szi
+szi
 hom
+sZU
 hom
-hom
-mvv
-bpD
-nRz
 syr
-uXj
+rpf
 nRz
-bFe
+wjS
+mvv
 bpD
-xdP
-vaH
-vaH
-vaH
-vaH
+nlO
+xGH
+mvv
+aBH
 qip
-ozI
+tBN
 mvv
 bpD
 hom
-qBu
-vVR
-qBu
-vVR
+fhh
+eBm
+aop
+xXm
 hom
-qBu
-vVR
-qBu
+gkn
+gVR
 hom
-gcK
+dve
+hom
 gcK
 gcK
 gcK
@@ -96229,57 +96324,57 @@ koD
 dMW
 fyf
 fyf
-gxn
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-xLY
-fyf
-fyf
-fyf
-upX
-fyf
-fyf
-tBN
+gcK
+ktB
+ktB
+gcK
+pea
+lAo
+mUx
+mUx
+mUx
+mUx
+pIX
+mvv
 mvv
 doX
-cWG
+qQo
 cWG
 iVE
-qXo
+cWG
+cWG
+qQo
 daU
-mvv
-doX
 hZw
-aKv
+sZQ
 sZQ
 jTJ
 daU
+mvv
 doX
 cWG
-cWG
-qXo
-cWG
-qXo
+daU
+mvv
+doX
 cWG
 daU
 mvv
 bpD
 hom
-nMk
-dFn
+cot
+rND
 pRl
-vVR
+xNm
 hom
 poX
-vVR
+iJG
 pQL
-hom
-gcK
-gcK
+hXb
+bby
+mHy
 gcK
 gcK
 gcK
@@ -96488,19 +96583,18 @@ fyf
 fyf
 fyf
 fyf
-bBK
-fyf
-fyf
-fyf
-fyf
-xLY
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
+gcK
+gcK
+ktB
+gcK
+gcK
+jIV
+lBS
+mVW
+mVW
+mVW
+mVW
+mVW
 mvv
 mvv
 mvv
@@ -96511,8 +96605,9 @@ mvv
 mvv
 mvv
 mvv
-xes
-qyZ
+mvv
+lwj
+lwj
 mvv
 mvv
 mvv
@@ -96526,16 +96621,16 @@ mvv
 mvv
 bpD
 rgS
-qBu
-vVR
-qBu
-vVR
+uVX
+fzt
+aop
+xXm
+hom
+hom
+iMo
 hom
 hom
 hom
-hom
-hom
-gcK
 gcK
 gcK
 gcK
@@ -96744,20 +96839,20 @@ dMW
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-xLY
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sDc
+gcK
+gcK
+gcK
+ktB
+gbL
+gcK
+uNK
+nlO
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
 mfD
 mfD
 mfD
@@ -96768,29 +96863,29 @@ mvv
 mvv
 mvv
 mvv
-xes
-qyZ
+lwj
+lwj
 mvv
 mvv
 aBH
 mfD
 mfD
+uuc
 mfD
 mfD
 mfD
-xGH
-mvv
-mvv
+mfD
+mfD
 gNG
 hom
-nMk
-vVR
-pRl
-cxH
+cot
+rYn
+cot
+uXs
 hom
-gcK
-gcK
-gcK
+rvl
+iXP
+hom
 gcK
 gcK
 gcK
@@ -97001,19 +97096,19 @@ dMW
 fyf
 osj
 fyf
-fyf
-fyf
-fyf
-fyf
 gcK
 gcK
 gcK
-ktB
 gcK
 gcK
-gcK
+gbL
+uNK
+hom
+mCf
+kRD
 hom
 hom
+kRD
 bWb
 kZb
 kZb
@@ -97025,8 +97120,8 @@ mvv
 aBH
 mfD
 kPX
-cbV
-fDG
+sZQ
+sZQ
 bJo
 mvv
 oSC
@@ -97035,19 +97130,19 @@ hom
 hom
 hom
 hom
-tBN
-mLc
-ulc
-imv
+hwC
+hwC
+hwC
+hwC
 hom
+uvp
+xXm
+mfz
+xXm
 hom
+aFK
+rHT
 hom
-hom
-hom
-hom
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -97258,20 +97353,20 @@ dMW
 fyf
 fFu
 fyf
-fyf
-fyf
-fyf
-fyf
 gcK
 gcK
 gcK
 ktB
+gcK
+gbL
+gcK
+gcK
 gbL
 gcK
 gcK
 hom
 rEk
-vVR
+xXm
 xYS
 iVE
 cWG
@@ -97283,28 +97378,28 @@ xjZ
 fyf
 nRz
 syr
-uXj
+rpf
 eXO
 mvv
 mvv
 dvo
 xys
-kUA
 dUv
+fsV
 hom
-tBN
-vSk
-bpD
-hKz
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+cRh
+hom
+mCf
+ezG
+hom
+hom
+hom
+hom
+hom
+hom
+hom
+hom
+hom
 gcK
 gcK
 gcK
@@ -97515,49 +97610,49 @@ dMW
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
 gcK
 gcK
 gcK
 ktB
+ktB
+gcK
+gcK
 gcK
 gcK
 gcK
 gcK
 hom
 cTN
-vVR
+xXm
 tBN
 rjH
 rjH
 bpD
-rXv
+nRz
 tBN
 mvv
 bpD
 rtR
 nRz
 syr
-uXj
+rpf
 eXO
 mvv
 aBH
 hom
 dUv
 xys
-aVY
+xys
+lDN
+wPS
+wPS
+wPS
+tUc
+xXq
+xXq
+aPQ
+mCf
 hom
-tBN
-jfx
-bpD
-fyf
-sJM
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -97769,14 +97864,14 @@ erY
 gmX
 koD
 dMW
-gxn
+fyf
 dhD
 fyf
 gcK
 gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -97785,7 +97880,7 @@ gcK
 gcK
 hom
 sgJ
-vVR
+xXm
 tBN
 rjH
 rjH
@@ -97797,7 +97892,7 @@ bpD
 hKz
 nRz
 syr
-uXj
+rpf
 eXO
 mvv
 bpD
@@ -97806,16 +97901,16 @@ asj
 jei
 xys
 hom
-tBN
-qot
-bpD
-fyf
-fyf
-fyf
+wPS
+wPS
+xXq
+lkc
+lkc
+lkc
 tUc
-dRs
-dRs
-lNv
+cRh
+hom
+gcK
 gcK
 gcK
 gcK
@@ -98042,7 +98137,7 @@ gcK
 gcK
 hom
 mVR
-vVR
+xXm
 tBN
 rjH
 rjH
@@ -98054,7 +98149,7 @@ bpD
 fyf
 nRz
 syr
-uXj
+rpf
 eXO
 mvv
 bpD
@@ -98063,16 +98158,16 @@ kih
 yir
 qKU
 hom
-tBN
-pyq
-tHc
-fyf
-fyf
-fyf
-dOf
+wSA
+tUc
+dRs
+lNv
+lNv
+lNv
+cjV
 xow
-okj
-vAv
+hom
+gcK
 gcK
 gcK
 gcK
@@ -98294,9 +98389,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-bcM
-bcM
+cRh
+uqW
+uqW
 hom
 hom
 rVr
@@ -98304,32 +98399,32 @@ tBN
 rjH
 rjH
 bpD
-nRz
+sGp
 tBN
 mvv
 bpD
 fyf
 nRz
 syr
-uXj
+rpf
 eXO
 mvv
 bpD
 hom
-dUv
+xqQ
 oxA
 dUv
 hom
 unJ
-qNs
-doX
-cWG
-cWG
-wDc
-gfY
-pIz
-kxY
-vAv
+cjV
+dRs
+lNv
+wfG
+cjV
+hbO
+esc
+hom
+gcK
 gcK
 gcK
 gcK
@@ -98551,10 +98646,10 @@ ktB
 gcK
 gcK
 gcK
-bcM
+uqW
 piw
-bcM
-bcM
+uqW
+uqW
 hom
 fyf
 tBN
@@ -98565,10 +98660,10 @@ nRz
 tBN
 mvv
 bpD
-uhY
+fyf
 nRz
 syr
-uXj
+rpf
 eXO
 mvv
 hgM
@@ -98577,16 +98672,16 @@ hom
 hom
 jaV
 hom
-gcK
-isJ
-dRs
+wSA
+xXq
 dRs
 lNv
-bpD
-dOf
+lNv
+jwG
+cjV
 gVQ
-xXq
-vAv
+hom
+gcK
 gcK
 gcK
 gcK
@@ -98807,11 +98902,11 @@ gbL
 gcK
 gcK
 gcK
-bcM
-bcM
-bcM
-bcM
-bcM
+uqW
+uqW
+uqW
+uqW
+uqW
 okZ
 sJr
 tBN
@@ -98825,7 +98920,7 @@ bpD
 fyf
 nRz
 syr
-uXj
+rpf
 eXO
 mvv
 doX
@@ -98834,16 +98929,16 @@ hom
 fsV
 dUv
 hom
-gcK
-qTI
+mCf
+wPS
 xXq
-pIz
 vAv
-bpD
-dOf
-kuo
-ftu
 vAv
+vAv
+xXq
+ezG
+hom
+gcK
 gcK
 gcK
 gcK
@@ -99065,42 +99160,42 @@ ktB
 gcK
 gcK
 gbL
-bcM
-bcM
+uqW
+uqW
 sUl
-bcM
+uqW
 iLQ
 fyf
 tBN
 rjH
 rjH
 bpD
-rXv
+nRz
 tBN
 mvv
 bpD
 sJM
 nRz
 syr
-uXj
+rpf
 eXO
 mvv
 mvv
 xkl
 hom
 dZE
-dUv
+qdG
+lDN
+xXm
+cRh
+wPS
+tUc
+xXq
+tUc
+aPQ
+hom
 hom
 gcK
-qTI
-gcy
-pIz
-aVH
-bpD
-aPQ
-hJt
-hJt
-pIX
 gcK
 gcK
 gcK
@@ -99322,10 +99417,10 @@ ktB
 gcK
 gcK
 gcK
-bcM
-bcM
+uqW
+uqW
 nTO
-bcM
+uqW
 okZ
 hge
 sDc
@@ -99336,10 +99431,10 @@ nRz
 tBN
 mvv
 bpD
-hKz
+sND
 nRz
 syr
-uXj
+rpf
 eXO
 mvv
 aBH
@@ -99348,14 +99443,14 @@ hom
 moX
 vWC
 hom
-gcK
-qTI
-gVQ
-dRT
-vAv
-bpD
-gcK
-gcK
+xXm
+xox
+hom
+mCf
+cRh
+hom
+hom
+hom
 gcK
 gcK
 gcK
@@ -99579,9 +99674,9 @@ ktB
 gcK
 gcK
 gcK
-gcK
+cRh
 piw
-bcM
+uqW
 cRh
 hom
 uNK
@@ -99596,7 +99691,7 @@ bpD
 fyf
 nRz
 syr
-uXj
+rpf
 eXO
 mvv
 hgM
@@ -99605,11 +99700,11 @@ hom
 hom
 hom
 hom
-gcK
 chv
-hJt
-hJt
-pIX
+chv
+hom
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -99832,39 +99927,39 @@ gcK
 gcK
 gcK
 ktB
-gcK
 ktB
-hom
-hom
-hom
-hom
-hom
+gcK
+gcK
+gcK
+gcK
+gcK
+uqW
 ezG
 nCl
 xfy
 ntJ
-vVR
-vVR
-vVR
-cde
+xXm
+vHe
+xXm
+dvo
 mvv
 mvv
 bpD
 fyf
 nRz
 syr
-uXj
+rpf
 eXO
 mvv
 bpD
 hom
-vVR
+xwW
 mTN
 hcr
 hom
-gcK
-gcK
-gcK
+hom
+hom
+hom
 gcK
 gcK
 gcK
@@ -100090,38 +100185,38 @@ gcK
 gcK
 ktB
 gcK
+gcK
+gcK
 ktB
-hom
-giq
-vVR
-wPS
-wPS
+gcK
+gcK
+gcK
 hom
 ooz
 cjV
 ntJ
-phd
-oMY
+xXm
+xNm
 fNB
 hom
-mEy
+mvv
 mvv
 bpD
 fyf
-nRz
+vSk
 syr
-uXj
+rpf
 eXO
 mvv
 bpD
-hHk
-oMY
-eVq
-uhW
 hom
-gcK
-gcK
-gcK
+qCO
+xNm
+xXm
+yin
+yky
+ggK
+ggK
 gcK
 gcK
 gcK
@@ -100347,19 +100442,19 @@ gcK
 gcK
 gcK
 gcK
+gcK
 ktB
-hom
-uAk
-oMY
-wPS
-wPS
+gcK
+gcK
+gcK
+gcK
 hom
 hom
 hom
 pqs
 uFt
 awT
-vVR
+xXm
 rgS
 mvv
 mvv
@@ -100367,7 +100462,7 @@ doX
 wDc
 hHK
 sKL
-uXj
+wag
 eXO
 mvv
 tHc
@@ -100376,12 +100471,12 @@ eaA
 aOO
 hxX
 hom
+ggK
+ggK
+ggK
+ggK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ggK
 vzG
 eMF
 gcK
@@ -100604,27 +100699,27 @@ gcK
 gcK
 ktB
 gcK
+gcK
+wom
 hom
 hom
-dSY
-vVR
-idC
-wPS
+hom
+gcK
 hom
 oFC
 biv
 hNZ
-oMY
-oMY
+xNm
+xNm
 cWq
 hom
-gcK
-gcK
+mvv
+mvv
 mvv
 hHK
-wOS
-uXj
-uXj
+sKL
+wag
+xTK
 eXO
 mvv
 hgM
@@ -100633,10 +100728,10 @@ hom
 hom
 hom
 hom
-gcK
-gcK
-gcK
-gcK
+cRh
+ezG
+ggK
+ggK
 ucZ
 dNW
 vzG
@@ -100861,25 +100956,25 @@ gcK
 gcK
 ktB
 gcK
+gcK
+wom
 hom
-itL
-jpW
 fKN
-wPS
-wPS
+xXm
+gcK
 hom
 nCl
 hbO
 ntJ
-oMY
-vVR
+qCO
+xXm
 lAD
 hom
-gcK
-gcK
-bcM
-iiY
-sVl
+mEy
+mvv
+mvv
+syr
+ulc
 hom
 hom
 hom
@@ -100891,9 +100986,9 @@ cWG
 cWS
 nvr
 nvr
-gcK
-gcK
-iKD
+cCU
+ggK
+ggK
 ggK
 vzG
 vzG
@@ -101118,29 +101213,29 @@ gcK
 gcK
 gcK
 ktB
+gcK
+wom
 hom
-ime
-vVR
-wPS
-wPS
+mZE
+xNm
 wPS
 cRh
 hom
 hom
 hom
 vKl
-tct
+xNm
 ooh
 kRD
-gcK
 ggK
 ggK
-iiY
-sVl
+ggK
+vwL
+vIB
 hom
 kQJ
-oMY
-pIz
+xNm
+mvv
 mvv
 mvv
 juc
@@ -101153,7 +101248,7 @@ ggK
 ggK
 cna
 ggK
-wnA
+ayd
 gcK
 gcK
 gcK
@@ -101374,30 +101469,30 @@ gcK
 gcK
 gcK
 ktB
+ktB
 gcK
 hom
-uOt
-ime
+hom
 fLB
-idC
-wPS
+xXm
+ohf
 hom
 hbO
 xfy
 hbO
 vHe
-oMY
+xNm
 abC
 hom
-gcK
+ggK
 ggK
 ljV
-wOS
-sVl
+vyw
+ggK
 hom
 wFo
 bwM
-oMY
+xNm
 aWz
 pyZ
 xGH
@@ -101405,11 +101500,11 @@ mvv
 qHQ
 pyZ
 eAD
+oVb
 ggK
 ggK
-gcK
-gcK
-gcK
+ggK
+ggK
 gcK
 gcK
 gcK
@@ -101624,18 +101719,18 @@ erY
 gmX
 koD
 dMW
-qTY
+fyf
 fyf
 gcK
 gcK
 gcK
 gcK
 gcK
+ktB
 gcK
 hom
-lww
 hJf
-wPS
+mZH
 ulU
 wPS
 hom
@@ -101643,18 +101738,18 @@ tZW
 tZW
 lez
 vHR
-vVR
+qZe
 udT
 fBx
 ggK
 ggK
 iiY
-sVl
-sVl
+ulc
+ggK
 hom
 kIs
-oMY
-oMY
+xNm
+xNm
 lCw
 hom
 hom
@@ -101663,15 +101758,15 @@ hom
 hom
 kRD
 hom
-cna
-wnA
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+kUM
+ggK
+ggK
+ggK
+jyM
+iKD
+iKD
+iKD
+iKD
 gcK
 gcK
 gcK
@@ -101888,14 +101983,14 @@ gbL
 gcK
 ktB
 gcK
+ktB
+ktB
 hom
-hom
-hom
-hom
-hom
-qCO
-hom
-hom
+uGF
+xXm
+wPS
+wPS
+jIV
 cRh
 cRh
 hom
@@ -101906,29 +102001,29 @@ mCf
 ggK
 ljV
 wOS
-sVl
-sVl
+vIB
+ggK
 hom
 mgg
-oMY
-oMY
-nAR
+xNm
+xNm
+xNm
 uNK
 dpK
 seY
-bMP
+wXo
 bMP
 leX
 hom
 ggK
+ggK
+ggK
+ggK
+ggK
 iKD
-ggK
-wnA
-ggK
-gcK
-gcK
-gcK
-gcK
+cjL
+sqy
+iKD
 gcK
 gcK
 gcK
@@ -102143,16 +102238,16 @@ fyf
 gcK
 gcK
 gcK
+gcK
 ktB
-ktB
+gcK
+gcK
 hom
-xNm
-oMY
-dvo
-ime
+lBY
+uGF
 eNb
-hom
-ggK
+ohf
+oPd
 ggK
 ggK
 gcK
@@ -102162,30 +102257,30 @@ gcK
 gcK
 ggK
 iiY
-sVl
-sVl
+ulc
+ggK
 gcK
 hom
 hom
 ylR
-oMY
-oMY
+xNm
+xNm
 cfp
-oMY
-oMY
-eNb
-oMY
+xNm
+xNm
+xNm
+xNm
 kTP
 mCf
 gcK
 ggK
 ggK
 ggK
-gcK
-gcK
-gcK
-gcK
-gcK
+ggK
+tXb
+wSF
+lli
+iKD
 gcK
 gcK
 gcK
@@ -102400,16 +102495,16 @@ fyf
 gcK
 gcK
 gcK
+gcK
+gcK
 ktB
 gcK
 hom
-qCv
-fNB
-hom
+lIW
 oWU
-vVR
+wPS
 cde
-ggK
+oPB
 ggK
 ggK
 ggK
@@ -102419,30 +102514,30 @@ gcK
 rwv
 ggK
 iiY
-sVl
-sVl
+ulc
+ggK
 gcK
 gcK
 pdn
 uda
-oMY
-oMY
+xNm
+xNm
 eHQ
-oMY
-oMY
-oMY
-oMY
+xNm
+xNm
+xNm
+xNm
 qnG
 hom
 gcK
-wnA
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+bUF
+ggK
+ggK
+ggK
+iKD
+sXU
+aoL
+iKD
 gcK
 gcK
 gcK
@@ -102657,17 +102752,17 @@ gcK
 gcK
 gcK
 gcK
-ktB
 gcK
+gcK
+ktB
 hom
 hom
 hom
 hom
-rrc
-oxP
-rgS
-ggK
-ggK
+hom
+hom
+hom
+rwv
 ggK
 ggK
 ggK
@@ -102676,13 +102771,13 @@ ggK
 ggK
 ggK
 iiY
-sVl
-sVl
+ulc
+ggK
 gcK
 gcK
 pdn
-oMY
-ime
+xNm
+uGF
 bMP
 kAJ
 ezv
@@ -102692,14 +102787,14 @@ vfn
 iDk
 hom
 gcK
+gcK
+ucZ
 ggK
-wnA
-xRp
-gcK
-gcK
-gcK
-gcK
-gcK
+ggK
+iKD
+iKQ
+lgP
+iKD
 gcK
 gcK
 gcK
@@ -102917,29 +103012,29 @@ gcK
 gcK
 gcK
 gcK
-ktB
-gcK
 hom
-hom
+xsI
+xNm
+dvo
 uGF
-hom
+xNm
+dvo
 ggK
 ggK
 ggK
-rwv
 ggK
 ggK
 ggK
 ggK
 ggK
 iiY
-sVl
+ulc
 ggK
 gcK
 gcK
 gcK
 yaI
-oMY
+xNm
 bMP
 cRh
 hom
@@ -102950,13 +103045,13 @@ hom
 hom
 gcK
 gcK
-gcK
 iKD
-ggK
-gcK
-gcK
-gcK
-gcK
+iKD
+tXb
+iKD
+iKD
+iKD
+iKD
 gcK
 gcK
 gcK
@@ -103174,13 +103269,13 @@ ktB
 gcK
 gcK
 ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+hom
+jNu
+lMr
+hom
+nDd
+xXm
+rgS
 ggK
 gcK
 gcK
@@ -103190,13 +103285,13 @@ gcK
 gcK
 ggK
 iiY
-sVl
+ulc
 ggK
 gcK
 gcK
 gcK
 rQI
-oMY
+wqz
 rQI
 gcK
 gcK
@@ -103207,12 +103302,12 @@ gcK
 gcK
 gcK
 gcK
+iKD
+aoL
+xXm
+iKD
 gcK
-ggK
-ggK
 gcK
-gcK
-gbL
 gcK
 gcK
 gcK
@@ -103431,13 +103526,13 @@ ktB
 ktB
 gcK
 ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+hom
+hom
+hom
+hom
+jmv
+okj
+hom
 gcK
 gcK
 gcK
@@ -103447,7 +103542,7 @@ gcK
 ggK
 ggK
 iiY
-sVl
+ulc
 ggK
 rwv
 gcK
@@ -103464,10 +103559,10 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+iKD
+lMO
+fWS
+iKD
 gcK
 gcK
 gcK
@@ -103689,12 +103784,12 @@ gcK
 gcK
 ktB
 gcK
+ktB
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+hom
+hom
+oxP
+hom
 gcK
 gcK
 gcK
@@ -103703,9 +103798,9 @@ gcK
 ggK
 ggK
 ggK
-iiY
-sVl
-ggK
+tvL
+unp
+vJM
 ggK
 gcK
 gcK
@@ -103721,10 +103816,10 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+iKD
+sXU
+dHl
+iKD
 gcK
 gcK
 gcK
@@ -103945,6 +104040,10 @@ gcK
 gcK
 gcK
 gcK
+ktB
+gcK
+gcK
+ktB
 gcK
 gcK
 gcK
@@ -103952,17 +104051,13 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+ggK
 ggK
 ggK
 ggK
 ggK
 iiY
-sVl
-ggK
+ulc
 ggK
 gcK
 gcK
@@ -103978,10 +104073,10 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+iKD
+iKD
+iKD
+iKD
 gcK
 gcK
 gcK
@@ -104217,9 +104312,9 @@ ggK
 ggK
 ggK
 ggK
-iiY
-sVl
 ggK
+iiY
+ulc
 ggK
 ktB
 gcK
@@ -104472,11 +104567,11 @@ hom
 hom
 bbV
 hom
-wPS
+wom
 ggK
-iiY
-sVl
-ggK
+ljV
+wOS
+vIB
 ggK
 ktB
 gcK
@@ -104729,10 +104824,10 @@ kRD
 ydY
 fqL
 mCf
-wPS
+wom
 ggK
 iiY
-sVl
+ulc
 ggK
 ggK
 ktB
@@ -104988,8 +105083,8 @@ hom
 hom
 wom
 oYb
-iiY
-sVl
+oYb
+oYb
 oYb
 oYb
 ktB

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -4097,7 +4097,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/caves)
+/area/f13/followers)
 "cMk" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -32854,10 +32854,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
 "umD" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/caves)
+/turf/closed/wall/f13/store,
+/area/f13/followers)
 "umS" = (
 /obj/structure/table/wood/fancy/black,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -74605,8 +74603,8 @@ gts
 gts
 gts
 gts
-nGq
-nGq
+gts
+gts
 ivm
 kMm
 jIB
@@ -74859,8 +74857,8 @@ gcK
 gcK
 gcK
 gcK
-trF
 umD
+uVE
 tSu
 tSu
 uBJ
@@ -75116,7 +75114,7 @@ ktB
 ktB
 ktB
 gcK
-trF
+umD
 cMg
 qkO
 qkO
@@ -75373,8 +75371,8 @@ xAZ
 xAZ
 ktB
 gcK
-trF
 umD
+uVE
 uyp
 uyp
 uVE
@@ -75630,8 +75628,8 @@ nft
 xAZ
 ktB
 gcK
-trF
 umD
+uVE
 uVE
 uVE
 uVE
@@ -75887,8 +75885,8 @@ nqw
 xAZ
 ktB
 ktB
-trF
 umD
+uVE
 fDE
 uVE
 uBJ

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -61,7 +61,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "abH" = (
 /obj/item/ammo_casing/shotgun/improvised,
 /turf/open/floor/plasteel/freezer,
@@ -106,7 +106,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "greenfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "adx" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden,
@@ -218,7 +218,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "ajc" = (
 /obj/structure/curtain{
 	color = "#5c131b"
@@ -273,7 +273,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "akd" = (
 /obj/structure/table,
 /obj/item/kitchen/knife/butcher,
@@ -321,7 +321,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "amM" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -337,7 +337,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "aoa" = (
 /obj/structure/closet/crate{
 	anchored = 1;
@@ -362,7 +362,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "showroomfloor"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "aou" = (
 /obj/effect/decal/fakelattice,
 /obj/machinery/light/small{
@@ -444,7 +444,7 @@
 	icon_state = "1-8"
 	},
 /turf/closed/wall/r_wall/rust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "auO" = (
 /obj/structure/target_stake,
 /obj/item/target/alien,
@@ -531,7 +531,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "azj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -646,7 +646,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "aFs" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -668,7 +668,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "greenfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "aGn" = (
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/unique,
@@ -822,7 +822,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "aQD" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
@@ -1399,7 +1399,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "bis" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -1512,7 +1512,7 @@
 "bme" = (
 /obj/structure/light_construct,
 /turf/open/floor/plasteel/f13,
-/area/f13/tunnel)
+/area/f13/bunker)
 "bmf" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -1638,7 +1638,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "bqs" = (
 /obj/structure/guncase,
 /obj/effect/decal/cleanable/dirt,
@@ -1714,7 +1714,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "bsF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/autoname{
@@ -1763,7 +1763,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/f13,
-/area/f13/tunnel)
+/area/f13/bunker)
 "bud" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -2031,6 +2031,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"bFk" = (
+/obj/machinery/door/airlock/hatch,
+/obj/structure/timeddoor/sixtyminute,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/bunker)
 "bFC" = (
 /obj/structure/decoration/hatch{
 	dir = 4
@@ -2503,7 +2510,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "caQ" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt{
@@ -3522,7 +3529,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "cQV" = (
 /obj/structure/barricade/bars,
 /obj/structure/barricade/bars,
@@ -3711,7 +3718,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "cXl" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
@@ -3763,7 +3770,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "dbZ" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -3806,7 +3813,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "ddQ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13{
@@ -3876,7 +3883,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "dhM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/filingcabinet/filingcabinet{
@@ -3910,7 +3917,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "diL" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
 	dir = 4;
@@ -3955,7 +3962,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "dkq" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/f13/wood,
@@ -4133,7 +4140,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "duI" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -4317,7 +4324,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "dDQ" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old"
@@ -4435,7 +4442,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "dHz" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -5154,7 +5161,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "eeT" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -5527,7 +5534,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "showroomfloor"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "evn" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard{
@@ -5602,7 +5609,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "eyq" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -6277,7 +6284,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "eZN" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -6605,7 +6612,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "fls" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13{
@@ -6641,7 +6648,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "showroomfloor"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "fmT" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -6992,7 +6999,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "fBM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -7440,7 +7447,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "fUR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder/reinforced,
@@ -7470,7 +7477,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "fXr" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -7605,7 +7612,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "showroomfloor"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "gcb" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -7649,7 +7656,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "gel" = (
 /mob/living/simple_animal/hostile/handy/gutsy/nsb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -7860,7 +7867,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "glq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters{
@@ -8016,7 +8023,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "gtM" = (
 /obj/structure/fluff/oldturret,
 /turf/open/floor/f13{
@@ -8214,7 +8221,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "gED" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -8486,7 +8493,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "gSv" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /obj/structure/closet/crate/miningcar,
@@ -8554,7 +8561,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "gTT" = (
 /obj/structure/bookcase/manuals/research_and_development,
 /turf/open/floor/f13{
@@ -8584,7 +8591,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "showroomfloor"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "gUF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/indestructible/f13/matrix,
@@ -8799,7 +8806,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "hdu" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -9064,7 +9071,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "hpp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -9242,7 +9249,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "huS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -9276,7 +9283,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "hwI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/chair,
@@ -9402,7 +9409,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "hCS" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -9462,7 +9469,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "hGa" = (
 /obj/effect/decal/cleanable/blood/gibs{
 	icon_state = "gibup1"
@@ -9576,7 +9583,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "hKm" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
@@ -9930,7 +9937,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "showroomfloor"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "hVV" = (
 /obj/structure/table/wood,
 /obj/machinery/processor/chopping_block,
@@ -10062,7 +10069,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "iaS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -10125,7 +10132,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "ieI" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/indestructible/f13vaultrusted,
@@ -10148,7 +10155,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "ifD" = (
 /obj/machinery/chem_heater,
 /obj/machinery/light{
@@ -10295,7 +10302,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "ikD" = (
 /obj/structure/table/snooker{
 	dir = 6
@@ -10389,7 +10396,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "inU" = (
 /obj/structure/chair{
 	dir = 8
@@ -10550,7 +10557,7 @@
 /obj/machinery/light,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13,
-/area/f13/tunnel)
+/area/f13/bunker)
 "itI" = (
 /obj/structure/table{
 	layer = 2.9
@@ -11412,7 +11419,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "jcG" = (
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/generic,
@@ -11581,20 +11588,20 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "jlb" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/part_replacer,
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "jlh" = (
 /obj/item/computer_hardware/recharger/APC,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "jll" = (
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/plasteel/vault/telecomms/mainframe{
@@ -11622,7 +11629,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "jmA" = (
 /obj/structure/closet/cabinet,
 /obj/item/taperecorder,
@@ -11961,7 +11968,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "jAK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
@@ -12081,7 +12088,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "jHN" = (
 /obj/machinery/chem_dispenser,
 /obj/effect/decal/cleanable/dirt,
@@ -12115,7 +12122,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "greenfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "jIZ" = (
 /obj/item/storage/trash_stack,
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
@@ -12472,7 +12479,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "jXu" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 1
@@ -12572,7 +12579,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "kaY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains{
@@ -12641,7 +12648,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "kee" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
@@ -12659,7 +12666,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "showroomfloor"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "keH" = (
 /obj/machinery/door/airlock/grunge{
 	req_access_txt = "120"
@@ -12709,7 +12716,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "greenfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "khz" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -12877,7 +12884,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "kpd" = (
 /obj/structure/lattice{
 	layer = 3
@@ -13073,7 +13080,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "kxL" = (
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
@@ -13363,7 +13370,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "kPb" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -13425,7 +13432,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "kRE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/prewar/poster69{
@@ -13583,7 +13590,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "kYh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
@@ -13708,7 +13715,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "ldK" = (
 /obj/structure/reagent_dispensers/barrel/old,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13789,7 +13796,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "leG" = (
 /obj/structure/table{
 	layer = 2.9
@@ -13950,7 +13957,7 @@
 /obj/item/reagent_containers/syringe/piercing,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13,
-/area/f13/tunnel)
+/area/f13/bunker)
 "llp" = (
 /obj/structure/curtain{
 	color = "#363636"
@@ -14235,7 +14242,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "lzd" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave,
@@ -14339,7 +14346,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "lDx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/paladin,
@@ -14481,7 +14488,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "showroomfloor"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "lLA" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -14633,7 +14640,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "lRu" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = -32
@@ -14832,7 +14839,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "mcC" = (
 /obj/item/storage/fancy/candle_box,
 /obj/item/storage/fancy/candle_box,
@@ -15626,7 +15633,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "mNE" = (
 /obj/structure/barricade/bars,
 /turf/open/water,
@@ -15694,7 +15701,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "mQX" = (
 /obj/effect/spawner/lootdrop/trash,
 /mob/living/simple_animal/hostile/gecko,
@@ -15753,7 +15760,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "mSs" = (
 /obj/structure/table,
 /obj/item/roller,
@@ -16605,8 +16612,9 @@
 /area/f13/tunnel)
 "nFy" = (
 /obj/structure/flora/tree/jungle{
-	pixel_x = -33;
-	pixel_y = -3
+	desc = "Rumor has it that, as long as this tree stands firm, so too will the town of Oasis.";
+	name = "\improper Oasis Oak";
+	pixel_x = -33
 	},
 /turf/open/indestructible/ground/outside/river,
 /area/f13/tunnel)
@@ -16729,7 +16737,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "nKk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fence/handrail{
@@ -16892,7 +16900,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "nQI" = (
 /obj/structure/foamedmetal,
 /turf/open/indestructible/ground/inside/mountain,
@@ -16902,7 +16910,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "nRE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -16950,7 +16958,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "nTr" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -17037,7 +17045,7 @@
 "nWe" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13,
-/area/f13/tunnel)
+/area/f13/bunker)
 "nWg" = (
 /obj/structure/chair/f13foldupchair,
 /obj/effect/decal/cleanable/dirt,
@@ -17355,7 +17363,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "ohb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
@@ -17403,7 +17411,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "ojC" = (
 /turf/open/water,
 /area/f13/bunker)
@@ -17444,7 +17452,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "platingdmg2"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "olK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -17560,7 +17568,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "opt" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light{
@@ -17688,7 +17696,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "ovr" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -17822,7 +17830,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "oBt" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -18066,13 +18074,13 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "oKN" = (
 /obj/structure/bed,
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "oMb" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibleg"
@@ -18180,7 +18188,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "oQP" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13/wood{
@@ -18357,7 +18365,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "platingdmg3"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "oXs" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -18447,7 +18455,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "paF" = (
 /obj/machinery/door/airlock/grunge{
 	req_access_txt = "120"
@@ -18923,7 +18931,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "pwH" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -19125,6 +19133,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
+"pFp" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "pGw" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -19408,7 +19420,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "pVA" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -20081,7 +20093,7 @@
 /area/f13/bunker)
 "qww" = (
 /turf/open/floor/plasteel/f13,
-/area/f13/tunnel)
+/area/f13/bunker)
 "qwz" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -20176,7 +20188,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "showroomfloor"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "qCm" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
@@ -20389,7 +20401,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "qLo" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -20771,7 +20783,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "qYq" = (
 /obj/machinery/light{
 	dir = 1;
@@ -20806,7 +20818,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "qYS" = (
 /obj/structure/fence/handrail_end/non_dense{
 	pixel_x = -16;
@@ -20880,7 +20892,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "rbg" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/f13/ruins,
@@ -21396,7 +21408,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "ruX" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -21538,7 +21550,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "platingdmg2"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "rzz" = (
 /obj/machinery/light/fo13colored/Red,
 /turf/open/floor/f13{
@@ -21708,7 +21720,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "rGw" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/f13{
@@ -21969,7 +21981,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "greendirtysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "rPi" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
@@ -22123,7 +22135,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "rWh" = (
 /obj/machinery/light/sign{
 	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
@@ -22236,7 +22248,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "sbj" = (
 /obj/structure/flora/junglebush/large,
 /turf/closed/mineral/random/low_chance,
@@ -22362,7 +22374,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "shc" = (
 /obj/structure/simple_door/bunker{
 	name = "Star Paladin Office";
@@ -22594,7 +22606,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "greendirtysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "srD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -22658,7 +22670,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "swY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22710,7 +22722,7 @@
 "sAx" = (
 /obj/item/reagent_containers/syringe/piercing,
 /turf/closed/wall/r_wall/rust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "sBu" = (
 /obj/structure/wreck/trash/engine,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -22736,7 +22748,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "sCZ" = (
 /obj/structure/barricade/bars,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -23009,7 +23021,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13,
-/area/f13/tunnel)
+/area/f13/bunker)
 "sTA" = (
 /obj/effect/landmark/start/f13/settler,
 /turf/open/floor/f13/wood,
@@ -23033,7 +23045,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "sVZ" = (
 /turf/closed/indestructible/vaultdoor{
 	desc = "A wall made out of metal, really fucking tough metal. Someone built this waaaay in advance.";
@@ -23257,7 +23269,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "tfw" = (
 /obj/effect/decal/cleanable/blood/innards,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -23305,7 +23317,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "tiS" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
@@ -23381,7 +23393,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "tmh" = (
 /obj/structure/chair/stool/retro/black,
 /obj/effect/decal/cleanable/dirt,
@@ -23420,7 +23432,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "tnp" = (
 /turf/closed/wall/f13/wood,
 /area/f13/sewer)
@@ -24107,7 +24119,7 @@
 	icon_state = "1-4"
 	},
 /turf/closed/wall/r_wall/rust,
-/area/f13/tunnel)
+/area/f13/bunker)
 "tYS" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -24646,7 +24658,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "uDs" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/indestructible/fakedoor{
@@ -25012,7 +25024,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "uVp" = (
 /obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/floor/f13{
@@ -25030,7 +25042,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "uVN" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -25294,13 +25306,13 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "vjm" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "vkb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/dresser,
@@ -25369,7 +25381,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "vlM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -25494,7 +25506,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "vqo" = (
 /obj/structure/simple_door/bunker{
 	name = "Star Knight Office";
@@ -25702,7 +25714,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "vCw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
@@ -25811,7 +25823,7 @@
 "vJy" = (
 /obj/item/reagent_containers/syringe/piercing,
 /turf/open/floor/plasteel/f13,
-/area/f13/tunnel)
+/area/f13/bunker)
 "vJC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink{
@@ -26266,7 +26278,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "wgS" = (
 /obj/structure/barricade/wooden/planks,
 /turf/closed/wall/f13/wood,
@@ -26327,7 +26339,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "wmJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/blackbox_recorder,
@@ -26690,7 +26702,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "wMr" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -27075,7 +27087,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "xjE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -27122,7 +27134,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "xlL" = (
 /obj/machinery/door/window/eastright,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -27167,7 +27179,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "platingdmg3"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "xnk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -27393,7 +27405,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "xEg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door{
@@ -27409,7 +27421,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "greendirtysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "xEV" = (
 /obj/structure/noticeboard{
 	pixel_x = 32
@@ -27473,7 +27485,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "xJw" = (
 /obj/machinery/door/airlock/grunge,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -27521,7 +27533,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "xNs" = (
 /obj/machinery/conveyor/auto{
 	dir = 1
@@ -27559,7 +27571,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "xOV" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -27678,7 +27690,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "xXK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice,
@@ -27862,7 +27874,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "yhT" = (
 /turf/closed/indestructible/opshuttle,
 /area/f13/caves)
@@ -27874,7 +27886,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/tunnel)
+/area/f13/bunker)
 "yix" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/machinery/light/broken{
@@ -47810,16 +47822,16 @@ uoO
 uoO
 uoO
 eLE
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
 eLE
 uoO
 uoO
@@ -48067,16 +48079,16 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 hvG
 hvG
 sha
 hvG
 wLV
-jmN
+fLU
 rGh
 rGh
-jmN
+fLU
 eLE
 uoO
 uoO
@@ -48324,7 +48336,7 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 hvG
 vqn
 sCO
@@ -48333,7 +48345,7 @@ hvG
 fWv
 hvG
 hvG
-jmN
+fLU
 eLE
 uoO
 uoO
@@ -48581,16 +48593,16 @@ eLE
 eLE
 eLE
 eLE
-jmN
+fLU
 hvG
 sCO
 nJX
 xXx
 wmF
-jmN
+fLU
 kxA
 hvG
-jmN
+fLU
 eLE
 uoO
 uoO
@@ -48834,11 +48846,11 @@ uoO
 aoj
 aoj
 eLE
-jmN
-jmN
-jmN
-jmN
-jmN
+fLU
+fLU
+fLU
+fLU
+fLU
 hvG
 xjy
 sCO
@@ -48847,7 +48859,7 @@ xIT
 oQA
 tYJ
 ruW
-jmN
+fLU
 eLE
 uoO
 uoO
@@ -49091,20 +49103,20 @@ uoO
 aoj
 uoO
 eLE
-jmN
+fLU
 evg
 kez
 gbL
-jmN
+fLU
 kpb
 hvG
 oAU
 hvG
 vjm
-jmN
+fLU
 duv
 hvG
-jmN
+fLU
 eLE
 eLE
 eLE
@@ -49348,7 +49360,7 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 qCb
 qCb
 qCb
@@ -49361,11 +49373,11 @@ pwi
 oQA
 auB
 ruW
-jmN
-jmN
-jmN
-jmN
-jmN
+fLU
+fLU
+fLU
+fLU
+fLU
 eLE
 uoO
 uoO
@@ -49605,24 +49617,24 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 qCb
 qCb
 qCb
-jmN
+fLU
 hvG
 ayR
 nJX
 xXx
 swQ
-jmN
+fLU
 eeL
 hvG
 qYd
 hvG
 hdq
 fBk
-jmN
+fLU
 eLE
 uoO
 uoO
@@ -49862,11 +49874,11 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 aok
 qCb
 fmO
-jmN
+fLU
 hvG
 xjy
 sCO
@@ -49879,7 +49891,7 @@ qYd
 hvG
 hvG
 nQL
-jmN
+fLU
 eLE
 uoO
 uoO
@@ -50119,24 +50131,24 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 lLl
 hVF
 lLl
-jmN
+fLU
 hvG
 hvG
 xNq
 hvG
 hvG
-jmN
+fLU
 kaG
 hvG
 qYd
 gdZ
 hvG
 kXX
-jmN
+fLU
 eLE
 uoO
 uoO
@@ -50376,24 +50388,24 @@ uoO
 uoO
 uoO
 eLE
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
 opm
 kRz
-jmN
-jmN
+fLU
+fLU
 ruW
-jmN
+fLU
 hFM
 hvG
 glc
-jmN
+fLU
 eLE
 uoO
 uoO
@@ -50637,24 +50649,24 @@ eLE
 eLE
 eLE
 eLE
-jmN
+fLU
 qww
 qww
 qww
 qww
 qww
 lkH
-jmN
+fLU
 hvG
 hvG
 iep
 caw
 hvG
-jmN
-jmN
-jmN
-jmN
-jmN
+pFp
+pFp
+fLU
+fLU
+fLU
 uoO
 uoO
 aoj
@@ -50894,7 +50906,7 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 qww
 jAi
 dhy
@@ -50907,11 +50919,11 @@ hvG
 hvG
 hvG
 vjm
-jmN
+pFp
 lCX
 xOn
 rVu
-jmN
+fLU
 uoO
 uoO
 aoj
@@ -51151,7 +51163,7 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 sSY
 ley
 hvG
@@ -51164,11 +51176,11 @@ hvG
 bpJ
 hvG
 hvG
-jmN
+pFp
 raR
 xnd
-jmN
-jmN
+fLU
+fLU
 uoO
 uoO
 aoj
@@ -51408,7 +51420,7 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 qww
 jWO
 hvG
@@ -51421,7 +51433,7 @@ hvG
 hvG
 hvG
 caw
-ruW
+bFk
 ifu
 oly
 oWM
@@ -51665,24 +51677,24 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 qww
 ouR
 oji
 yim
 qKn
 qww
-jmN
+fLU
 hvG
 wLV
 gdZ
 gdZ
 hvG
-jmN
+pFp
 raR
 xnd
-jmN
-jmN
+fLU
+fLU
 xVz
 xVz
 uoO
@@ -51922,24 +51934,24 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 qww
 qww
 sCO
 djX
 qww
 qww
-jmN
+fLU
 abm
 jmk
 eZn
 gSt
 vjm
-jmN
+pFp
 jHD
 lQA
 wgE
-jmN
+fLU
 xVz
 xVz
 xVz
@@ -52179,24 +52191,24 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 sSY
 qww
 nWe
 qww
 qww
 itD
-jmN
+fLU
 hvG
 jmk
 bsz
 aQr
 tfs
-jmN
-jmN
-jmN
-jmN
-jmN
+pFp
+pFp
+fLU
+fLU
+fLU
 aoj
 aoj
 xVz
@@ -52436,7 +52448,7 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 qww
 qww
 sCO
@@ -52449,7 +52461,7 @@ hvG
 iep
 iep
 hvG
-jmN
+fLU
 eLE
 aoj
 aoj
@@ -52693,20 +52705,20 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 nWe
 hpn
 tin
 tin
 kdX
 qww
-jmN
+fLU
 dHv
 hvG
 hvG
 hvG
 hvG
-jmN
+fLU
 eLE
 aoj
 aoj
@@ -52950,20 +52962,20 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 qww
 gDy
 pan
 hvG
 uDa
 qww
-jmN
-jmN
+fLU
+fLU
 qYd
 qYd
 xEp
-jmN
-jmN
+fLU
+fLU
 eLE
 uoO
 uoO
@@ -53207,7 +53219,7 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 sSY
 jWO
 gTD
@@ -53220,7 +53232,7 @@ kgX
 kgX
 kgX
 kgX
-jmN
+fLU
 eLE
 uoO
 uoO
@@ -53464,7 +53476,7 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 qww
 qYD
 xkQ
@@ -53477,7 +53489,7 @@ sqz
 rPg
 rPg
 ads
-jmN
+fLU
 eLE
 uoO
 uoO
@@ -53721,20 +53733,20 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 vJy
 qww
 btC
 qww
 qww
 qww
-jmN
+fLU
 jIs
 rPg
 aFX
 kgX
 kgX
-jmN
+fLU
 eLE
 uoO
 uoO
@@ -53978,20 +53990,20 @@ uoO
 uoO
 uoO
 eLE
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
 mQj
-jmN
-jmN
-jmN
-jmN
-jmN
+fLU
+fLU
+fLU
+fLU
+fLU
 eLE
 uoO
 uoO
@@ -54235,20 +54247,20 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 ldD
 cVS
 sUx
 flo
 gtx
 ogE
-jmN
+fLU
 mci
 lyO
 mSi
 akb
 fUi
-jmN
+fLU
 eLE
 uoO
 uoO
@@ -54492,20 +54504,20 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 imw
 uVv
 cVS
 cVS
 nSQ
 cQS
-jmN
+fLU
 lyO
 amC
 lyO
 xDi
 lyO
-jmN
+fLU
 eLE
 uoO
 uoO
@@ -54749,20 +54761,20 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 hCy
 cVS
 aiQ
 cVS
 oJP
 anU
-jmN
+fLU
 lyO
 lyO
 lyO
 lyO
 vjk
-jmN
+fLU
 eLE
 uoO
 uoO
@@ -55006,7 +55018,7 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 vkW
 cVS
 cVS
@@ -55019,7 +55031,7 @@ yhC
 oKN
 tnm
 oKN
-jmN
+fLU
 eLE
 uoO
 uoO
@@ -55263,7 +55275,7 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 vCm
 eym
 cVS
@@ -55276,7 +55288,7 @@ lyO
 oKN
 jlb
 huw
-jmN
+fLU
 eLE
 uoO
 uoO
@@ -55520,20 +55532,20 @@ uoO
 uoO
 uoO
 eLE
-jmN
+fLU
 sUx
 cVS
 dig
 jks
 iks
 ddx
-jmN
+fLU
 uUw
 lyO
 jcn
 pTD
 oKN
-jmN
+fLU
 eLE
 uoO
 uoO
@@ -55777,20 +55789,20 @@ uoO
 uoO
 uoO
 eLE
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
-jmN
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
+fLU
 eLE
 uoO
 uoO

--- a/code/modules/jobs/job_types/tribals.dm
+++ b/code/modules/jobs/job_types/tribals.dm
@@ -9,7 +9,7 @@
 /datum/outfit/job/tribal/
 	name = "TRIBALdatums"
 	jobtype = /datum/job/tribal/
-	shoes = 		/obj/item/clothing/shoes/f13/rag
+	shoes = 		/obj/item/clothing/shoes/sandal
 	gloves =        /obj/item/clothing/gloves/f13/handwraps
 	backpack = 	/obj/item/storage/backpack/explorer
 	satchel = 	/obj/item/storage/backpack/satchel/explorer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This finnaly ports over the DR Legion camp but with more improvements and upgrades than before, also adds improvements to Oasis and changes the shoes for tribals spawn to something more better.

## Why It's Good For The Game

Firstly, Legion camp got a bit of a facelift, the original Legion camp was made before rebase and wasn't touched for a good while, compared to the NCR base that got multiple updates and fixes the Legion camp was outdated and needed upgrades. Firstly things around the camp have been moved, the slave pens are in the mines now, the addition of a war room, an upgraded holding cell with clothing and collars for slaves, a gate house that can be built upon and improved, a gate to keep people in and out, and much more have been changed and edited around the camp.

![StrongDMM_IU4XJAeMBi](https://user-images.githubusercontent.com/62493359/121392432-02004380-c915-11eb-9b12-ee6d469641f8.png)


Secondly, the NCR has a very strong and thick wall to mine into the side of their base, while previous Legion base walls were about 8 tiles, this severely improves that to match NCR standards by giving them their own wall to mine into. Mining into the Legion camp is now more difficult and noticeable that I believe this change helps balance them both out.

![StrongDMM_jYYsMw7oOZ](https://user-images.githubusercontent.com/62493359/121392450-062c6100-c915-11eb-9f5d-621e19c01b89.png)

Thirdly, some minor improvement to Oasis homes and buildings, adding a dresser to each home and also some cooking stoves to add that feeling of homeliness is rather simple. The new major improvement is the addition of a double gate system, which allows for easier venting of people to enter Oasis, while also adding even more defense to the neutral town.

![StrongDMM_KCXwxG6UOP](https://user-images.githubusercontent.com/62493359/121392728-4390ee80-c915-11eb-879c-05a70cbebc3a.png)
(this is also applied to the north gate as well)

Lastly, tribals just wear sandals instead of footrags (they look better on slaves tbh)



## Changelog
:cl:
add: Oasis double gates
add: easter eggs
add: mountain
del: old road
tweak: Legion base
balance: Legio base
fix: zoning errors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
