### PR TITLE
Enclave Base Edit

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -6403,9 +6403,9 @@
 /area/f13/brotherhood/surface)
 "fez" = (
 /obj/item/storage/bag/ore,
-/obj/item/pickaxe/drill,
 /obj/structure/table,
 /obj/item/mining_scanner,
+/obj/item/pickaxe/drill/diamonddrill,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -66,6 +66,12 @@
 /obj/item/ammo_casing/shotgun/improvised,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
+"abX" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "abY" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/floor/f13{
@@ -463,12 +469,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "avg" = (
-/obj/structure/table/greyscale,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/synthflesh,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -701,10 +704,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "aGH" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aHj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/window/survival_pod{
@@ -778,12 +780,6 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"aND" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "aOT" = (
 /obj/structure/simple_door/bunker/glass,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -1329,9 +1325,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
-"bfy" = (
-/turf/closed/wall/rust,
-/area/f13/enclave)
 "bfL" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "bosdorm8";
@@ -2032,12 +2025,9 @@
 	},
 /area/f13/brotherhood/leisure)
 "bFk" = (
-/obj/machinery/door/airlock/hatch,
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/bunker)
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bFC" = (
 /obj/structure/decoration/hatch{
 	dir = 4
@@ -2477,6 +2467,14 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"bXQ" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "bYK" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -3105,10 +3103,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"cBS" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/dark,
-/area/f13/enclave)
 "cCj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3263,6 +3257,14 @@
 /obj/structure/sign/poster/prewar/poster93,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
+"cHa" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/emergency,
+/obj/item/storage/toolbox/electrical,
+/obj/item/clothing/glasses/welding,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "cHw" = (
 /obj/structure/closet/crate/secure/weapon{
 	anchored = 1
@@ -3330,20 +3332,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "cIY" = (
-/obj/structure/rack,
-/obj/item/clothing/head/helmet/f13/combat/enclave,
-/obj/machinery/light,
-/obj/item/clothing/suit/armor/f13/combat/enclave,
-/obj/item/clothing/suit/armor/f13/combat/enclave,
-/obj/item/clothing/suit/armor/f13/combat/enclave,
-/obj/item/clothing/suit/armor/f13/combat/enclave,
-/obj/item/clothing/suit/armor/f13/combat/enclave,
-/obj/item/clothing/head/helmet/f13/combat/enclave,
-/obj/item/clothing/head/helmet/f13/combat/enclave,
-/obj/item/clothing/head/helmet/f13/combat/enclave,
-/obj/item/clothing/head/helmet/f13/combat/enclave,
-/turf/open/floor/plasteel/dark,
-/area/f13/enclave)
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "cJp" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier9,
@@ -3723,6 +3714,14 @@
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"cXK" = (
+/obj/machinery/door/airlock/hatch{
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/enclave)
 "cYr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/hatch,
@@ -4383,9 +4382,12 @@
 	},
 /area/f13/sewer)
 "dFC" = (
-/obj/structure/wreck/trash/four_barrels,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/barricade/wooden,
+/obj/machinery/light/fo13colored/Pink{
+	dir = 1;
+	name = "light tube"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "dFI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4655,6 +4657,11 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/curtain,
+/obj/structure/decoration/vent,
+/obj/machinery/shower{
+	pixel_y = 23
+	},
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -4837,6 +4844,11 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"dTQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "dTR" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -4894,34 +4906,9 @@
 	},
 /area/f13/brotherhood/medical)
 "dVt" = (
-/obj/structure/rack,
-/obj/machinery/light,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/item/clothing/under/f13/brahminf,
-/obj/item/clothing/under/f13/brahminf,
-/obj/item/clothing/under/f13/brahminf,
-/obj/item/clothing/under/f13/brahminf,
-/obj/item/clothing/under/f13/brahminf,
-/obj/item/clothing/under/f13/brahminf,
-/obj/item/clothing/under/f13/brahminm,
-/obj/item/clothing/under/f13/brahminm,
-/obj/item/clothing/under/f13/brahminm,
-/obj/item/clothing/under/f13/brahminm,
-/obj/item/clothing/under/f13/brahminm,
-/obj/item/clothing/under/f13/brahminm,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/plasteel/dark,
-/area/f13/enclave)
+/obj/structure/nest/ghoul,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/tunnel)
 "dVB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/toilet{
@@ -5379,9 +5366,12 @@
 	},
 /area/f13/bunker)
 "eom" = (
-/obj/structure/wreck/trash/three_barrels,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/waste,
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "eoy" = (
 /turf/closed/wall/f13/ruins,
@@ -5399,19 +5389,11 @@
 	},
 /area/f13/brotherhood/leisure)
 "epZ" = (
-/obj/structure/sign/warning{
-	pixel_x = 6;
-	pixel_y = -3
+/obj/structure/sink{
+	pixel_y = 19
 	},
-/obj/structure/decoration/warning{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/obj/structure/decoration/warning{
-	pixel_x = -3;
-	pixel_y = -5
-	},
-/turf/closed/wall/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "eqi" = (
 /obj/effect/decal/cleanable/dirt{
@@ -5471,11 +5453,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "esJ" = (
-/obj/effect/decal/waste,
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "esP" = (
@@ -6047,9 +6025,9 @@
 	},
 /area/f13/brotherhood/leisure)
 "eMX" = (
-/obj/structure/table/greyscale,
-/obj/item/defibrillator/loaded,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/frame/machine,
+/obj/structure/table,
+/obj/item/circuitboard/machine/chem_heater,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -6334,10 +6312,8 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
 "fbD" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "fbP" = (
@@ -6425,6 +6401,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/surface)
+"fez" = (
+/obj/item/storage/bag/ore,
+/obj/item/pickaxe/drill,
+/obj/structure/table,
+/obj/item/mining_scanner,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/enclave)
 "feB" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/f13{
@@ -6640,6 +6625,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"flZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "fmO" = (
 /obj/structure/toilet{
 	dir = 1
@@ -7351,14 +7343,17 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "fPQ" = (
-/obj/structure/table/optable,
+/obj/machinery/reagentgrinder,
+/obj/structure/table,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
 "fPS" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/autolathe/ammo/unlocked,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
 "fPT" = (
@@ -8222,6 +8217,12 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
+"gDQ" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "gED" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -8263,10 +8264,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "gFV" = (
-/obj/structure/table/booth,
+/obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "gGa" = (
 /obj/machinery/vending/coffee,
@@ -8300,6 +8300,14 @@
 /obj/effect/landmark/start/f13/prospector,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"gJG" = (
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/defibrillator/loaded,
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "gKc" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
@@ -8357,7 +8365,9 @@
 /area/f13/brotherhood/operations)
 "gNg" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/simple_door/bunker,
+/obj/machinery/door/airlock/hatch{
+	req_one_access_txt = "134"
+	},
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -8389,9 +8399,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "gNZ" = (
+/obj/machinery/light/fo13colored/Pink{
+	name = "light tube"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "gOG" = (
 /obj/structure/table,
@@ -8621,9 +8634,10 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "gWc" = (
+/obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing,
-/turf/open/floor/f13/wood,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "gWt" = (
 /obj/structure/barricade/bars{
@@ -8695,7 +8709,7 @@
 	},
 /area/f13/brotherhood/operations)
 "gZF" = (
-/mob/living/simple_animal/hostile/ghoul/reaver,
+/mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "hac" = (
@@ -8853,6 +8867,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"heJ" = (
+/obj/item/circuitboard/machine/biogenerator,
+/obj/structure/frame/machine,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "hfb" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -9203,16 +9224,6 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"hsN" = (
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	pixel_y = 23
-	},
-/obj/structure/curtain,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "hsP" = (
 /obj/structure/decoration/vent,
 /obj/effect/decal/cleanable/dirt,
@@ -9360,6 +9371,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"hBp" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "hBz" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/cable{
@@ -9441,7 +9460,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "hEp" = (
-/obj/structure/wreck/trash/three_barrels,
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "hFm" = (
@@ -9620,7 +9642,7 @@
 	},
 /area/f13/brotherhood/mining)
 "hLd" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "hLo" = (
@@ -9662,8 +9684,9 @@
 	},
 /area/f13/followers)
 "hME" = (
-/obj/structure/nest/ghoul,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "hMJ" = (
 /obj/machinery/vending/cigarette,
@@ -10238,8 +10261,9 @@
 	},
 /area/f13/followers)
 "igH" = (
-/obj/structure/wreck/trash/two_barrels,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "igL" = (
 /obj/machinery/door/unpowered/wooddoor,
@@ -10415,9 +10439,11 @@
 	},
 /area/f13/bunker)
 "ioO" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "ioQ" = (
 /obj/effect/turf_decal/arrows/white,
@@ -10429,6 +10455,14 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"ipb" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "ipv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/kitchenspike_frame{
@@ -10896,7 +10930,7 @@
 /area/f13/bunker)
 "iKI" = (
 /obj/structure/mirror,
-/turf/closed/wall/rust,
+/turf/closed/wall/r_wall/rust,
 /area/f13/enclave)
 "iKQ" = (
 /obj/structure/lattice{
@@ -11044,6 +11078,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"iRi" = (
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/ore_redemption,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/enclave)
 "iRw" = (
 /obj/structure/table/wood/fancy,
 /turf/open/floor/wood/f13/carpet,
@@ -12169,12 +12210,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
-"jJV" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "jKo" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -12196,9 +12231,8 @@
 	},
 /area/f13/followers)
 "jKY" = (
-/obj/structure/dresser,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jLX" = (
 /obj/effect/spawner/lootdrop/f13/advcrafting,
@@ -12428,6 +12462,33 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"jUI" = (
+/obj/structure/rack,
+/obj/item/card/id/dogtag/enclave/recruit,
+/obj/item/card/id/dogtag/enclave/recruit,
+/obj/item/card/id/dogtag/enclave/recruit,
+/obj/item/card/id/dogtag/enclave/recruit,
+/obj/item/card/id/dogtag/enclave/recruit,
+/obj/item/card/id/dogtag/enclave/recruit,
+/obj/item/card/id/dogtag/enclave/recruit,
+/obj/item/card/id/dogtag/enclave/recruit,
+/obj/item/card/id/dogtag/enclave/recruit,
+/obj/item/card/id/dogtag/enclave/recruit,
+/obj/item/radio/headset/headset_enclave,
+/obj/item/radio/headset/headset_enclave,
+/obj/item/radio/headset/headset_enclave,
+/obj/item/radio/headset/headset_enclave,
+/obj/item/radio/headset/headset_enclave,
+/obj/item/radio/headset/headset_enclave,
+/obj/item/radio/headset/headset_enclave,
+/obj/item/radio/headset/headset_enclave,
+/obj/item/radio/headset/headset_enclave,
+/obj/item/radio/headset/headset_enclave,
+/obj/item/radio/headset/headset_enclave,
+/obj/item/radio/headset/headset_enclave,
+/obj/item/radio/headset/headset_enclave,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "jVx" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 1
@@ -12523,6 +12584,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"jYu" = (
+/obj/machinery/computer/terminal{
+	dir = 4
+	},
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "jYL" = (
 /obj/structure/table/glass,
 /obj/item/stock_parts/cell/high,
@@ -13252,6 +13322,13 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"kGv" = (
+/obj/machinery/computer/terminal,
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "kGx" = (
 /obj/structure/sign/poster/prewar/poster89,
 /turf/closed/wall/r_wall,
@@ -13815,6 +13892,8 @@
 /obj/item/stack/sheet/leather/five,
 /obj/item/stack/sheet/plastic/five,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/sheet/hay/five,
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
 "lfg" = (
@@ -14334,7 +14413,8 @@
 	},
 /area/f13/brotherhood/medical)
 "lCU" = (
-/obj/machinery/autolathe/ammo,
+/obj/machinery/autolathe/ammo/unlocked,
+/obj/item/stack/ore/blackpowder/fifty,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
 "lCX" = (
@@ -14542,6 +14622,14 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
+"lMw" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "lMT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -15137,6 +15225,18 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
+"mrP" = (
+/obj/item/book/granter/trait/lowsurgery,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "mrV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -15249,12 +15349,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "myX" = (
-/obj/machinery/door/airlock/abandoned{
-	req_one_access_txt = "134"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/turf/closed/wall/r_wall/rust,
 /area/f13/enclave)
 "mzn" = (
 /turf/open/floor/f13/wood{
@@ -16707,11 +16802,8 @@
 	},
 /area/f13/bunker)
 "nJB" = (
-/obj/machinery/light/fo13colored/Pink{
-	name = "light tube"
-	},
+/obj/structure/wreck/trash/four_barrels,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "nJV" = (
@@ -17149,8 +17241,7 @@
 	},
 /area/f13/brotherhood/offices1st)
 "nYd" = (
-/obj/structure/table/greyscale,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/structure/table,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -17307,7 +17398,7 @@
 "oeA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/cell_charger,
-/obj/structure/table/greyscale,
+/obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
 "ofm" = (
@@ -17431,13 +17522,10 @@
 	},
 /area/f13/clinic)
 "olp" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/enclave)
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "olw" = (
 /obj/machinery/light{
 	dir = 4;
@@ -18242,6 +18330,26 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"oTI" = (
+/obj/structure/rack,
+/obj/item/clothing/head/helmet/f13/combat/enclave,
+/obj/machinery/light,
+/obj/item/clothing/suit/armor/f13/combat/enclave,
+/obj/item/clothing/suit/armor/f13/combat/enclave,
+/obj/item/clothing/suit/armor/f13/combat/enclave,
+/obj/item/clothing/suit/armor/f13/combat/enclave,
+/obj/item/clothing/suit/armor/f13/combat/enclave,
+/obj/item/clothing/head/helmet/f13/combat/enclave,
+/obj/item/clothing/head/helmet/f13/combat/enclave,
+/obj/item/clothing/head/helmet/f13/combat/enclave,
+/obj/item/clothing/head/helmet/f13/combat/enclave,
+/obj/item/clothing/mask/infiltrator,
+/obj/item/clothing/mask/infiltrator,
+/obj/item/clothing/mask/infiltrator,
+/obj/item/clothing/mask/infiltrator,
+/obj/item/clothing/mask/infiltrator,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "oUK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -18804,6 +18912,36 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
+"psv" = (
+/obj/machinery/light,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/item/clothing/under/f13/brahminf,
+/obj/item/clothing/under/f13/brahminf,
+/obj/item/clothing/under/f13/brahminf,
+/obj/item/clothing/under/f13/brahminf,
+/obj/item/clothing/under/f13/brahminf,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/item/clothing/under/f13/lumberjack,
+/obj/item/clothing/under/f13/mechanic,
+/obj/structure/rack,
+/obj/item/clothing/under/f13/raiderharness,
+/obj/item/clothing/under/f13/raider_leather,
+/obj/item/clothing/under/f13/police,
+/obj/item/clothing/under/f13/shiny,
+/obj/item/clothing/under/f13/female/mercadv,
+/obj/item/clothing/under/f13/merca,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "psA" = (
 /obj/structure/lattice{
 	layer = 3
@@ -19016,6 +19154,15 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"pAf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "pAn" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "headscribedorm";
@@ -19134,9 +19281,10 @@
 	},
 /area/f13/brotherhood/mining)
 "pFp" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/closed/wall/r_wall/rust,
-/area/f13/bunker)
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "pGw" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -19469,6 +19617,14 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"pWK" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "pWX" = (
 /obj/structure/chair/wood/modern{
 	icon_state = "wooden_chair_settler"
@@ -19621,10 +19777,21 @@
 	},
 /area/f13/tunnel)
 "qcp" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/decoration/warning{
+	pixel_y = -2
+	},
+/obj/structure/sign/warning{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/closed/wall/f13/wood,
 /area/f13/tunnel)
+"qcU" = (
+/obj/machinery/door/airlock/hatch{
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "qdj" = (
 /obj/structure/table/wood/fancy/black,
 /obj/machinery/computer/libraryconsole/bookmanagement{
@@ -19750,9 +19917,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "qhk" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "qhm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -19814,6 +19981,17 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"qjk" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/frame/machine,
+/obj/structure/table,
+/obj/item/circuitboard/machine/chem_dispenser,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "qju" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -19923,6 +20101,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"qpF" = (
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/enclave)
 "qpI" = (
 /obj/item/instrument/eguitar,
 /obj/structure/rack,
@@ -21082,11 +21266,19 @@
 	},
 /area/f13/tunnel)
 "rjq" = (
-/obj/structure/toilet{
-	dir = 1
+/obj/structure/sign/warning{
+	pixel_x = 6;
+	pixel_y = -3
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/decoration/warning{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/structure/decoration/warning{
+	pixel_x = -3;
+	pixel_y = -5
+	},
+/turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "rjz" = (
 /turf/open/floor/f13/wood,
@@ -21104,6 +21296,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"rkp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "rkH" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
@@ -21277,8 +21477,8 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "rrq" = (
-/obj/structure/curtain,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "rrE" = (
 /obj/machinery/light/small{
@@ -21304,9 +21504,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rsg" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/wreck/trash/three_barrels,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "rsj" = (
 /obj/structure/table{
 	layer = 2.9
@@ -21547,6 +21748,7 @@
 	},
 /area/f13/brotherhood/leisure)
 "rzm" = (
+/obj/structure/timeddoor,
 /turf/open/floor/plasteel/f13{
 	icon_state = "platingdmg2"
 	},
@@ -21748,12 +21950,9 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/reactor)
 "rIL" = (
-/obj/structure/table/greyscale,
-/obj/item/book/granter/trait/lowsurgery,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/obj/structure/barricade/wooden/planks,
+/turf/closed/wall/f13/wood,
+/area/f13/tunnel)
 "rIS" = (
 /obj/item/candle{
 	pixel_x = 7;
@@ -21829,6 +22028,15 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"rKe" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "rKx" = (
 /mob/living/simple_animal/hostile/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
@@ -22197,6 +22405,12 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"rZx" = (
+/obj/structure/table/optable,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "rZF" = (
 /obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/indestructible/ground/inside/mountain,
@@ -22319,6 +22533,9 @@
 /area/f13/tcoms)
 "sfx" = (
 /obj/machinery/autolathe,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
 "sfy" = (
@@ -22439,8 +22656,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "siP" = (
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "sjA" = (
 /obj/structure/flora/junglebush,
@@ -22455,6 +22673,16 @@
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"skh" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "skC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash/large,
@@ -22656,7 +22884,7 @@
 	},
 /area/f13/ncr)
 "svI" = (
-/obj/machinery/door/airlock/abandoned{
+/obj/machinery/door/airlock/hatch{
 	req_one_access_txt = "134"
 	},
 /turf/open/floor/f13{
@@ -22792,6 +23020,15 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"sFz" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "sGx" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -22937,14 +23174,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "sOi" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/obj/structure/decoration/warning,
+/turf/closed/wall/rust,
+/area/f13/tunnel)
 "sOq" = (
 /obj/structure/sink{
 	dir = 8;
@@ -23352,6 +23584,14 @@
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"tjZ" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "tkS" = (
 /obj/machinery/door/airlock/hatch{
 	name = "NCR War Room";
@@ -23840,6 +24080,14 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"tJQ" = (
+/obj/structure/bed,
+/obj/effect/spawner/lootdrop/bedsheet,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "tJY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/photocopier,
@@ -23956,6 +24204,11 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"tRy" = (
+/obj/item/circuitboard/machine/ore_silo,
+/obj/structure/frame/machine,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "tRz" = (
 /mob/living/simple_animal/hostile/ghoul/wyomingghost{
 	desc = "A happily proud Enclave commander, mutated and boiled alive by the forced evolutionary virus. His armor looks to be sunken into his flesh.";
@@ -24135,12 +24388,14 @@
 	},
 /area/f13/bunker)
 "tZf" = (
-/obj/structure/sink{
-	pixel_y = 19
+/obj/structure/bed/mattress{
+	icon_state = "mattress4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "tZg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -24245,9 +24500,16 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "ufQ" = (
-/obj/structure/decoration/warning,
-/turf/closed/wall/rust,
-/area/f13/tunnel)
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "ufR" = (
 /obj/structure/rack,
 /obj/item/electropack/shockcollar{
@@ -24492,7 +24754,7 @@
 /area/f13/caves)
 "utz" = (
 /obj/structure/sink/kitchen,
-/turf/closed/wall/rust,
+/turf/closed/wall/r_wall/rust,
 /area/f13/enclave)
 "utP" = (
 /obj/machinery/door/airlock/grunge{
@@ -24531,6 +24793,25 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"uvn" = (
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/m556/rifle/extended,
+/obj/item/ammo_box/magazine/m556/rifle/extended,
+/obj/item/ammo_box/magazine/m556/rifle/extended,
+/obj/item/ammo_box/magazine/m556/rifle/extended,
+/obj/item/ammo_box/magazine/m556/rifle/extended,
+/obj/item/ammo_box/magazine/m556/rifle/extended,
+/obj/item/ammo_box/magazine/m556/rifle/extended,
+/obj/item/ammo_box/magazine/m556/rifle/extended,
+/obj/item/ammo_box/magazine/m556/rifle/extended,
+/obj/item/ammo_box/magazine/m556/rifle/extended,
+/obj/item/gun/ballistic/automatic/assault_carbine,
+/obj/item/gun/ballistic/automatic/assault_carbine,
+/obj/item/gun/ballistic/automatic/assault_carbine,
+/obj/item/gun/ballistic/automatic/assault_carbine,
+/obj/item/gun/ballistic/automatic/assault_carbine,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "uvE" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/f13/wood,
@@ -24547,7 +24828,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "uwt" = (
-/mob/living/simple_animal/hostile/ghoul/glowing,
+/mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "uwA" = (
@@ -25519,12 +25800,12 @@
 	},
 /area/f13/brotherhood/offices1st)
 "vra" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/area/f13/enclave)
 "vrD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -25921,7 +26202,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "vPn" = (
-/obj/structure/table/greyscale,
+/obj/structure/bed/mattress{
+	icon_state = "mattress3"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/ash,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -25951,11 +26239,8 @@
 	},
 /area/f13/brotherhood/medical)
 "vQn" = (
-/obj/effect/decal/waste{
-	icon_state = "goo10"
-	},
-/obj/machinery/shower{
-	dir = 8
+/obj/structure/toilet{
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -26061,9 +26346,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "vWZ" = (
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "vXh" = (
 /obj/structure/chair/stool,
 /obj/machinery/button/door{
@@ -26109,9 +26397,13 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
 "vYC" = (
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "vZj" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -26280,8 +26572,14 @@
 	},
 /area/f13/bunker)
 "wgS" = (
-/obj/structure/barricade/wooden/planks,
-/turf/closed/wall/f13/wood,
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "whp" = (
 /obj/structure/table,
@@ -26318,13 +26616,12 @@
 	},
 /area/f13/caves)
 "wkN" = (
-/obj/structure/barricade/wooden,
-/obj/machinery/light/fo13colored/Pink{
-	dir = 1;
-	name = "light tube"
+/obj/structure/simple_door/metal/barred,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/area/f13/enclave)
 "wle" = (
 /obj/structure/frame/machine,
 /turf/open/floor/f13{
@@ -26389,8 +26686,7 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
 "wrg" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul,
+/obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "wrJ" = (
@@ -26406,18 +26702,11 @@
 	},
 /area/f13/bunker)
 "wrY" = (
-/obj/structure/rack,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/card/id/dogtag/enclave/recruit,
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
 /area/f13/enclave)
 "wsm" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -26536,21 +26825,12 @@
 	},
 /area/f13/tunnel)
 "wAg" = (
-/obj/structure/rack,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
 /area/f13/enclave)
 "wAq" = (
 /obj/item/ammo_casing/shotgun/buckshot,
@@ -26716,13 +26996,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "wNG" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/glasses/welding,
-/obj/item/storage/toolbox/electrical,
-/obj/item/storage/toolbox/emergency,
-/obj/item/stack/ore/blackpowder/fifty,
-/turf/open/floor/plasteel/dark,
+/obj/item/circuitboard/machine/seed_extractor,
+/obj/structure/frame/machine,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
 /area/f13/enclave)
 "wOg" = (
 /obj/structure/chair/wood{
@@ -26856,15 +27134,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "wXG" = (
-/obj/structure/decoration/warning{
-	pixel_y = -2
+/obj/item/circuitboard/machine/plantgenes,
+/obj/structure/frame/machine,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
 	},
-/obj/structure/sign/warning{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/tunnel)
+/area/f13/enclave)
 "wYe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/chair,
@@ -27058,23 +27333,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "xjn" = (
-/obj/structure/rack,
-/obj/item/gun/ballistic/automatic/assault_carbine,
-/obj/item/gun/ballistic/automatic/assault_carbine,
-/obj/item/gun/ballistic/automatic/assault_carbine,
-/obj/item/gun/ballistic/automatic/assault_carbine,
-/obj/item/gun/ballistic/automatic/assault_carbine,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/structure/table,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
 /area/f13/enclave)
 "xjp" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -27262,6 +27531,14 @@
 	icon_state = "bluedirtyfull"
 	},
 /area/f13/bunker)
+"xux" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/enclave)
 "xuF" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -27422,6 +27699,14 @@
 	icon_state = "greendirtysolid"
 	},
 /area/f13/bunker)
+"xER" = (
+/obj/structure/frame/machine,
+/obj/structure/table,
+/obj/item/circuitboard/machine/chem_master/advanced,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/enclave)
 "xEV" = (
 /obj/structure/noticeboard{
 	pixel_x = 32
@@ -27429,6 +27714,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"xFe" = (
+/obj/structure/closet,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "xFN" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -27477,6 +27766,14 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
+"xIG" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/enclave)
 "xIT" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -27593,6 +27890,10 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"xQW" = (
+/obj/structure/rack,
+/turf/open/floor/plasteel/dark,
+/area/f13/enclave)
 "xRm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -50662,11 +50963,11 @@ hvG
 iep
 caw
 hvG
-pFp
-pFp
 fLU
 fLU
-fLU
+pYd
+pYd
+pYd
 uoO
 uoO
 aoj
@@ -50919,11 +51220,11 @@ hvG
 hvG
 hvG
 vjm
-pFp
+fLU
 lCX
 xOn
 rVu
-fLU
+pYd
 uoO
 uoO
 aoj
@@ -51176,11 +51477,11 @@ hvG
 bpJ
 hvG
 hvG
-pFp
+fLU
 raR
 xnd
 fLU
-fLU
+pYd
 uoO
 uoO
 aoj
@@ -51433,7 +51734,7 @@ hvG
 hvG
 hvG
 caw
-bFk
+ruW
 ifu
 oly
 oWM
@@ -51690,11 +51991,11 @@ wLV
 gdZ
 gdZ
 hvG
-pFp
+fLU
 raR
 xnd
 fLU
-fLU
+pYd
 xVz
 xVz
 uoO
@@ -51947,11 +52248,11 @@ jmk
 eZn
 gSt
 vjm
-pFp
+fLU
 jHD
 lQA
 wgE
-fLU
+pYd
 xVz
 xVz
 xVz
@@ -52204,11 +52505,11 @@ jmk
 bsz
 aQr
 tfs
-pFp
-pFp
 fLU
 fLU
-fLU
+pYd
+pYd
+pYd
 aoj
 aoj
 xVz
@@ -57966,7 +58267,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+eLE
 uoO
 eLE
 "}
@@ -58477,8 +58778,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+eLE
+eLE
 aoj
 uoO
 uoO
@@ -59699,24 +60000,24 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-xVz
-uoO
-uoO
-uoO
-tur
-xhF
-nEr
-fTt
-gFV
-cOn
-tjd
-igH
-bEw
-bEw
-dFC
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
+jmN
 tur
 uoO
 uoO
@@ -59748,9 +60049,9 @@ uoO
 uoO
 uoO
 uoO
-bfy
+myX
 vbu
-bfy
+myX
 uoO
 uoO
 uoO
@@ -59958,21 +60259,21 @@ eoy
 eoy
 uoO
 uoO
-vYC
-qhk
+uoO
 xVz
 uoO
-rsg
+uoO
+uoO
 tur
-bEw
-hME
+xhF
 nEr
-nEr
+fTt
+gWc
 cOn
-cOn
-wrg
 tjd
-ckx
+wrg
+bEw
+bEw
 nJB
 tur
 uoO
@@ -59996,22 +60297,22 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-bfy
-bfy
-bfy
+myX
+myX
+myX
+myX
+myX
+myX
+myX
+myX
 iKI
-bfy
+myX
 svI
-bfy
-bfy
-bfy
-bfy
-bfy
+myX
+myX
+myX
+myX
+myX
 uoO
 uoO
 uoO
@@ -60216,20 +60517,20 @@ eoy
 uoO
 uoO
 hLd
+uwt
 xVz
-qhk
-xVz
-xVz
+uoO
+cIY
 tur
-wkN
-rxG
+bEw
+dVt
+nEr
+nEr
 cOn
-vuj
-ioO
-vra
-wKH
-vWZ
-eom
+cOn
+pFp
+tjd
+ckx
 gNZ
 tur
 uoO
@@ -60253,22 +60554,22 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-bfy
-jJV
+myX
+tZf
+vYC
+wTH
+vYC
+skh
+myX
 dNK
 gzs
-bfy
+myX
 wTH
 pon
 qfx
 qNd
 fgy
-bfy
+myX
 uoO
 uoO
 aoj
@@ -60472,22 +60773,22 @@ veq
 eoy
 uoO
 uoO
-uoO
+aGH
 xVz
 uwt
 xVz
-wuf
-lnr
-lnr
-wKH
-xhF
-xhF
-xhF
+xVz
+tur
+dFC
+rxG
+cOn
+vuj
+igH
 hEp
-tur
+wKH
 rrq
-tur
-tur
+rsg
+siP
 tur
 uoO
 uoO
@@ -60510,22 +60811,22 @@ qDR
 uoO
 uoO
 uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-bfy
-hsN
+myX
+ufQ
+wkN
 wTH
+wkN
+lMw
+myX
+flZ
 dwY
-bfy
+myX
 wTH
 nYd
 nYd
 vbu
 hMJ
-bfy
+myX
 uoO
 uoO
 uoO
@@ -60730,20 +61031,20 @@ eoy
 uoO
 uoO
 uoO
-tiS
+xVz
 gZF
-uoO
-uoO
-tur
-tjd
-siP
-vuj
-vuj
-gWc
+xVz
+wuf
+lnr
+lnr
+wKH
 xhF
+xhF
+xhF
+jKY
 tur
-ghw
-rjq
+qhk
+tur
 tur
 tur
 uoO
@@ -60767,22 +61068,22 @@ xVz
 uoO
 uoO
 uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-bfy
-bfy
+myX
+vra
+vra
+wTH
+vra
+vra
+myX
 eZN
-bfy
-bfy
+myX
+myX
 wTH
 ejG
 ouq
 vbu
 wXe
-bfy
+myX
 aoj
 uoO
 uoO
@@ -60987,19 +61288,19 @@ eoy
 uoO
 uoO
 uoO
-uoO
-uoO
+tiS
+bFk
 uoO
 uoO
 tur
-tur
+tjd
 esJ
-qcp
-jKY
+vuj
+vuj
 fbD
-aGH
+xhF
 tur
-tZf
+ghw
 vQn
 tur
 tur
@@ -61024,22 +61325,22 @@ xVz
 uoO
 uoO
 uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-bfy
-sOi
-vbu
-vbu
-vbu
-vbu
+myX
+vPn
+wrY
+wTH
+wTH
+wTH
+wTH
+wTH
+wTH
+wTH
+wTH
 wTH
 wTH
 vbu
 uHT
-bfy
+myX
 aoj
 uoO
 aoj
@@ -61244,21 +61545,21 @@ eoy
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
 tur
 tur
+eom
+gFV
+hME
+ioO
+olp
 tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-tur
-wXG
 epZ
 wgS
-ufQ
+tur
 tur
 uoO
 uoO
@@ -61281,22 +61582,22 @@ xVz
 uoO
 uoO
 uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-bfy
+myX
+vWZ
+wAg
+wTH
+xjn
 wTH
 wTH
-vbu
-vbu
-vbu
-lwJ
-vbu
+pAf
+wTH
+wTH
+wTH
+rKe
+wTH
 vbu
 ghD
-bfy
+myX
 uoO
 uoO
 uoO
@@ -61502,20 +61803,20 @@ tur
 tur
 tur
 tur
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-weW
-kPb
-nuA
-lOu
-weW
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+tur
+qcp
+rjq
+rIL
+sOi
 tur
 uoO
 uoO
@@ -61538,26 +61839,26 @@ qDR
 uoO
 uoO
 uoO
-uoO
-uoO
-bfy
-bfy
-bfy
-bfy
-cBS
-bfy
-cBS
-eZN
-bfy
-bfy
-aND
-vbu
-bfy
-bfy
-uoO
-bfy
-bfy
-bfy
+myX
+myX
+myX
+myX
+myX
+qcU
+myX
+myX
+myX
+qcU
+myX
+myX
+myX
+svI
+myX
+myX
+myX
+myX
+myX
+myX
 aoj
 aoj
 uoO
@@ -61797,24 +62098,24 @@ uoO
 uoO
 uoO
 uoO
-bfy
+myX
 lCU
 gXQ
 gXQ
 xiO
-bfy
+myX
+xFe
 xiO
 xiO
-wrY
-bfy
-bfy
-gNg
-bfy
-uoO
-uoO
-bfy
+jUI
+myX
+wTH
+tjZ
+sFz
+jYu
+myX
 gUF
-bfy
+myX
 uoO
 uoO
 uoO
@@ -62054,24 +62355,24 @@ uoO
 uoO
 uoO
 uoO
-bfy
+myX
 sfx
 gXQ
 gXQ
 mHA
-bfy
-gXQ
+myX
+rkp
 xiO
-dVt
-bfy
-bfy
+xiO
+psv
+myX
 wTH
-bfy
-bfy
-bfy
-bfy
+kGv
+hBp
+bXQ
+myX
 gNg
-bfy
+myX
 uoO
 uoO
 uoO
@@ -62311,24 +62612,24 @@ uoO
 uoO
 uoO
 uoO
-bfy
+myX
 aEJ
 gXQ
 gXQ
 xiO
-bfy
+myX
+dTQ
 gXQ
-gXQ
-wAg
-bfy
-bfy
-vbu
+xiO
+xQW
+myX
+avg
 vbu
 mRk
 mRk
 qRy
 vbu
-bfy
+myX
 uoO
 uoO
 uoO
@@ -62568,24 +62869,24 @@ uoO
 uoO
 uoO
 uoO
-bfy
+myX
 jwN
 xiO
 jfx
+tRy
+myX
+dTQ
 xiO
-bfy
-gXQ
 xiO
-xjn
-bfy
-bfy
+xQW
+myX
 wTH
 wpj
 vbu
 bcw
 wTH
-wpj
-bfy
+tJQ
+myX
 uoO
 uoO
 uoO
@@ -62825,24 +63126,24 @@ aoj
 uoO
 uoO
 uoO
-bfy
+myX
 fKm
 gXQ
 gXQ
 leT
-bfy
+myX
 fPS
 gXQ
-cIY
-bfy
-bfy
+xiO
+oTI
+myX
 vbu
 vbu
 deH
 czl
 aWj
 vbu
-bfy
+myX
 uoO
 uoO
 uoO
@@ -63082,24 +63383,24 @@ aoj
 uoO
 uoO
 uoO
-bfy
+myX
 rxi
 slw
 xiO
 xTp
-bfy
+myX
 oeA
+cHa
 xiO
-wNG
-bfy
-bfy
+uvn
+myX
 bgL
 nim
 vbu
-nim
+wpj
 vbu
-nim
-bfy
+wpj
+myX
 uoO
 uoO
 aoj
@@ -63339,24 +63640,24 @@ aoj
 aoj
 uoO
 uoO
-bfy
-bfy
-cBS
-cBS
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
+myX
+myX
+myX
+qcU
+myX
+myX
+myX
+myX
+myX
+myX
+myX
+myX
+myX
+myX
+myX
+myX
+myX
+myX
 uoO
 uoO
 uoO
@@ -63596,19 +63897,19 @@ aoj
 aoj
 uoO
 uoO
-bfy
+myX
 snf
 vbu
 vbu
-eZN
-vbu
-vbu
-vbu
+myX
+mrP
+rZx
+gJG
 myX
 iBp
-iBp
-uoO
-uoO
+iRi
+xIG
+myX
 uoO
 uoO
 uoO
@@ -63853,19 +64154,19 @@ uoO
 uoO
 uoO
 uoO
-bfy
+myX
 owF
 vbu
 vbu
-bfy
-vPn
+svI
 vbu
 vbu
-bfy
-olp
+vbu
+svI
 iBp
-uoO
-uoO
+iBp
+iBp
+myX
 uoO
 uoO
 uoO
@@ -64110,19 +64411,19 @@ uoO
 aoj
 aoj
 uoO
-bfy
+myX
 cuT
 vbu
 cuT
-bfy
-vPn
+myX
 vbu
 vbu
-bfy
-uoO
-uoO
-uoO
-uoO
+vbu
+myX
+xux
+iBp
+iBp
+myX
 uoO
 uoO
 uoO
@@ -64367,19 +64668,19 @@ uoO
 aoj
 aoj
 uoO
-bfy
+myX
 odU
 vbu
 oWK
-bfy
+myX
 avg
 vbu
 nBe
-bfy
-uoO
-uoO
-uoO
-uoO
+myX
+qpF
+iBp
+fez
+myX
 uoO
 uoO
 uoO
@@ -64624,19 +64925,19 @@ uoO
 aoj
 aoj
 uoO
-bfy
+myX
 cuT
 vbu
 cuT
-bfy
-rIL
+myX
 vbu
 vbu
-bfy
-uoO
-uoO
-uoO
-uoO
+vbu
+myX
+myX
+cXK
+myX
+myX
 uoO
 uoO
 uoO
@@ -64881,19 +65182,19 @@ uoO
 uoO
 uoO
 uoO
-bfy
-cuT
+myX
+wNG
 vbu
-cuT
-bfy
+gDQ
+myX
 fPQ
-vbu
-vbu
-bfy
-uoO
-uoO
-uoO
-uoO
+ipb
+pWK
+myX
+xVz
+xVz
+abX
+xVz
 uoO
 uoO
 uoO
@@ -65139,17 +65440,17 @@ uoO
 uoO
 uoO
 utz
-vbu
+wXG
 lwJ
-vbu
-bfy
+heJ
+myX
 eMX
-lwJ
-vbu
-bfy
-uoO
-uoO
-uoO
+qjk
+xER
+myX
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -65395,16 +65696,16 @@ uoO
 uoO
 uoO
 uoO
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-bfy
-uoO
+myX
+myX
+myX
+myX
+myX
+myX
+myX
+myX
+myX
+xVz
 uoO
 uoO
 uoO
@@ -74409,7 +74710,7 @@ aoj
 aoj
 aoj
 uoO
-uoO
+eLE
 uoO
 uoO
 uoO
@@ -74924,9 +75225,9 @@ tur
 hkD
 hkD
 uoO
-uoO
-uoO
-uoO
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -75441,8 +75742,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+eLE
+eLE
 uoO
 eLE
 "}

--- a/code/modules/clothing/masks/boxing.dm
+++ b/code/modules/clothing/masks/boxing.dm
@@ -18,7 +18,7 @@
 
 /obj/item/clothing/mask/infiltrator
 	name = "insidious balaclava"
-	desc = "An incredibly suspicious balaclava made with Syndicate nanofibers to absorb impacts slightly while obfuscating the voice and face using a garbled vocoder."
+	desc = "An incredibly suspicious balaclava made by the enclave, obfuscating the voice and face using a garbled vocoder."
 	icon_state = "syndicate_balaclava"
 	item_state = "syndicate_balaclava"
 	clothing_flags = ALLOWINTERNALS
@@ -26,7 +26,7 @@
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	visor_flags_inv = HIDEFACE|HIDEFACIALHAIR
 	w_class = WEIGHT_CLASS_SMALL
-	armor = list("melee" = 10, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 0, "bio" = 0, "rad" = 10, "fire" = 30, "acid" = 30)
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	mutantrace_variation = STYLE_MUZZLE
 	var/voice_unknown = TRUE ///This makes it so that your name shows up as unknown when wearing the mask.


### PR DESCRIPTION
## About The Pull Request
Expands and Edits the enclaves base so it's not so crammed and pathetic anymore, while also giving it a proper framework for machines so newer players atleast get an idea of what to do outside of what's ordered or advised by MHelp and Superiors. Also adds four edited insidious balaclavas to the enclave armoury for the purpose of stealth. This also edits the oasis ghoul hole north of the enclave by adding an extra wall to stop the funny meta, and replaces the 60min timer in the NW bunker with the abomination to a 30min timer.
![image](https://user-images.githubusercontent.com/76075239/121543432-d064a680-ca00-11eb-88e4-c0ecf4b1e084.png)
## Why It's Good For The Game
QoL base changes so it's not-shit while also making stealthing a bit easier thanks to the balaclavas, while also doing 2 general fixes to the sewers north of the enclaves base.
## Changelog
- Adds four insidious balaclavas to the armoury
- Adds basic mining equipment at the mine
- Replaces airlocks with a different airlock
- Adds a cellblock
- Shrinks the bathroom
- Expands armoury and disguise options
- Makes it harder to cheese the oasis ghoul pit
- Changes the time-door in the abom-bunker to a 30 min from a 60 min
- See other changes in above screenshot