### PR TITLE
crafting punji sticks removal

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -369,7 +369,7 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
  */
 
 GLOBAL_LIST_INIT(bamboo_recipes, list ( \
-	new/datum/stack_recipe("punji sticks trap", /obj/structure/punji_sticks, 5, time = 30, one_per_turf = TRUE, on_floor = TRUE), \
+	/* new/datum/stack_recipe("punji sticks trap", /obj/structure/punji_sticks, 5, time = 30, one_per_turf = TRUE, on_floor = TRUE), */ \
 	))
 
 /obj/item/stack/sheet/mineral/bamboo


### PR DESCRIPTION

## About The Pull Request

Notes out the code responsible for making punji sticks craft-able.

## Why It's Good For The Game

Punji sticks apply enough damage to inflict damage slowdown through armor and cause knockdown regardless of nostun or stun resistance. They were semi-usually used by the Brotherhood to easily destroy people because of this. 

You'd usually see stuff like this, where the layering under the gate makes it so they're invisible until its broken through.
![image](https://user-images.githubusercontent.com/46099003/121785104-750bf300-cb7d-11eb-8e81-2b0c27ae2973.png)

They should either return in a tribal ruin or as a tribal-exclusive recipe but allowing anyone to make these deathtrap sticks was a bad idea.

## Changelog
:cl:
del: Punji sticks can no longer be crafted.
/:cl:
