### PR TITLE
Better multitile handling

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -173,7 +173,11 @@
 				continue
 
 			if(!(SEND_SIGNAL(target.loc, COMSIG_ATOM_CANREACH, next) & COMPONENT_BLOCK_REACH) && target.loc.canReachInto(src, ultimate_target, next, view_only, tool))
-				next += target.loc
+				if(isturf(target.loc))
+					var/atom/movable/movable_target = target
+					next += movable_target.locs
+				else
+					next += target.loc
 
 		checking = next
 	return FALSE

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -45,10 +45,7 @@
 	if(!(attackchain_flags & ATTACK_IGNORE_CLICKDELAY) && !CheckAttackCooldown(user, A))
 		return STOP_ATTACK_PROC_CHAIN
 
-// No comment
 /atom/proc/attackby(obj/item/W, mob/user, params)
-	if(linked_attack_parent)
-		linked_attack_parent.attackby(W, user)
 	if(SEND_SIGNAL(src, COMSIG_PARENT_ATTACKBY, W, user, params) & COMPONENT_NO_AFTERATTACK)
 		return STOP_ATTACK_PROC_CHAIN
 

--- a/code/datums/components/largeobjecttransparency.dm
+++ b/code/datums/components/largeobjecttransparency.dm
@@ -2,7 +2,7 @@
 /datum/component/largetransparency
 	//Can be positive or negative. Determines how far away from parent the first registered turf is.
 	var/x_offset = 0
-	var/y_offset = 1
+	var/y_offset = 0
 	//Has to be positive or 0.
 	var/x_size = 0
 	var/y_size = 0
@@ -17,6 +17,7 @@
 /datum/component/largetransparency/Initialize(x_offset, y_offset, x_size, y_size, initial_alpha, target_alpha)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
+	var/atom/large_atom = parent
 	if(!isnull(x_offset))
 		src.x_offset = x_offset
 	if(!isnull(y_offset))
@@ -26,14 +27,21 @@
 	if(!isnull(y_size))
 		src.y_size = y_size
 	if(isnull(initial_alpha))
-		var/atom/at = parent
-		src.initial_alpha = at.alpha
+		src.initial_alpha = large_atom.alpha
 	else
 		src.initial_alpha = initial_alpha
 	if(!isnull(target_alpha))
 		src.target_alpha = target_alpha
 	if(!isnull(toggle_click))
 		src.toggle_click = toggle_click
+	if(large_atom.pixel_x)
+		src.x_offset += FLOOR(large_atom.pixel_x / 32, 1) // Every full 32 pixel shifts we leave one turf behind.
+		if(large_atom.pixel_x % 32)
+			src.x_size++ // Sprite is now sticking between two tiles, we'll have to listen for both.
+	if(large_atom.pixel_y)
+		src.y_offset += FLOOR(large_atom.pixel_y / 32, 1)
+		if(large_atom.pixel_y % 32)
+			src.y_size++
 
 
 /datum/component/largetransparency/Destroy()

--- a/code/datums/components/largeobjecttransparency.dm
+++ b/code/datums/components/largeobjecttransparency.dm
@@ -1,34 +1,39 @@
 ///Makes large icons partially see through if high priority atoms are behind them.
 /datum/component/largetransparency
 	//Can be positive or negative. Determines how far away from parent the first registered turf is.
-	var/x_offset
-	var/y_offset
+	var/x_offset = 0
+	var/y_offset = 1
 	//Has to be positive or 0.
-	var/x_size
-	var/y_size
+	var/x_size = 0
+	var/y_size = 0
 	//The alpha values this switches in between.
-	var/initial_alpha
-	var/target_alpha
+	var/initial_alpha = 255
+	var/target_alpha = 140
 	//if this is supposed to prevent clicks if it's transparent.
-	var/toggle_click
-	var/list/registered_turfs
+	var/toggle_click = TRUE
+	var/list/registered_turfs = list()
 	var/amounthidden = 0
 
-/datum/component/largetransparency/Initialize(_x_offset = 0, _y_offset = 1, _x_size = 0, _y_size = 1, _initial_alpha = null, _target_alpha = 140, _toggle_click = TRUE)
+/datum/component/largetransparency/Initialize(x_offset, y_offset, x_size, y_size, initial_alpha, target_alpha)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
-	x_offset = _x_offset
-	y_offset = _y_offset
-	x_size = _x_size
-	y_size = _y_size
-	if(isnull(_initial_alpha))
+	if(!isnull(x_offset))
+		src.x_offset = x_offset
+	if(!isnull(y_offset))
+		src.y_offset = y_offset
+	if(!isnull(x_size))
+		src.x_size = x_size
+	if(!isnull(y_size))
+		src.y_size = y_size
+	if(isnull(initial_alpha))
 		var/atom/at = parent
