### PR TITLE
Enclave base changes take2

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -462,17 +462,6 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"avg" = (
-/obj/structure/table/greyscale,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/synthflesh,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "avG" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden,
@@ -573,6 +562,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"aAL" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/paper_bin{
+	pixel_x = 4
+	},
+/obj/item/pen/fountain{
+	pixel_x = -4
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "aBb" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/tunnel)
@@ -701,6 +704,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"aHf" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/computer/terminal,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "aHj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/window/survival_pod{
@@ -774,12 +786,6 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"aND" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "aOT" = (
 /obj/structure/simple_door/bunker/glass,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -1325,9 +1331,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
-"bfy" = (
-/turf/closed/wall/rust,
-/area/f13/enclave)
 "bfL" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "bosdorm8";
@@ -1459,6 +1462,13 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"bjQ" = (
+/obj/structure/table,
+/obj/item/book/granter/trait/midsurgery,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "bjS" = (
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -2034,15 +2044,6 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/bunker)
-"bFq" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/pickaxe/drill,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/enclave)
 "bFC" = (
 /obj/structure/decoration/hatch{
 	dir = 4
@@ -2676,6 +2677,14 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"cim" = (
+/obj/machinery/door/airlock/hatch{
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "ciF" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -3110,10 +3119,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"cBS" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/dark,
-/area/f13/enclave)
 "cCj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3309,6 +3314,21 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"cIu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "cIA" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -4012,6 +4032,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/brotherhood/reactor)
+"doa" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "doi" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
@@ -4050,6 +4076,12 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"dqr" = (
+/obj/structure/bed/mattress/pregame,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "dqs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/prewar/poster72{
@@ -4656,14 +4688,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"dNK" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "dOf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
@@ -5329,6 +5353,12 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"emV" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "emX" = (
 /obj/structure/sign/poster/prewar/poster90{
 	pixel_y = 32
@@ -5470,13 +5500,6 @@
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"etj" = (
-/obj/machinery/light,
-/obj/machinery/chem_heater,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "eub" = (
 /turf/open/floor/plating,
 /area/f13/brotherhood/reactor)
@@ -6029,14 +6052,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"eMX" = (
-/obj/structure/table/greyscale,
-/obj/item/defibrillator/loaded,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "eNt" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -6097,6 +6112,12 @@
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"ePF" = (
+/obj/structure/barricade/bars,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "ePT" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/deathclaw{
@@ -6268,12 +6289,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
-"eZN" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "faa" = (
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/gloves/color/white/bos,
@@ -6308,6 +6323,18 @@
 /obj/structure/safe/floor,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
+"faK" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/emergency,
+/obj/item/storage/toolbox/electrical,
+/obj/item/clothing/glasses/welding,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "faR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/wallmed{
@@ -6452,11 +6479,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"ffS" = (
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+"fgo" = (
+/obj/machinery/door/airlock/hatch{
+	req_one_access_txt = "134"
 	},
+/turf/open/floor/plasteel/dark,
 /area/f13/enclave)
 "fgy" = (
 /obj/machinery/vending/toyliberationstation,
@@ -6850,6 +6877,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"fwR" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fwX" = (
 /obj/machinery/computer/libraryconsole/bookmanagement{
 	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
@@ -7281,6 +7314,16 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
+"fMJ" = (
+/obj/structure/barricade/bars,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "fMR" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -7345,11 +7388,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
-"fPS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/autolathe/ammo/unlocked,
-/turf/open/floor/plasteel/dark,
-/area/f13/enclave)
 "fPT" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood{
@@ -7360,6 +7398,13 @@
 /obj/structure/chalkboard,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"fQo" = (
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "fQF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -7551,12 +7596,6 @@
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"fZN" = (
-/obj/machinery/chem_master/advanced,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "fZO" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/handcuffs,
@@ -8053,13 +8092,6 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/followers)
-"gvW" = (
-/obj/structure/table/greyscale,
-/obj/item/book/granter/trait/midsurgery,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "gwm" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -8130,21 +8162,6 @@
 /obj/machinery/mineral/ore_redemption,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"gzk" = (
-/obj/item/storage/bag/ore,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/enclave)
-"gzs" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -13
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "gzt" = (
 /obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13/wood{
@@ -8549,6 +8566,15 @@
 /obj/item/storage/money_stack,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"gTk" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/chem_master/advanced,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "gTv" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 5
@@ -8628,6 +8654,15 @@
 /obj/machinery/telecomms/broadcaster/preset_left,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"gVW" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/pickaxe/drill,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/enclave)
 "gWc" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/ghoul/glowing,
@@ -8764,6 +8799,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"hcf" = (
+/obj/structure/table,
+/obj/item/defibrillator/loaded,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "hcq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -8912,14 +8954,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"hhA" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/storage/toolbox/electrical,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plasteel/dark,
-/area/f13/enclave)
 "hhC" = (
 /obj/item/trash/f13/dog,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10279,11 +10313,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"iis" = (
-/obj/structure/frame/machine,
-/obj/item/circuitboard/machine/ore_silo,
-/turf/open/floor/plasteel/dark,
-/area/f13/enclave)
 "iiu" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -10418,6 +10447,14 @@
 	icon_state = "whitebluechess"
 	},
 /area/f13/bunker)
+"imP" = (
+/obj/structure/simple_door/metal/barred{
+	req_one_access_txt = "120"
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "inU" = (
 /obj/structure/chair{
 	dir = 8
@@ -10765,6 +10802,11 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/enclave)
+"iCd" = (
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/ore_silo,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "iCA" = (
 /turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
@@ -10915,10 +10957,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
-"iKI" = (
-/obj/structure/mirror,
-/turf/closed/wall/rust,
-/area/f13/enclave)
 "iKQ" = (
 /obj/structure/lattice{
 	layer = 3
@@ -10987,6 +11025,12 @@
 /obj/effect/decal/cleanable/blood/splats,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
+"iNP" = (
+/obj/item/storage/bag/ore,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/enclave)
 "iNY" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -11139,13 +11183,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"iTe" = (
-/obj/structure/table/greyscale,
-/obj/item/book/granter/trait/chemistry,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "iTy" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -11463,24 +11500,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"jdV" = (
-/obj/structure/table/greyscale,
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -10;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -10;
-	pixel_y = 4
-	},
-/obj/item/storage/bag/chemistry{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "jej" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
@@ -11676,6 +11695,14 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/bunker)
+"jmp" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "jmA" = (
 /obj/structure/closet/cabinet,
 /obj/item/taperecorder,
@@ -11707,6 +11734,9 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"joH" = (
+/turf/closed/wall/r_wall/rust,
+/area/f13/enclave)
 "jpg" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -12215,12 +12245,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
-"jJV" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "jKo" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -13510,6 +13534,38 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"kSx" = (
+/obj/structure/rack,
+/obj/machinery/light,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/item/clothing/under/f13/brahminf,
+/obj/item/clothing/under/f13/brahminf,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/item/clothing/under/f13/raider_leather,
+/obj/item/clothing/under/f13/vault,
+/obj/item/clothing/under/f13/cowboyb,
+/obj/item/clothing/under/f13/caravaneer,
+/obj/item/clothing/under/f13/machinist,
+/obj/item/clothing/shoes/f13/diesel,
+/obj/item/clothing/shoes/f13/military/leather,
+/obj/item/clothing/shoes/f13/military,
+/obj/item/clothing/shoes/f13/explorer,
+/obj/item/clothing/shoes/f13/cowboy,
+/obj/item/clothing/gloves/f13/military,
+/obj/item/clothing/gloves/f13/military,
+/obj/item/clothing/gloves/f13/military,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "kTB" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
@@ -13602,14 +13658,6 @@
 	id = "topcellghoul"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
-"kXn" = (
-/obj/structure/camera_assembly{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
 /area/f13/tunnel)
 "kXA" = (
 /obj/structure/table{
@@ -15228,6 +15276,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mvO" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "mxa" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 5
@@ -15290,14 +15346,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"myX" = (
-/obj/machinery/door/airlock/abandoned{
-	req_one_access_txt = "134"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/enclave)
 "mzn" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
@@ -15596,6 +15644,12 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
+"mKH" = (
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/enclave)
 "mKY" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -15676,12 +15730,6 @@
 	icon_state = "whitebluechess"
 	},
 /area/f13/bunker)
-"mNg" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "mNE" = (
 /obj/structure/barricade/bars,
 /turf/open/water,
@@ -15715,6 +15763,12 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
+"mOw" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "mOF" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -15744,6 +15798,14 @@
 "mPC" = (
 /turf/open/indestructible/ground/outside/river,
 /area/f13/tunnel)
+"mQd" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "mQj" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/f13{
@@ -16125,16 +16187,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"nim" = (
-/obj/structure/bed,
-/obj/effect/spawner/lootdrop/bedsheet,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "nip" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -16151,6 +16203,10 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
+"niW" = (
+/obj/structure/closet,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "njZ" = (
 /obj/machinery/autolathe,
 /turf/open/floor/f13/wood,
@@ -16268,6 +16324,11 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"npa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "npi" = (
 /obj/structure/table/optable/abductor,
 /obj/effect/decal/remains/xeno,
@@ -16542,6 +16603,12 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"nBe" = (
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "nBh" = (
 /obj/structure/table/abductor{
 	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
@@ -18822,6 +18889,16 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
+"prL" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -13
+	},
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "prM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice{
@@ -19076,6 +19153,12 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"pAY" = (
+/obj/machinery/chem_heater,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "pBe" = (
 /obj/machinery/light/small,
 /mob/living/simple_animal/hostile/deathclaw,
@@ -19265,12 +19348,6 @@
 /obj/structure/nest/scorpion,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"pKZ" = (
-/obj/machinery/mineral/equipment_vendor,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/enclave)
 "pLl" = (
 /obj/machinery/ore_silo,
 /obj/effect/decal/cleanable/dirt,
@@ -19727,6 +19804,13 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
+"qeW" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "qfa" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -19844,13 +19928,6 @@
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"qiJ" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table/greyscale,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "qiO" = (
 /obj/item/chair,
 /turf/open/indestructible/ground/inside/subway,
@@ -21244,6 +21321,17 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/tunnel)
+"rnw" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/computer/terminal{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "rnI" = (
 /obj/structure/barricade/bars,
 /obj/structure/table,
@@ -21266,12 +21354,6 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"rof" = (
-/obj/structure/closet,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "roS" = (
 /obj/item/cultivator,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -22022,6 +22104,12 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"rOT" = (
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/enclave)
 "rPg" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13{
@@ -22701,14 +22789,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"svI" = (
-/obj/machinery/door/airlock/abandoned{
-	req_one_access_txt = "134"
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "swQ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -22982,15 +23062,6 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"sOi" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "sOq" = (
 /obj/structure/sink{
 	dir = 8;
@@ -23019,6 +23090,14 @@
 /obj/item/circuitboard/machine/autolathe/ammo,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"sPX" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "sPY" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/structure/spider/stickyweb,
@@ -23595,6 +23674,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"ttE" = (
+/obj/structure/sink/kitchen,
+/turf/closed/wall/r_wall/rust,
+/area/f13/enclave)
 "ttW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
@@ -23820,6 +23903,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"tGA" = (
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "tGP" = (
 /obj/structure/simple_door/wood,
 /obj/structure/barricade/wooden/planks,
@@ -24110,10 +24199,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/indestructible/ground/outside/river,
 /area/f13/tunnel)
-"tXn" = (
-/obj/machinery/workbench/advanced,
-/turf/open/floor/plasteel/dark,
-/area/f13/enclave)
 "tXq" = (
 /obj/structure/decoration/clock/active{
 	pixel_x = -1;
@@ -24430,6 +24515,17 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"uog" = (
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "uoq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -24540,10 +24636,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"utz" = (
-/obj/structure/sink/kitchen,
-/turf/closed/wall/rust,
-/area/f13/enclave)
 "utP" = (
 /obj/machinery/door/airlock/grunge{
 	req_access_txt = "120"
@@ -24825,6 +24917,12 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"uIk" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "uIE" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -24877,6 +24975,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/f13/tcoms)
+"uLI" = (
+/obj/machinery/autolathe/ammo/unlocked,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/ore/blackpowder/fifty,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "uLM" = (
 /obj/structure/table,
 /obj/item/clothing/under/f13/enclave_officer,
@@ -24946,6 +25050,15 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
+"uMQ" = (
+/obj/structure/barricade/bars,
+/obj/structure/table{
+	layer = 2.9
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "uNS" = (
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -24956,38 +25069,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"uOg" = (
-/obj/structure/rack,
-/obj/machinery/light,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/item/clothing/under/f13/brahminf,
-/obj/item/clothing/under/f13/brahminf,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/item/clothing/under/f13/raider_leather,
-/obj/item/clothing/under/f13/vault,
-/obj/item/clothing/under/f13/cowboyb,
-/obj/item/clothing/under/f13/caravaneer,
-/obj/item/clothing/under/f13/machinist,
-/obj/item/clothing/shoes/f13/diesel,
-/obj/item/clothing/shoes/f13/military/leather,
-/obj/item/clothing/shoes/f13/military,
-/obj/item/clothing/shoes/f13/explorer,
-/obj/item/clothing/shoes/f13/cowboy,
-/obj/item/clothing/gloves/f13/military,
-/obj/item/clothing/gloves/f13/military,
-/obj/item/clothing/gloves/f13/military,
-/turf/open/floor/plasteel/dark,
-/area/f13/enclave)
 "uOE" = (
 /obj/structure/table/wood/poker,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
@@ -25220,6 +25301,13 @@
 	},
 /area/f13/tunnel)
 "vbu" = (
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
+"vbE" = (
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -25870,6 +25958,15 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
+"vFv" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/infiltrator,
+/obj/item/clothing/mask/infiltrator,
+/obj/item/clothing/mask/infiltrator,
+/obj/item/clothing/mask/infiltrator,
+/obj/item/clothing/mask/infiltrator,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "vFx" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/inside/mountain,
@@ -26069,6 +26166,13 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"vRs" = (
+/obj/structure/table,
+/obj/item/book/granter/trait/chemistry,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "vRM" = (
 /obj/effect/decal/cleanable/blood/old{
 	pixel_x = 12
@@ -26077,6 +26181,14 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"vSW" = (
+/obj/machinery/door/airlock/hatch{
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/enclave)
 "vTY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains{
@@ -26280,6 +26392,10 @@
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"wcQ" = (
+/obj/structure/mirror,
+/turf/closed/wall/r_wall/rust,
+/area/f13/enclave)
 "wdF" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -26791,21 +26907,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"wMZ" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
-"wNG" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/glasses/welding,
-/obj/item/storage/toolbox/electrical,
-/obj/item/storage/toolbox/emergency,
-/obj/item/stack/ore/blackpowder/fifty,
-/turf/open/floor/plasteel/dark,
-/area/f13/enclave)
 "wOg" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -26915,12 +27016,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"wWv" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "wWF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -27355,6 +27450,10 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"xuW" = (
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "xvg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -27364,6 +27463,13 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
+"xvZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "xwm" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/caves)
@@ -27437,6 +27543,24 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"xAa" = (
+/obj/structure/table,
+/obj/item/storage/bag/chemistry{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -10;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -10;
+	pixel_y = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "xAn" = (
 /obj/structure/simple_door/blast{
 	max_integrity = 10000;
@@ -59318,7 +59442,7 @@ wWF
 wWF
 miI
 miI
-kXn
+miI
 miI
 miI
 rOq
@@ -59554,11 +59678,11 @@ tur
 tur
 tur
 tur
-tur
-tur
-tur
 rOq
 ttq
+tur
+tur
+tur
 tur
 tur
 tur
@@ -59810,9 +59934,6 @@ miI
 tur
 uoO
 uoO
-uoO
-uoO
-uoO
 dXE
 xVz
 dXE
@@ -59830,9 +59951,12 @@ uoO
 uoO
 uoO
 uoO
-bfy
+uoO
+uoO
+uoO
+joH
 vbu
-bfy
+joH
 uoO
 uoO
 uoO
@@ -60068,9 +60192,6 @@ tur
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
 xVz
 uoO
 uoO
@@ -60081,19 +60202,22 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-bfy
-bfy
-bfy
-iKI
-bfy
-svI
-bfy
-bfy
-bfy
-bfy
-bfy
+joH
+joH
+joH
+joH
+joH
+joH
+joH
+joH
+wcQ
+joH
+cim
+joH
+joH
+joH
+joH
+joH
 uoO
 uoO
 uoO
@@ -60325,9 +60449,6 @@ tur
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
 xVz
 xVz
 uoO
@@ -60338,19 +60459,22 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-bfy
-jJV
-dNK
-gzs
-bfy
+joH
+dqr
+uMQ
+qNd
+fMJ
+dqr
+joH
+hsN
+prL
+joH
 wTH
 pon
 qfx
 qNd
 fgy
-bfy
+joH
 uoO
 uoO
 aoj
@@ -60581,9 +60705,6 @@ miI
 tur
 uoO
 uoO
-uoO
-uoO
-uoO
 qDR
 xVz
 xVz
@@ -60594,20 +60715,23 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-bfy
-hsN
+uoO
+joH
+wTH
+imP
+wTH
+imP
+vbu
+joH
 wTH
 dwY
-bfy
+joH
 wTH
 nYd
 nYd
 vbu
 hMJ
-bfy
+joH
 uoO
 uoO
 uoO
@@ -60838,9 +60962,6 @@ miI
 tur
 uoO
 uoO
-uoO
-uoO
-uoO
 xVz
 xVz
 xVz
@@ -60851,20 +60972,23 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-bfy
-bfy
-eZN
-bfy
-bfy
+uoO
+joH
+ePF
+ePF
+vbu
+fQo
+fQo
+joH
+cim
+joH
+joH
 wTH
 ejG
 ouq
 vbu
 wXe
-bfy
+joH
 aoj
 uoO
 uoO
@@ -61096,9 +61220,6 @@ tur
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
 xVz
 xVz
 wuf
@@ -61108,11 +61229,14 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-bfy
-sOi
+uoO
+joH
+wTH
+imP
+vbu
+vbu
+wTH
+vbu
 vbu
 vbu
 vbu
@@ -61121,7 +61245,7 @@ wTH
 wTH
 vbu
 uHT
-bfy
+joH
 aoj
 uoO
 aoj
@@ -61353,9 +61477,6 @@ tur
 uoO
 aoj
 uoO
-uoO
-uoO
-uoO
 qDR
 xVz
 xVz
@@ -61365,11 +61486,14 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-bfy
-wTH
+uoO
+joH
+dqr
+uMQ
+lwJ
+cIu
+vbu
+xvZ
 wTH
 vbu
 vbu
@@ -61378,7 +61502,7 @@ lwJ
 vbu
 vbu
 ghD
-bfy
+joH
 uoO
 uoO
 uoO
@@ -61611,9 +61735,6 @@ uoO
 aoj
 uoO
 uoO
-uoO
-uoO
-uoO
 xVz
 tiS
 qDR
@@ -61622,24 +61743,27 @@ uoO
 uoO
 uoO
 uoO
-bfy
-bfy
-bfy
-bfy
-cBS
-bfy
-cBS
-eZN
-bfy
-bfy
-aND
-vbu
-bfy
-bfy
 uoO
-bfy
-bfy
-bfy
+joH
+joH
+joH
+joH
+joH
+joH
+fgo
+joH
+joH
+cim
+joH
+joH
+joH
+cim
+joH
+joH
+joH
+joH
+joH
+joH
 aoj
 aoj
 uoO
@@ -61879,24 +62003,24 @@ uoO
 uoO
 uoO
 uoO
-bfy
-iis
+joH
+iCd
 gXQ
 gXQ
 xiO
-bfy
+joH
+niW
 xiO
 xiO
 wrY
-bfy
-bfy
-gNg
-bfy
-uoO
-uoO
-bfy
+joH
+wTH
+aAL
+aAL
+rnw
+joH
 gUF
-bfy
+joH
 uoO
 uoO
 uoO
@@ -62136,24 +62260,24 @@ uoO
 uoO
 uoO
 uoO
-bfy
+joH
 sfx
 gXQ
 gXQ
 mHA
-bfy
-gXQ
+joH
+npa
 xiO
-uOg
-bfy
-bfy
+xiO
+kSx
+joH
 wTH
-bfy
-bfy
-bfy
-bfy
+aHf
+jmp
+mvO
+joH
 gNg
-bfy
+joH
 uoO
 uoO
 uoO
@@ -62393,24 +62517,24 @@ uoO
 uoO
 uoO
 uoO
-bfy
-tXn
+joH
+xuW
 gXQ
 gXQ
 xiO
-bfy
+joH
+npa
 gXQ
-gXQ
-wAg
-bfy
-vbu
-vbu
+xiO
+vFv
+joH
+mQd
 vbu
 mRk
 mRk
 qRy
 vbu
-bfy
+joH
 uoO
 uoO
 uoO
@@ -62650,24 +62774,24 @@ uoO
 uoO
 uoO
 uoO
-bfy
+joH
 jwN
 xiO
 jfx
 xiO
-bfy
-gXQ
+joH
+npa
+xiO
 xiO
 xjn
-bfy
-rof
+joH
 wTH
 wpj
 vbu
 bcw
 wTH
 wpj
-bfy
+joH
 uoO
 uoO
 uoO
@@ -62907,24 +63031,24 @@ aoj
 uoO
 uoO
 uoO
-bfy
+joH
 fKm
 gXQ
 gXQ
 leT
-bfy
-fPS
+joH
+gXQ
+gXQ
 gXQ
 cIY
-bfy
-rof
+joH
 vbu
 vbu
 deH
 czl
 aWj
-vbu
-bfy
+nBe
+joH
 uoO
 uoO
 uoO
@@ -63164,24 +63288,24 @@ aoj
 uoO
 uoO
 uoO
-bfy
+joH
 rxi
 slw
 xiO
-hhA
-bfy
+faK
+joH
 oeA
+uLI
 xiO
-wNG
-bfy
-rof
+wAg
+joH
 bgL
-nim
+wpj
 vbu
-nim
+wpj
 vbu
-nim
-bfy
+wpj
+joH
 uoO
 uoO
 aoj
@@ -63421,24 +63545,24 @@ aoj
 aoj
 uoO
 uoO
-bfy
-bfy
-cBS
-cBS
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
+joH
+joH
+joH
+fgo
+joH
+joH
+joH
+joH
+joH
+joH
+joH
+joH
+joH
+joH
+joH
+joH
+joH
+joH
 uoO
 uoO
 uoO
@@ -63678,19 +63802,19 @@ aoj
 aoj
 uoO
 uoO
-bfy
+joH
 snf
 vbu
 vbu
-eZN
+cim
 vbu
 vbu
 vbu
-myX
+vSW
 iBp
 iBp
-pKZ
-uoO
+mKH
+joH
 uoO
 uoO
 uoO
@@ -63935,19 +64059,19 @@ uoO
 uoO
 uoO
 uoO
-bfy
+joH
 owF
 vbu
-wMZ
-bfy
-jdV
+uIk
+joH
+bjQ
 vbu
-wWv
-bfy
-bFq
+vbE
+joH
+gVW
 iBp
 iBp
-uoO
+joH
 uoO
 uoO
 uoO
@@ -64192,19 +64316,19 @@ uoO
 aoj
 aoj
 uoO
-bfy
+joH
 cuT
 vbu
 cuT
-bfy
-iTe
+joH
+hcf
 vbu
-fZN
-bfy
-gzk
+fPQ
+joH
+iNP
 iBp
-ffS
-uoO
+rOT
+joH
 uoO
 uoO
 uoO
@@ -64449,19 +64573,19 @@ uoO
 aoj
 aoj
 uoO
-bfy
+joH
 odU
 vbu
 oWK
-bfy
-avg
+joH
+uog
 vbu
-etj
-bfy
-uoO
-uoO
-uoO
-uoO
+nBe
+joH
+iBp
+iBp
+iBp
+joH
 uoO
 uoO
 uoO
@@ -64706,19 +64830,19 @@ uoO
 aoj
 aoj
 uoO
-bfy
+joH
 cuT
 vbu
 cuT
-bfy
-gvW
+joH
+xAa
 vbu
-qiJ
-bfy
-uoO
-uoO
-uoO
-uoO
+vRs
+joH
+joH
+vSW
+joH
+joH
 uoO
 uoO
 uoO
@@ -64963,19 +65087,19 @@ uoO
 uoO
 uoO
 uoO
-bfy
+joH
 cuT
 vbu
 cuT
-bfy
-fPQ
-vbu
-vbu
-bfy
-uoO
-uoO
-uoO
-uoO
+joH
+tGA
+sPX
+qeW
+joH
+xVz
+xVz
+fwR
+xVz
 uoO
 uoO
 uoO
@@ -65220,18 +65344,18 @@ uoO
 uoO
 uoO
 uoO
-utz
-vbu
+ttE
+mOw
 lwJ
-mNg
-bfy
-eMX
-lwJ
-vbu
-bfy
-uoO
-uoO
-uoO
+emV
+joH
+doa
+gTk
+pAY
+joH
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -65477,17 +65601,17 @@ uoO
 uoO
 uoO
 uoO
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-uoO
-uoO
+joH
+joH
+joH
+joH
+joH
+joH
+joH
+joH
+joH
+xVz
+xVz
 uoO
 uoO
 uoO

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -632,10 +632,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"aEJ" = (
-/obj/machinery/workbench,
-/turf/open/floor/plasteel/dark,
-/area/f13/enclave)
 "aFl" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2038,6 +2034,15 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/bunker)
+"bFq" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/pickaxe/drill,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/enclave)
 "bFC" = (
 /obj/structure/decoration/hatch{
 	dir = 4
@@ -4893,35 +4898,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"dVt" = (
-/obj/structure/rack,
-/obj/machinery/light,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/item/clothing/under/f13/brahminf,
-/obj/item/clothing/under/f13/brahminf,
-/obj/item/clothing/under/f13/brahminf,
-/obj/item/clothing/under/f13/brahminf,
-/obj/item/clothing/under/f13/brahminf,
-/obj/item/clothing/under/f13/brahminf,
-/obj/item/clothing/under/f13/brahminm,
-/obj/item/clothing/under/f13/brahminm,
-/obj/item/clothing/under/f13/brahminm,
-/obj/item/clothing/under/f13/brahminm,
-/obj/item/clothing/under/f13/brahminm,
-/obj/item/clothing/under/f13/brahminm,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/plasteel/dark,
-/area/f13/enclave)
 "dVB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/toilet{
@@ -5494,6 +5470,13 @@
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"etj" = (
+/obj/machinery/light,
+/obj/machinery/chem_heater,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "eub" = (
 /turf/open/floor/plating,
 /area/f13/brotherhood/reactor)
@@ -6469,6 +6452,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"ffS" = (
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/enclave)
 "fgy" = (
 /obj/machinery/vending/toyliberationstation,
 /turf/open/floor/f13{
@@ -7562,6 +7551,12 @@
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"fZN" = (
+/obj/machinery/chem_master/advanced,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "fZO" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/handcuffs,
@@ -8058,6 +8053,13 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/followers)
+"gvW" = (
+/obj/structure/table/greyscale,
+/obj/item/book/granter/trait/midsurgery,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "gwm" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -8128,6 +8130,12 @@
 /obj/machinery/mineral/ore_redemption,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"gzk" = (
+/obj/item/storage/bag/ore,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/enclave)
 "gzs" = (
 /obj/structure/sink{
 	dir = 8;
@@ -8904,6 +8912,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"hhA" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "hhC" = (
 /obj/item/trash/f13/dog,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10263,6 +10279,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"iis" = (
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/ore_silo,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "iiu" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -11118,6 +11139,13 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"iTe" = (
+/obj/structure/table/greyscale,
+/obj/item/book/granter/trait/chemistry,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "iTy" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -11435,6 +11463,24 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"jdV" = (
+/obj/structure/table/greyscale,
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -10;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -10;
+	pixel_y = 4
+	},
+/obj/item/storage/bag/chemistry{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "jej" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
@@ -14333,10 +14379,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"lCU" = (
-/obj/machinery/autolathe/ammo,
-/turf/open/floor/plasteel/dark,
-/area/f13/enclave)
 "lCX" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced{
@@ -15634,6 +15676,12 @@
 	icon_state = "whitebluechess"
 	},
 /area/f13/bunker)
+"mNg" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "mNE" = (
 /obj/structure/barricade/bars,
 /turf/open/water,
@@ -16494,12 +16542,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nBe" = (
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "nBh" = (
 /obj/structure/table/abductor{
 	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
@@ -17430,14 +17472,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
-"olp" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/enclave)
 "olw" = (
 /obj/machinery/light{
 	dir = 4;
@@ -19231,6 +19265,12 @@
 /obj/structure/nest/scorpion,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"pKZ" = (
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/enclave)
 "pLl" = (
 /obj/machinery/ore_silo,
 /obj/effect/decal/cleanable/dirt,
@@ -19804,6 +19844,13 @@
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"qiJ" = (
+/obj/machinery/reagentgrinder,
+/obj/structure/table/greyscale,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "qiO" = (
 /obj/item/chair,
 /turf/open/indestructible/ground/inside/subway,
@@ -21219,6 +21266,12 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"rof" = (
+/obj/structure/closet,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "roS" = (
 /obj/item/cultivator,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -21747,13 +21800,6 @@
 /obj/machinery/newscaster,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/reactor)
-"rIL" = (
-/obj/structure/table/greyscale,
-/obj/item/book/granter/trait/lowsurgery,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "rIS" = (
 /obj/item/candle{
 	pixel_x = 7;
@@ -24064,6 +24110,10 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/indestructible/ground/outside/river,
 /area/f13/tunnel)
+"tXn" = (
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "tXq" = (
 /obj/structure/decoration/clock/active{
 	pixel_x = -1;
@@ -24906,6 +24956,38 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"uOg" = (
+/obj/structure/rack,
+/obj/machinery/light,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/item/clothing/under/f13/brahminf,
+/obj/item/clothing/under/f13/brahminf,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/item/clothing/under/f13/raider_leather,
+/obj/item/clothing/under/f13/vault,
+/obj/item/clothing/under/f13/cowboyb,
+/obj/item/clothing/under/f13/caravaneer,
+/obj/item/clothing/under/f13/machinist,
+/obj/item/clothing/shoes/f13/diesel,
+/obj/item/clothing/shoes/f13/military/leather,
+/obj/item/clothing/shoes/f13/military,
+/obj/item/clothing/shoes/f13/explorer,
+/obj/item/clothing/shoes/f13/cowboy,
+/obj/item/clothing/gloves/f13/military,
+/obj/item/clothing/gloves/f13/military,
+/obj/item/clothing/gloves/f13/military,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "uOE" = (
 /obj/structure/table/wood/poker,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
@@ -25920,12 +26002,6 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"vPn" = (
-/obj/structure/table/greyscale,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "vPw" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -26715,6 +26791,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"wMZ" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "wNG" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -26833,6 +26915,12 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"wWv" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "wWF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -27646,12 +27734,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"xTp" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/plasteel/dark,
-/area/f13/enclave)
 "xVt" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -61798,7 +61880,7 @@ uoO
 uoO
 uoO
 bfy
-lCU
+iis
 gXQ
 gXQ
 xiO
@@ -62062,7 +62144,7 @@ mHA
 bfy
 gXQ
 xiO
-dVt
+uOg
 bfy
 bfy
 wTH
@@ -62312,7 +62394,7 @@ uoO
 uoO
 uoO
 bfy
-aEJ
+tXn
 gXQ
 gXQ
 xiO
@@ -62321,7 +62403,7 @@ gXQ
 gXQ
 wAg
 bfy
-bfy
+vbu
 vbu
 vbu
 mRk
@@ -62578,7 +62660,7 @@ gXQ
 xiO
 xjn
 bfy
-bfy
+rof
 wTH
 wpj
 vbu
@@ -62835,7 +62917,7 @@ fPS
 gXQ
 cIY
 bfy
-bfy
+rof
 vbu
 vbu
 deH
@@ -63086,13 +63168,13 @@ bfy
 rxi
 slw
 xiO
-xTp
+hhA
 bfy
 oeA
 xiO
 wNG
 bfy
-bfy
+rof
 bgL
 nim
 vbu
@@ -63607,7 +63689,7 @@ vbu
 myX
 iBp
 iBp
-uoO
+pKZ
 uoO
 uoO
 uoO
@@ -63856,15 +63938,15 @@ uoO
 bfy
 owF
 vbu
-vbu
+wMZ
 bfy
-vPn
+jdV
 vbu
-vbu
+wWv
 bfy
-olp
+bFq
 iBp
-uoO
+iBp
 uoO
 uoO
 uoO
@@ -64115,13 +64197,13 @@ cuT
 vbu
 cuT
 bfy
-vPn
+iTe
 vbu
-vbu
+fZN
 bfy
-uoO
-uoO
-uoO
+gzk
+iBp
+ffS
 uoO
 uoO
 uoO
@@ -64374,7 +64456,7 @@ oWK
 bfy
 avg
 vbu
-nBe
+etj
 bfy
 uoO
 uoO
@@ -64629,9 +64711,9 @@ cuT
 vbu
 cuT
 bfy
-rIL
+gvW
 vbu
-vbu
+qiJ
 bfy
 uoO
 uoO
@@ -65141,7 +65223,7 @@ uoO
 utz
 vbu
 lwJ
-vbu
+mNg
 bfy
 eMX
 lwJ

--- a/code/modules/clothing/masks/boxing.dm
+++ b/code/modules/clothing/masks/boxing.dm
@@ -18,7 +18,7 @@
 
 /obj/item/clothing/mask/infiltrator
 	name = "insidious balaclava"
-	desc = "An incredibly suspicious balaclava made with Syndicate nanofibers to absorb impacts slightly while obfuscating the voice and face using a garbled vocoder."
+	desc = "An incredibly suspicious balaclava made by the Enclave, obfuscating the voice and face using a garbled vocoder."
 	icon_state = "syndicate_balaclava"
 	item_state = "syndicate_balaclava"
 	clothing_flags = ALLOWINTERNALS
@@ -26,7 +26,7 @@
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	visor_flags_inv = HIDEFACE|HIDEFACIALHAIR
 	w_class = WEIGHT_CLASS_SMALL
-	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 0, "bio" = 0, "rad" = 10, "fire" = 30, "acid" = 30)
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	mutantrace_variation = STYLE_MUZZLE
 	var/voice_unknown = TRUE ///This makes it so that your name shows up as unknown when wearing the mask.


### PR DESCRIPTION
## About The Pull Request

In enclave base:
Removes the second redundant reloading bench.
Replaces workbench with advanced workbench.
Adds a chemistry area and chemistry trait book.
Adds an ore silo (unfinshied so it does not mess things up).
Adds an ore redemtion machine and mining rewards vendor.
Adds a seed extractor and biogenerator.
Adds lockers to the starting room, the double thick wall was pointless.

Replaced most of the brahmin skin disguises with more varied ones, including boots and gloves.

Then added changes from #27 

![image](https://user-images.githubusercontent.com/41198990/121568101-4fe87a80-c9ed-11eb-8e7f-3fa5183cc7ce.png)

## Why It's Good For The Game

I have thought about this before but the enclave were quite strong and giving them anything more seemed a little off.

Now with #18 merged I dont think this PR will be too crazy.

This PR adds a lot of machines to the enclave bunker that they would otherwise have to make themselves. This is important because it decreases the amount of time needed to be spent doing menial stuff and increases the time they can spend doing roleplay and really enjoying the best the game has to offer. Setting up an ore silo, ORM and mining rewards vendor every round is a chore.

This PR also gives them a chemistry trait book and chemistry setup. This is both to decrease the time setting up machines and to make it so they do not have to compete with wastelanders for materials. The enclave shouldn't be forced to loot the low tier dungeons and compete with wasters for materials. Its not fun or fair to have someone with power armour and advanced weaponry show up when you're halfway through a dungeon and demand the loot for themselves because they flat out need it to use their technology.

**If some parts of this PR are unwanted I can take off pieces of it so it can be merged, but I think most of its reasonable after the nerf they recieved in #18.**

## Changelog
:cl:
tweak: Enclave base recieves more varied disguises and more machines.
del: Removed redundant ammo bench in enclave base.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
