### PR TITLE
Fixes to legion household slave treasurer loadout, changes to NCR medic ranger and legion forgemaster loadout.

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -356,7 +356,7 @@
 	mask =			/obj/item/clothing/mask/bandana/legvet
 	neck =			/obj/item/storage/belt/holster
 	glasses = 		/obj/item/clothing/glasses/sunglasses
-	suit_store = 	/obj/item/gun/ballistic/automatic/pistol/beretta/automatic	
+	suit_store = 	/obj/item/gun/ballistic/automatic/pistol/beretta/automatic
 	r_pocket =		/obj/item/flashlight/lantern
 	l_pocket =		/obj/item/restraints/handcuffs
 	l_hand = 		/obj/item/nullrod/claymore/chainsaw_sword
@@ -415,7 +415,7 @@
 
 /datum/outfit/loadout/vetberserker
 	name =			"Berserker"
-	suit_store =	/obj/item/gun/ballistic/shotgun/automatic/combat/auto5	
+	suit_store =	/obj/item/gun/ballistic/shotgun/automatic/combat/auto5
 	backpack_contents = list(
 		/obj/item/storage/fancy/ammobox/slugshot=1,
 		/obj/item/twohanded/fireaxe=1,
@@ -550,7 +550,7 @@
 		/obj/item/ammo_box/magazine/autopipe=2)
 
 
-// EXPLORER 
+// EXPLORER
 
 /datum/job/CaesarsLegion/Legionnaire/f13explorer
 	title = "Legion Explorer"
@@ -608,7 +608,7 @@
 	suit_store =	/obj/item/gun/ballistic/shotgun/automatic/hunting/trail
 	backpack_contents = list(
 		/obj/item/ammo_box/tube/m44=4,
-		/obj/item/gun/ballistic/revolver/m29=1,		
+		/obj/item/gun/ballistic/revolver/m29=1,
 		/obj/item/ammo_box/a357=2)
 
 //////////////////////
@@ -749,7 +749,7 @@
 		/obj/item/pen/fountain=1,
 		/obj/item/storage/bag/money/small/legofficers=2,
 		/obj/item/taperecorder=1,
-		/obj/item/book/granter/trait/tinkering)
+		/obj/item/book/granter/trait/tinkering=1)
 
 /datum/outfit/loadout/auxmedicus
 	name =		"Medicus (Surgeon)"
@@ -854,7 +854,7 @@
 Possible paths - refine Forgemaster role, more recipes etc.
 Continue tweaking down power of loadouts in tandem with NCR.
 Slavemaster merged with Forgemaster in a support role has pros and cons, might need shuffle around at some later date.
-Add recipes/traits to keep refining support roles. 
+Add recipes/traits to keep refining support roles.
 
 Priestess of Mars removed to reduce bloat, Legate is enough for admin intervention IC.
 

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -683,7 +683,7 @@
 		/obj/item/stack/sheet/cloth/thirty=1,
 		/obj/item/stack/sheet/prewar=1,
 		/obj/item/book/granter/trait/forgemaster=1,
-		/obj/item/book/granter/trait/tinkering=1)
+		/obj/item/book/granter/trait/techno=1)
 
 
 // AUXILIA - Females with specialist training. Cause men dont do womens work in Legion and vice versa. Cant have it both ways. Healing is womens work, basta.

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -611,7 +611,7 @@ Trooper
 	suit_store = /obj/item/gun/ballistic/automatic/m1carbine //Generally worse weapon, though can be upgraded
 	backpack_contents = list(
 		/obj/item/book/granter/trait/trekking=1, //You get a worse weapon, but are good at scouting. Hence "Pathfinder."
-		/obj/item/storage/box/ration/menu_eight=1, 
+		/obj/item/storage/box/ration/menu_eight=1,
 		/obj/item/ammo_box/magazine/m10mm_adv/ext=1)
 
 /datum/outfit/loadout/trooperfiresupport
@@ -735,7 +735,7 @@ Rear Echelon
 		/obj/item/gun/ballistic/shotgun/hunting=1, \
 		/obj/item/storage/fancy/ammobox/lethalshot=2, \
 		/obj/item/weldingtool/largetank)
-		
+
 
 /*
 Trooper
@@ -970,5 +970,5 @@ Veteran Ranger
 		/obj/item/book/granter/trait/chemistry = 1,
 		/obj/item/gun/ballistic/automatic/pistol/m1911/compact=1,
 		/obj/item/ammo_box/magazine/m45=3,
-		/obj/item/book/granter/trait/lowsurgery
+		/obj/item/book/granter/trait/lowsurgery=1
 	)

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -970,5 +970,5 @@ Veteran Ranger
 		/obj/item/book/granter/trait/chemistry = 1,
 		/obj/item/gun/ballistic/automatic/pistol/m1911/compact=1,
 		/obj/item/ammo_box/magazine/m45=3,
-		/obj/item/book/granter/trait/lowsurgery=1
+		/obj/item/book/granter/trait/midsurgery=1
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the fact that the legion treasurer loadout for household slave doesn't get a tinkering book that they should get.
Removed the tinkering book given to camp duty forgemaster loadout as the forgemaster trait book already gives master_gunsmith (along with legion recipes), replaced with the trait book for technophreak (for salvaging)

Swaps out the surgery_low book given to the NCR medic ranger to a surgery_mid book since NCR combat medic gets the trait and because surgery_low is not that useful.
## Why It's Good For The Game
Fixes bugs. Stinky bugs.

## Changelog
:cl:
fix: Treasurer now actually gets the tinkering perk book.
fix: NCR medic ranger now actually gets the surgery trait book they need.
fix: Forgemaster now doesn't have 2 books that give the same trait, replaced with a book for salvaging.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