-		initial_alpha = at.alpha
+		src.initial_alpha = at.alpha
 	else
-		initial_alpha = _initial_alpha
-	target_alpha = _target_alpha
-	toggle_click = _toggle_click
-	registered_turfs = list()
+		src.initial_alpha = initial_alpha
+	if(!isnull(target_alpha))
+		src.target_alpha = target_alpha
+	if(!isnull(toggle_click))
+		src.toggle_click = toggle_click
 
 
 /datum/component/largetransparency/Destroy()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -73,8 +73,6 @@
 	///Mobs that are currently do_after'ing this atom, to be cleared from on Destroy()
 	var/list/targeted_by
 
-	///Linked atom that will be attacked if this atom is attacked. Currently implemented for /structure/car
-	var/atom/linked_attack_parent
 
 /atom/New(loc, ...)
 	//atom creation method that preloads variables at creation

--- a/code/game/objects/items/fallout13misc.dm
+++ b/code/game/objects/items/fallout13misc.dm
@@ -159,7 +159,7 @@
 
 /obj/item/flag/Initialize()
 	. = ..()
-	AddComponent(/datum/component/largetransparency)
+	AddComponent(/datum/component/largetransparency, y_size = 1)
 
 /obj/item/flag/ncr
 	name = "NCR flag"

--- a/code/modules/fallout/machinery/light_sources/bar.dm
+++ b/code/modules/fallout/machinery/light_sources/bar.dm
@@ -18,7 +18,7 @@
 
 /obj/machinery/light/sign/Initialize()
 	. = ..()
-	AddComponent(/datum/component/largetransparency, x_size = 1)
+	AddComponent(/datum/component/largetransparency, x_size = 1, y_size = 1)
 
 
 /obj/machinery/light/sign/update_icon()

--- a/code/modules/fallout/machinery/light_sources/bar.dm
+++ b/code/modules/fallout/machinery/light_sources/bar.dm
@@ -5,6 +5,7 @@
 	icon_state = "blue"
 	base_state = "blue"
 	icon = 'icons/fallout/machines/64x32.dmi'
+	bound_width = 64
 	fitting = "bulb"
 	brightness = 4
 	active_power_usage = 0
@@ -17,7 +18,7 @@
 
 /obj/machinery/light/sign/Initialize()
 	. = ..()
-	AddComponent(/datum/component/largetransparency)
+	AddComponent(/datum/component/largetransparency, x_size = 1)
 
 
 /obj/machinery/light/sign/update_icon()

--- a/code/modules/fallout/obj/structures/billboard.dm
+++ b/code/modules/fallout/obj/structures/billboard.dm
@@ -13,7 +13,7 @@
 
 /obj/structure/billboard/Initialize()
 	. = ..()
-	AddComponent(/datum/component/largetransparency, x_size = 1)
+	AddComponent(/datum/component/largetransparency, x_size = 1, y_size = 1)
 
 /*
 /obj/structure/billboard/New()

--- a/code/modules/fallout/obj/structures/billboard.dm
+++ b/code/modules/fallout/obj/structures/billboard.dm
@@ -8,11 +8,12 @@
 	anchored = 1
 	layer = 5
 	icon = 'icons/obj/Ritas.dmi'
+	bound_width = 64
 	resistance_flags = INDESTRUCTIBLE
 
 /obj/structure/billboard/Initialize()
 	. = ..()
-	AddComponent(/datum/component/largetransparency)
+	AddComponent(/datum/component/largetransparency, x_size = 1)
 
 /*
 /obj/structure/billboard/New()

--- a/code/modules/fallout/obj/structures/cargocrate.dm
+++ b/code/modules/fallout/obj/structures/cargocrate.dm
@@ -12,4 +12,4 @@
 /obj/structure/cargocrate/Initialize()
 	. = ..()
 	icon_state = pick("cargocrate1","cargocrate2","cargocrate3","cargocrate4","cargocrate5")
-	AddComponent(/datum/component/largetransparency, x_size = 1)
+	AddComponent(/datum/component/largetransparency, x_size = 1, y_size = 1)

--- a/code/modules/fallout/obj/structures/cargocrate.dm
+++ b/code/modules/fallout/obj/structures/cargocrate.dm
@@ -7,7 +7,7 @@
 	density = 1
 	layer = ABOVE_MOB_LAYER
 	resistance_flags = INDESTRUCTIBLE
-	bound_width = 62
+	bound_width = 64
 
 /obj/structure/cargocrate/Initialize()
 	. = ..()

--- a/code/modules/fallout/obj/structures/cargocrate.dm
+++ b/code/modules/fallout/obj/structures/cargocrate.dm
@@ -7,14 +7,9 @@
 	density = 1
 	layer = ABOVE_MOB_LAYER
 	resistance_flags = INDESTRUCTIBLE
+	bound_width = 62
 
-/obj/structure/cargocrate/New()
-	..()
+/obj/structure/cargocrate/Initialize()
+	. = ..()
 	icon_state = pick("cargocrate1","cargocrate2","cargocrate3","cargocrate4","cargocrate5")
-//	dir = pick("1","2","4","5","6","8","9","10")
-
-	var/atom/movable/S = new (locate(x+1,y,z))
-	S.density = 1
-	S.anchored = 1
-	S.icon = null
-	S.verbs.Cut()
+	AddComponent(/datum/component/largetransparency, x_size = 1)

--- a/code/modules/fallout/obj/structures/well.dm
+++ b/code/modules/fallout/obj/structures/well.dm
@@ -5,3 +5,4 @@
 	desc = "A structure used to provide a source of fresh water - nothing out of the ordinary."
 	icon_state = "wellwheel"
 	icon = 'icons/obj/Ritas.dmi'
+	bound_width = 64

--- a/code/modules/vehicles/rubbish.dm
+++ b/code/modules/vehicles/rubbish.dm
@@ -40,88 +40,57 @@
 	density = 1
 	layer = ABOVE_MOB_LAYER
 	resistance_flags = INDESTRUCTIBLE
-	var/uses_left = 5 //yea, when it "read" 4, it was 5 still. I've changed some stuff to where it "reads" 5 and actually is 5.
+	bound_height = 64
+	bound_width = 64
+	var/uses_left = 5
 	var/inuse = FALSE
-	var/S1
-	var/S2
-	var/S3
-	var/S4
 
-/obj/structure/car/New()
-	..()
 
-	var/atom/movable/S = new (locate(x+1,y,z))
-	S1 = S
-	S.density = 1
-	S.anchored = 1
-	S.icon = null
-	S.verbs.Cut()
-	S.linked_attack_parent = src
-
-	S = new (locate(x+1,y+1,z))
-	S2 = S
-	S.density = 1
-	S.anchored = 1
-	S.icon = null
-	S.verbs.Cut()
-	S.linked_attack_parent = src
-
-	S = new (locate(x,y+1,z))
-	S3 = S
-	S.density = 1
-	S.anchored = 1
-	S.icon = null
-	S.verbs.Cut()
-	S.linked_attack_parent = src
-
-/obj/structure/car/attackby(obj/item/I, mob/living/user, params)
-	if(istype(I, /obj/item/weldingtool))
-		var/obj/item/weldingtool/W = I
-		if(inuse || uses_left <= 0) //this means that if mappers or admins want an nonharvestable version, set the uses_left to 0
-			return
-		inuse = TRUE //one at a time boys, this isn't some kind of weird party
-		if(!I.tool_start_check(user, amount=0)) //this seems to be called everywhere, so for consistency's sake
+/obj/structure/car/welder_act(mob/living/user, obj/item/I)
+	. = TRUE
+	var/obj/item/weldingtool/W = I
+	if(inuse || uses_left <= 0) //this means that if mappers or admins want an nonharvestable version, set the uses_left to 0
+		return
+	inuse = TRUE //one at a time boys, this isn't some kind of weird party
+	if(!I.tool_start_check(user, amount=0)) //this seems to be called everywhere, so for consistency's sake
+		inuse = FALSE
+		return //the tool fails this check, so stop
+	user.visible_message("[user] starts disassembling [src].")
+	if(!I.use_tool(src, user, 0, volume=100)) //here is the dilemma, use_tool doesn't work like do_after, so moving away screws it(?)
+		inuse = FALSE
+		return //you can't use the tool, so stop
+	for(var/i1 in 1 to 2) //so, I hate waiting 30 seconds straight... what if we wait 10 seconds 3 times? (yes, its the same, but it'll feel more!)
+		if(!do_after(user, 10 SECONDS * W.toolspeed, target = src)) //this is my work around, because do_After does have a move away
+			user.visible_message("[user] stops disassembling [src].")
 			inuse = FALSE
-			return //the tool fails this check, so stop
-		user.visible_message("[user] starts disassembling [src].")
-		if(!I.use_tool(src, user, 0, volume=100)) //here is the dilemma, use_tool doesn't work like do_after, so moving away screws it(?)
-			inuse = FALSE
-			return //you can't use the tool, so stop
-		for(var/i1 in 1 to 2) //so, I hate waiting 30 seconds straight... what if we wait 10 seconds 3 times? (yes, its the same, but it'll feel more!)
-			if(!do_after(user, 10 SECONDS * W.toolspeed, target = src)) //this is my work around, because do_After does have a move away
-				user.visible_message("[user] stops disassembling [src].")
-				inuse = FALSE
-				return //you did something, like moving, so stop
-			var/fake_dismantle = pick("plating", "rod", "rim", "part of the frame")
-			user.visible_message("[user] slices through a [fake_dismantle].")
-			I.play_tool_sound(src, 100)
-		var/turf/usr_turf = get_turf(user)
-		if(HAS_TRAIT(user,TRAIT_TECHNOPHREAK))
-			for(var/i3 in 1 to 5) //this is just less lines for the same thing
-				if(prob(3))
-					new /obj/item/salvage/high(usr_turf)
-				if(prob(5))
-					new /obj/item/salvage/crafting(usr_turf)
-				if(prob(5))
-					new /obj/item/salvage/low(usr_turf)
-		for(var/i2 in 1 to rand(3,5)) //also changing this a little. IDEA: perhaps a mechanic skill could affect the amount dropped instead
-			if(prob(25))
-				if(prob(50))
-					new /obj/item/salvage/crafting(usr_turf)
-				else
-					new /obj/item/salvage/low(usr_turf)
-		for(var/i3 in 1 to 3) //this is just less lines for the same thing
+			return //you did something, like moving, so stop
+		var/fake_dismantle = pick("plating", "rod", "rim", "part of the frame")
+		user.visible_message("[user] slices through a [fake_dismantle].")
+		I.play_tool_sound(src, 100)
+	var/turf/usr_turf = get_turf(user)
+	if(HAS_TRAIT(user,TRAIT_TECHNOPHREAK))
+		for(var/i3 in 1 to 5) //this is just less lines for the same thing
 			if(prob(3))
 				new /obj/item/salvage/high(usr_turf)
-		uses_left--
-		inuse = FALSE //putting this after the -- because the first check prevents cheesing
-		if(uses_left <= 0) //I prefer to put any qdel stuff at the very end, with src being the very last thing
-			visible_message("[src] falls apart, the final components having been removed.")
-			qdel(S1)
-			qdel(S2)
-			qdel(S3)
-			qdel(S4)
-			qdel(src)
+			if(prob(5))
+				new /obj/item/salvage/crafting(usr_turf)
+			if(prob(5))
+				new /obj/item/salvage/low(usr_turf)
+	for(var/i2 in 1 to rand(3,5)) //also changing this a little. IDEA: perhaps a mechanic skill could affect the amount dropped instead
+		if(prob(25))
+			if(prob(50))
+				new /obj/item/salvage/crafting(usr_turf)
+			else
+				new /obj/item/salvage/low(usr_turf)
+	for(var/i3 in 1 to 3) //this is just less lines for the same thing
+		if(prob(3))
+			new /obj/item/salvage/high(usr_turf)
+	uses_left--
+	inuse = FALSE //putting this after the -- because the first check prevents cheesing
+	if(uses_left <= 0) //I prefer to put any qdel stuff at the very end, with src being the very last thing
+		visible_message("[src] falls apart, the final components having been removed.")
+		qdel(src)
+
 
 /obj/structure/car/rubbish1
 	name = "pre-War rubbish"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
* Removes hacky and old multitile code and replaces it with the engine's system.
* Modifies the adjacency checks to take it into account.
* Minor code cleanup.
* Properly implements the big object transparency.
* Cargo crates, being large and dense, will now block two tiles instead of just one. I'm assuming their base is 64x32, and the top is just 3/4 perspective.
* The large object transparency component now handles pixel shifted objects.

<!-- ## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can now interact with multi-tile objects (like old car wrecks) from any direction, not just from their bottom-left tile.
fix: Large object transparency should now work on any tile underneath them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
