### PR TITLE
Nerfs enclave, maxcaps and pulse rifle

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -65,15 +65,15 @@
 	name = "Enclave Sergeant"
 	jobtype = /datum/job/wasteland/enclavesgt
 	backpack = /obj/item/storage/backpack/satchel/leather
-	head = 			/obj/item/clothing/head/helmet/f13/power_armor/x02helmet
+	head = 			/obj/item/clothing/head/helmet/f13/combat/enclave
 	ears = 			/obj/item/radio/headset/headset_enclave
 	glasses = 		/obj/item/clothing/glasses/night
 	uniform =		/obj/item/clothing/under/f13/enclave_officer
-	suit = 			/obj/item/clothing/suit/armor/f13/power_armor/x02
+	suit = 			/obj/item/clothing/suit/armor/f13/combat/enclave
 	belt = 			/obj/item/storage/belt/military/army
 	shoes = 		/obj/item/clothing/shoes/combat/swat
 	id = 			/obj/item/card/id/dogtag/enclave
-	suit_store =  	/obj/item/gun/energy/laser/plasma/carbine
+	suit_store =  	/obj/item/gun/energy/laser/aer14
 
 	backpack_contents = list(
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=2,
@@ -114,11 +114,11 @@
 	name = "Enclave Lieutenant"
 	jobtype = /datum/job/wasteland/enclavelt
 	backpack = /obj/item/storage/backpack/satchel/leather
-	head = 			/obj/item/clothing/head/helmet/f13/power_armor/advanced
+	head = 			/obj/item/clothing/head/helmet/f13/power_armor/x02helmet
 	ears = 			/obj/item/radio/headset/headset_enclave
 	glasses = 		/obj/item/clothing/glasses/night
 	uniform =		/obj/item/clothing/under/f13/enclave_officer
-	suit = 			/obj/item/clothing/suit/armor/f13/power_armor/advanced
+	suit = 			/obj/item/clothing/suit/armor/f13/power_armor/x02
 	belt = 			/obj/item/storage/belt/military/army
 	shoes = 		/obj/item/clothing/shoes/combat/swat
 	id = 			/obj/item/card/id/dogtag/enclave

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -1,5 +1,5 @@
 /obj/item/ammo_casing/energy/ion
-	projectile_type = /obj/item/projectile/ion
+	projectile_type = /obj/item/projectile/ion/weak
 	select_name = "ion"
 	fire_sound = 'sound/weapons/ionrifle.ogg'
 

--- a/code/modules/projectiles/projectile/special/ion.dm
+++ b/code/modules/projectiles/projectile/special/ion.dm
@@ -16,4 +16,4 @@
 /obj/item/projectile/ion/weak
 	emp_radius = 1
 	damage = 25
-	armour_penetration = 0.5
+	armour_penetration = 0.2

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -30,7 +30,7 @@
 	id = /datum/reagent/nitroglycerin
 	results = list(/datum/reagent/nitroglycerin = 2)
 	required_reagents = list(/datum/reagent/glycerol = 1, /datum/reagent/toxin/acid/fluacid = 1, /datum/reagent/toxin/acid = 1)
-	strengthdiv = 2
+	strengthdiv = 6
 
 /datum/chemical_reaction/reagent_explosion/nitroglycerin/on_reaction(datum/reagents/holder, multiplier)
 	if(holder.has_reagent(/datum/reagent/stabilizing_agent))
@@ -43,7 +43,7 @@
 	id = "nitroglycerin_explosion"
 	required_reagents = list(/datum/reagent/nitroglycerin = 1)
 	required_temp = 474
-	strengthdiv = 2
+	strengthdiv = 6
 
 
 /datum/chemical_reaction/reagent_explosion/potassium_explosion
@@ -95,7 +95,7 @@
 	id = "blackpowder_explosion"
 	required_reagents = list(/datum/reagent/blackpowder = 1)
 	required_temp = 474
-	strengthdiv = 6
+	strengthdiv = 10
 	modifier = 1
 	mix_message = "<span class='boldannounce'>Sparks start flying around the black powder!</span>"
 
@@ -167,7 +167,7 @@
 	id = "methboom1"
 	required_temp = 380 //slightly above the meth mix time.
 	required_reagents = list(/datum/reagent/drug/methamphetamine = 1)
-	strengthdiv = 6
+	strengthdiv = 10
 	modifier = 1
 	mob_react = FALSE
 

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -50,7 +50,7 @@
 	name = "Explosion"
 	id = "potassium_explosion"
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/potassium = 1)
-	strengthdiv = 10
+	strengthdiv = 12
 
 /datum/chemical_reaction/reagent_explosion/holyboom
 	name = "Holy Explosion"


### PR DESCRIPTION
-Enclave SGTs no longer get PA, get AER14 instead of a plasma carbine
-Enclave LT gets X-02 PA.
-Pulse rifle's EMP range is smaller now
-Pulse rifle looses alot of its previous AP
-Gunpowder and meth maxcaps are now the same as potassium and water maxcaps, potassium and water maxcaps are weaker to give incentive to make meth/gunpowder maxcaps, nitroglycerin maxcaps are as strong as meth maxcaps are currently.

The Enclave had ridiculously good loadouts, allowing them to factionwipe anyone effortlessly without recruiting. Now they need to recruit if they wanna fight against factions better. The Pulse rifles used to have a massive radius requiring no aim, now you need to aim with them and they no longer are that good against anything that isnt PA and won't obliterate you with ease unless you have implants or are wearing PA. (in other words, to be used against BoS and Enclave or just any other PA in general)

Maxcaps are nerfed accross the board, so BoS and Enclave can no longer make your defenses go bye bye so effortlessly.