### PR TITLE
Remove Nutriment from Agave

### DIFF
--- a/code/modules/fallout/obj/food_and_drinks/wastefood.dm
+++ b/code/modules/fallout/obj/food_and_drinks/wastefood.dm
@@ -635,7 +635,7 @@
 	icon_grow = "agave-grow"
 	icon_dead = "agave-dead"
 	icon_harvest = "agave-harvest"
-	reagents_add = list(/datum/reagent/medicine/kelotane = 0.1, /datum/reagent/toxin/lipolicide = 0.1, /datum/reagent/consumable/nutriment = 0.1)
+	reagents_add = list(/datum/reagent/medicine/kelotane = 0.1, /datum/reagent/toxin/lipolicide = 0.1 )
 
 
 /obj/item/reagent_containers/food/snacks/grown/agave


### PR DESCRIPTION
## About The Pull Request

Removes nutriment from agave 

## Why It's Good For The Game

Otherwise the nutriment would have canceled out the lipolicide

## Changelog
:cl:
del: Removed  nutriment in agave

/:cl:

