### PR TITLE
Makes Punji sticks exclusive for Tribals

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_primal.dm
+++ b/code/datums/components/crafting/recipes/recipes_primal.dm
@@ -102,3 +102,12 @@
 			/obj/item/shovel/spade = 1)
 	result = /obj/item/shovel/serrated
 	category = CAT_PRIMAL
+
+/datum/crafting_recipe/punji_sticks
+	name = "Punji stick Trap"
+	time = 30
+	reqs = list(
+			/obj/item/stack/sheet/mineral/bamboo = 5)
+	result = /obj/structure/punji_sticks
+	category = CAT_PRIMAL
+	always_availible = FALSE

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -369,7 +369,7 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
  */
 
 GLOBAL_LIST_INIT(bamboo_recipes, list ( \
-	new/datum/stack_recipe("punji sticks trap", /obj/structure/punji_sticks, 5, time = 30, one_per_turf = TRUE, on_floor = TRUE), \
+	/*new/datum/stack_recipe("punji sticks trap", /obj/structure/punji_sticks, 5, time = 30, one_per_turf = TRUE, on_floor = TRUE), */ \
 	))
 
 /obj/item/stack/sheet/mineral/bamboo

--- a/code/modules/jobs/job_types/tribals.dm
+++ b/code/modules/jobs/job_types/tribals.dm
@@ -27,6 +27,7 @@
 	ADD_TRAIT(H, TRAIT_TRAPPER, src)
 	ADD_TRAIT(H, TRAIT_MACHINE_SPIRITS, src)
 	H.grant_language(/datum/language/tribal)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/punji_sticks)
 
 /*
 Tribal Chief


### PR DESCRIPTION
## About The Pull Request

Gives only tribal the ability to craft punji sticks traps

## Why It's Good For The Game

So other factions don't use these.

## Changelog
:cl:
fix: Made Punji sticks only craftable by tribals
/:cl:
