### PR TITLE
The Be-All End-All Enclave Rebalance

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -64,16 +64,16 @@
 /datum/outfit/job/wasteland/enclavesgt
 	name = "Enclave Sergeant"
 	jobtype = /datum/job/wasteland/enclavesgt
-	backpack = /obj/item/storage/backpack/satchel/leather
-	head = 			/obj/item/clothing/head/helmet/f13/power_armor/x02helmet
+	backpack = /obj/item/storage/backpack/satchel/enclave
+	head = 			/obj/item/clothing/head/helmet/f13/power_armor/advanced
 	ears = 			/obj/item/radio/headset/headset_enclave
 	glasses = 		/obj/item/clothing/glasses/night
-	uniform =		/obj/item/clothing/under/f13/enclave_officer
-	suit = 			/obj/item/clothing/suit/armor/f13/power_armor/x02
+	uniform =		/obj/item/clothing/under/f13/navy
+	suit = 			/obj/item/clothing/suit/armor/f13/power_armor/advanced
 	belt = 			/obj/item/storage/belt/military/army
-	shoes = 		/obj/item/clothing/shoes/combat/swat
+	shoes = 		/obj/item/clothing/shoes/f13/enclave/serviceboots
 	id = 			/obj/item/card/id/dogtag/enclave
-	suit_store =  	/obj/item/gun/energy/laser/plasma/carbine
+	suit_store =  	/obj/item/gun/energy/laser/plasma
 
 	backpack_contents = list(
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=2,
@@ -113,14 +113,14 @@
 /datum/outfit/job/wasteland/enclavelt
 	name = "Enclave Lieutenant"
 	jobtype = /datum/job/wasteland/enclavelt
-	backpack = /obj/item/storage/backpack/satchel/leather
-	head = 			/obj/item/clothing/head/helmet/f13/power_armor/advanced
+	backpack = /obj/item/storage/backpack/satchel/enclave
+	head = 			/obj/item/clothing/head/donor/enclave
 	ears = 			/obj/item/radio/headset/headset_enclave
 	glasses = 		/obj/item/clothing/glasses/night
+	mask = 			/obj/item/clothing/mask/gas/enclave
 	uniform =		/obj/item/clothing/under/f13/enclave_officer
-	suit = 			/obj/item/clothing/suit/armor/f13/power_armor/advanced
-	belt = 			/obj/item/storage/belt/military/army
-	shoes = 		/obj/item/clothing/shoes/combat/swat
+	belt = 			/obj/item/storage/belt/military/assault/enclave
+	shoes = 		/obj/item/clothing/shoes/f13/enclave/serviceboots
 	id = 			/obj/item/card/id/dogtag/enclave
 	suit_store =  	/obj/item/gun/energy/laser/plasma/glock/extended
 

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -70,7 +70,7 @@
 	glasses = 		/obj/item/clothing/glasses/night
 	uniform =		/obj/item/clothing/under/f13/navy
 	suit = 			/obj/item/clothing/suit/armor/f13/power_armor/advanced
-	belt = 			/obj/item/storage/belt/military/army
+	belt = 			/obj/item/storage/belt/military/assault/enclave
 	shoes = 		/obj/item/clothing/shoes/f13/enclave/serviceboots
 	id = 			/obj/item/card/id/dogtag/enclave
 	suit_store =  	/obj/item/gun/energy/laser/plasma


### PR DESCRIPTION
## About The Pull Request

As certain faction mains that will go unnamed evidently have issue with the current state of the Enclave, this PR serves to not nerf them, but instead rework them. Whilst both Sergeants are given upgrades to advanced power armor, the lieutenant loses their set entirely in favor of a super badass flatcap on their head, plus a cool gas mask. The sergeants' armaments have also been nerfed to standard plasma rifles, as plasma carbines were quite literally the best guns in the game to the point of critting power armor in two clicks. This PR also brushes over their bags and shoes to be more proper, and also ensures that ONLY the lieutenant gets the officer uniform to match their cap. Woohoo.

## Why It's Good For The Game

Instead of attempting to remove the Enclave remnants entirely, or nerf them into the ground, this PR changes them up: they lack three suits of power armor, with their two suits being better than previously, which ensures that they must still attempt to recruit or remain in hiding rather than tanking the Brotherhood head-on with their three suits. Nerfing the armor but letting them all still have it changes nothing, as it's still power armor- it still deflects shots. This is precisely why I've changed it the way I have.

## Changelog
:cl:
tweak: full enclave rework
/:cl:
