### PR TITLE
chemsplosives nerf

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -30,7 +30,7 @@
 	id = /datum/reagent/nitroglycerin
 	results = list(/datum/reagent/nitroglycerin = 2)
 	required_reagents = list(/datum/reagent/glycerol = 1, /datum/reagent/toxin/acid/fluacid = 1, /datum/reagent/toxin/acid = 1)
-	strengthdiv = 2
+	strengthdiv = 6
 
 /datum/chemical_reaction/reagent_explosion/nitroglycerin/on_reaction(datum/reagents/holder, multiplier)
 	if(holder.has_reagent(/datum/reagent/stabilizing_agent))
@@ -43,14 +43,14 @@
 	id = "nitroglycerin_explosion"
 	required_reagents = list(/datum/reagent/nitroglycerin = 1)
 	required_temp = 474
-	strengthdiv = 2
+	strengthdiv = 6
 
 
 /datum/chemical_reaction/reagent_explosion/potassium_explosion
 	name = "Explosion"
 	id = "potassium_explosion"
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/potassium = 1)
-	strengthdiv = 10
+	strengthdiv = 12
 
 /datum/chemical_reaction/reagent_explosion/holyboom
 	name = "Holy Explosion"
@@ -95,7 +95,7 @@
 	id = "blackpowder_explosion"
 	required_reagents = list(/datum/reagent/blackpowder = 1)
 	required_temp = 474
-	strengthdiv = 6
+	strengthdiv = 10
 	modifier = 1
 	mix_message = "<span class='boldannounce'>Sparks start flying around the black powder!</span>"
 
@@ -167,7 +167,7 @@
 	id = "methboom1"
 	required_temp = 380 //slightly above the meth mix time.
 	required_reagents = list(/datum/reagent/drug/methamphetamine = 1)
-	strengthdiv = 6
+	strengthdiv = 10
 	modifier = 1
 	mob_react = FALSE
 


### PR DESCRIPTION
## About The Pull Request

Completes the same explosives change as #18 but atomized this time.

## Why It's Good For The Game

The abuse of explosives is absurd, nitro takes the place of meth/blackpowder. Nitroglycerin is good as it is with the strengthdiv of blackpowder because it effectively has double strength if you mix it without stabilizing agent, which makes it not completely ridiculous as before but still formidable (and risky because it can immediately explode). That, and nitroglycerin is still very difficult to make without a high-maintenance setup.

Nitroglycerin takes the place of blackpowder, blackpowder and meth explosions take the place of water and potassium, water and potassium becomes overall less powerful.

PH explosions are unchanged because they don't work in chemical grenades (they neutralize PH due to wonky code IIRC) and are mainly used to destroy chemists who aren't keeping track of it while mixing.

## Changelog
:cl:
balance: Chemical explosions are now overall less powerful.
/:cl:
