### PR TITLE
Autosurgeon removal

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -1117,7 +1117,7 @@
 	build_path = /obj/item/construction/plumbing
 	category = list("Misc","Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
-
+/*
 /datum/design/autosurgeon
 	name = "Autosurgeon"
 	desc = "An automatic surgeon used to install organs or implants automatically."
@@ -1128,4 +1128,4 @@
 	build_path = /obj/item/autosurgeon
 	category = list("Misc","Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
-
+*/

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -55,7 +55,7 @@
 	display_name = "Experimental Surgery"
 	description = "When evolution isn't fast enough."
 	prereq_ids = list("adv_surgery")
-	design_ids = list("surgery_revival", "surgery_pacify","surgery_vein_thread","surgery_nerve_splice","surgery_nerve_ground","surgery_viral_bond", "autosurgeon")
+	design_ids = list("surgery_revival", "surgery_pacify","surgery_vein_thread","surgery_nerve_splice","surgery_nerve_ground","surgery_viral_bond")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 

--- a/code/modules/research/techweb/nodes/medical_nodes.dm
+++ b/code/modules/research/techweb/nodes/medical_nodes.dm
@@ -52,7 +52,7 @@
 	description = "Basic fragile prosthetics for the impaired."
 	starting_node = TRUE
 	prereq_ids = list("biotech")
-	design_ids = list("basic_l_arm", "basic_r_arm", "basic_r_leg", "basic_l_leg", "autosurgeon")
+	design_ids = list("basic_l_arm", "basic_r_arm", "basic_r_leg", "basic_l_leg")
 
 /datum/techweb_node/advance_limbs
 	id = "advance_limbs"


### PR DESCRIPTION
## About The Pull Request

Autosurgeons are snipped from R&D, could potentially still be used as some "ruin loot prototype."

## Why It's Good For The Game

Autosurgeons invalidated any need to have skills or personnel to obtain implants. It was a source of constant powergame for easy implants (which should otherwise be a big project to do.) It's the sort of thing you'd see at Big MT, not dispensed willy nilly by a protolathe.

More jobs for scribes, more roleplay interaction.

## Changelog
:cl:
del: You can no longer print autosurgeons.
/:cl:

