### PR TITLE
Syringe gun removal

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -306,7 +306,8 @@
 	build_path = /obj/item/gun/energy/decloner
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-
+	
+/*
 /datum/design/rapidsyringe
 	name = "Rapid Syringe Gun"
 	desc = "A gun that fires many syringes."
@@ -316,6 +317,7 @@
 	build_path = /obj/item/gun/syringe/rapidsyringe
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+*/
 
 /datum/design/temp_gun
 	name = "Temperature Gun"

--- a/code/modules/research/techweb/nodes/weaponry_nodes.dm
+++ b/code/modules/research/techweb/nodes/weaponry_nodes.dm
@@ -47,7 +47,7 @@
 	display_name = "Medical Weaponry"
 	description = "Weapons using medical technology."
 	prereq_ids = list("adv_biotech", "adv_weaponry")
-	design_ids = list("rapidsyringe", "shotgundartcryostatis")
+	design_ids = list("shotgundartcryostatis")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 
 /datum/techweb_node/beam_weapons


### PR DESCRIPTION

## About The Pull Request

Not a lore friendly weapon.
Not a balanced weapon.

## Why It's Good For The Game

This should have never been added to "medical weaponry". Whoever did it years back should've had some foresight that syringe guns are badly balanced, especially with superOD chems like Med-X.

## Changelog
:cl:
del: The syringe gun is no longer printable.
/:cl: