### PR TITLE
Revert "Takes Romerol out the back yard and puts a shovel in its brain"

### DIFF
--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -132,4 +132,6 @@ Bonus
 	M.adjustBruteLoss(get_damage)
 	if(chems)
 		M.reagents.add_reagent_list(list(/datum/reagent/toxin/heparin = 2, /datum/reagent/toxin/lipolicide = 2))
+	if(zombie)
+		M.reagents.add_reagent(/datum/reagent/romerol, 1)
 	return 1

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -17,6 +17,7 @@
 			new /obj/item/chameleon(src) // 7 tc
 
 		if("stealth") // 31 tc
+			new /obj/item/pen/sleepy(src)
 			new /obj/item/healthanalyzer/rad_laser(src)
 			new /obj/item/chameleon(src)
 			new /obj/item/soap/syndie(src)
@@ -33,6 +34,7 @@
 		if("screwed") // 29 tc
 			new /obj/item/sbeacondrop/bomb(src)
 			new /obj/item/grenade/syndieminibomb(src)
+			new /obj/item/sbeacondrop/powersink(src)
 			new /obj/item/clothing/suit/space/syndicate/black/red(src)
 			new /obj/item/clothing/head/helmet/space/syndicate/black/red(src)
 			new /obj/item/encryptionkey/syndicate(src)
@@ -48,17 +50,25 @@
 			new /obj/item/screwdriver/power(src) //2 tc item
 
 		if("murder") // 35 tc
+			new /obj/item/melee/transforming/energy/sword/saber(src)
 			new /obj/item/clothing/glasses/thermal/syndi(src)
 			new /obj/item/card/emag(src)
+			new /obj/item/clothing/shoes/chameleon/noslip(src)
+			new /obj/item/encryptionkey/syndicate(src)
+			new /obj/item/grenade/syndieminibomb(src)
 			new /obj/item/clothing/glasses/phantomthief/syndicate(src)
 			new /obj/item/reagent_containers/syringe/stimulants(src)
 
 		if("baseball") // 42~ tc
+			new /obj/item/melee/baseball_bat/ablative/syndi(src) //Lets say 12 tc, lesser sleeping carp
 			new /obj/item/clothing/glasses/sunglasses/garb(src) //Lets say 2 tc
 			new /obj/item/card/emag(src) //6 tc
 			new /obj/item/clothing/shoes/sneakers/noslip(src) //2tc
 			new /obj/item/encryptionkey/syndicate(src) //1tc
+			new /obj/item/autosurgeon/anti_drop(src) //Lets just say 7~
 			new /obj/item/clothing/under/syndicate/baseball(src) //3tc
+			new /obj/item/clothing/head/soft/baseball(src) //Lets say 4 tc
+			new /obj/item/reagent_containers/hypospray/medipen/stimulants/baseball(src) //lets say 5tc
 
 		if("implant") // 67+ tc holy shit what the fuck this is a lottery disguised as fun boxes isn't it?
 			new /obj/item/implanter/freedom(src)
@@ -80,6 +90,7 @@
 			new /obj/item/emagrecharge(src)
 
 		if("lordsingulo") // "36" tc aka 23 tc
+			new /obj/item/sbeacondrop(src) // 14 kinda useless
 			new /obj/item/clothing/suit/space/syndicate/black/red(src) //2
 			new /obj/item/clothing/head/helmet/space/syndicate/black/red(src) //2
 			new /obj/item/card/emag(src) //6
@@ -240,6 +251,19 @@
 	STR.max_items = 14
 
 /obj/item/storage/box/syndie_kit/chemical/PopulateContents()
+	new /obj/item/reagent_containers/glass/bottle/polonium(src)
+	new /obj/item/reagent_containers/glass/bottle/venom(src)
+	new /obj/item/reagent_containers/glass/bottle/fentanyl(src)
+	new /obj/item/reagent_containers/glass/bottle/formaldehyde(src)
+	new /obj/item/reagent_containers/glass/bottle/spewium(src)
+	new /obj/item/reagent_containers/glass/bottle/cyanide(src)
+	new /obj/item/reagent_containers/glass/bottle/histamine(src)
+	new /obj/item/reagent_containers/glass/bottle/initropidril(src)
+	new /obj/item/reagent_containers/glass/bottle/pancuronium(src)
+	new /obj/item/reagent_containers/glass/bottle/sodium_thiopental(src)
+	new /obj/item/reagent_containers/glass/bottle/coniine(src)
+	new /obj/item/reagent_containers/glass/bottle/curare(src)
+	new /obj/item/reagent_containers/glass/bottle/amanitin(src)
 	new /obj/item/reagent_containers/syringe(src)
 
 /obj/item/storage/box/syndie_kit/nuke
@@ -263,6 +287,11 @@
 	name = "boxed virus grenade kit"
 
 /obj/item/storage/box/syndie_kit/tuberculosisgrenade/PopulateContents()
+	new /obj/item/grenade/chem_grenade/tuberculosis(src)
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/hypospray/medipen/tuberculosiscure(src)
+	new /obj/item/reagent_containers/syringe(src)
+	new /obj/item/reagent_containers/glass/bottle/tuberculosiscure(src)
 
 /obj/item/storage/box/syndie_kit/chameleon
 	name = "chameleon kit"
@@ -296,6 +325,12 @@
 	for(var/i in 1 to 3)
 		new/obj/item/cardboard_cutout/adaptive(src)
 	new/obj/item/toy/crayon/rainbow(src)
+
+/obj/item/storage/box/syndie_kit/romerol/PopulateContents()
+	new /obj/item/reagent_containers/glass/bottle/romerol(src)
+	new /obj/item/reagent_containers/syringe(src)
+	new /obj/item/reagent_containers/dropper(src)
+	new /obj/item/paper/guides/antag/romerol_instructions(src)
 
 /obj/item/storage/box/syndie_kit/ez_clean/PopulateContents()
 	for(var/i in 1 to 3)
@@ -349,6 +384,8 @@
 	name = "Kitchen Gun (TM) package"
 
 /obj/item/storage/box/syndie_kit/kitchen_gun/PopulateContents()
+	new /obj/item/ammo_box/magazine/m45/kitchengun(src)
+	new /obj/item/ammo_box/magazine/m45/kitchengun(src)
 
 
 /obj/item/storage/box/strange_seeds_10pack
@@ -363,12 +400,14 @@
 /obj/item/storage/box/syndie_kit/revolver
 
 /obj/item/storage/box/syndie_kit/revolver/PopulateContents()
-
+	new /obj/item/gun/ballistic/revolver/syndicate(src)
+	new /obj/item/ammo_box/a357(src)
 
 /obj/item/storage/box/syndie_kit/pistol
 
 /obj/item/storage/box/syndie_kit/pistol/PopulateContents()
-
+	new /obj/item/gun/ballistic/automatic/pistol(src)
+	new /obj/item/ammo_box/magazine/m10mm(src)
 
 /obj/item/storage/box/syndie_kit/contract_kit
 	name = "contractor kit"
@@ -422,6 +461,12 @@
 	return ..()
 
 /obj/item/storage/box/syndicate/contractor_loadout/PopulateContents()
+	new /obj/item/clothing/head/helmet/space/syndicate/contract(src)
+	new /obj/item/clothing/suit/space/syndicate/contract(src)
+	new /obj/item/clothing/under/chameleon(src)
+	new /obj/item/clothing/mask/chameleon(src)
+	new /obj/item/card/id/syndicate(src)
+	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate(src)
 	new /obj/item/lighter(src)
 
 /obj/item/storage/box/syndie_kit/contract_kit/PopulateContents()
@@ -429,7 +474,24 @@
 	new /obj/item/storage/box/syndicate/contractor_loadout(src)
 	new /obj/item/melee/classic_baton/telescopic/contractor_baton(src)
 	var/list/item_list = list(	// All 4 TC or less - some nukeops only items, but fit nicely to the theme.
-		/obj/item/storage/firstaid/tactical)
+		/obj/item/storage/backpack/duffelbag/syndie/x4,
+		/obj/item/storage/box/syndie_kit/throwing_weapons,
+		/obj/item/gun/syringe/syndicate,
+		/obj/item/pen/edagger,
+		/obj/item/pen/sleepy,
+		/obj/item/flashlight/emp,
+		/obj/item/reagent_containers/syringe/mulligan,
+		/obj/item/clothing/shoes/chameleon/noslip,
+		/obj/item/storage/firstaid/tactical,
+		/obj/item/storage/backpack/duffelbag/syndie/surgery,
+		/obj/item/encryptionkey/syndicate,
+		/obj/item/clothing/glasses/thermal/syndi,
+		/obj/item/storage/box/syndie_kit/imp_uplink,
+		/obj/item/clothing/gloves/krav_maga/combatglovesplus,
+		/obj/item/reagent_containers/syringe/stimulants,
+		/obj/item/storage/box/syndie_kit/imp_freedom,
+		/obj/item/storage/toolbox/infiltrator
+	)
 	var/obj/item1 = pick_n_take(item_list)
 	var/obj/item2 = pick_n_take(item_list)
 	var/obj/item3 = pick_n_take(item_list)
@@ -441,6 +503,7 @@
 /obj/item/storage/box/syndie_kit/northstar
 
 /obj/item/storage/box/syndie_kit/northstar/PopulateContents()
+	new /obj/item/clothing/gloves/fingerless/pugilist/rapid(src)
 	new /obj/item/clothing/accessory/padding(src)
 	new /obj/item/clothing/under/chameleon(src)
 	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate(src)

--- a/code/modules/antagonists/traitor/classes/hijack.dm
+++ b/code/modules/antagonists/traitor/classes/hijack.dm
@@ -5,6 +5,7 @@
 	chaos = 5
 	threat = 3
 	min_players = 25
+	uplink_filters = list(/datum/uplink_item/stealthy_weapons/romerol_kit)
 
 /datum/traitor_class/human/hijack/forge_objectives(datum/antagonist/traitor/T)
 	var/datum/objective/hijack/O = new

--- a/code/modules/antagonists/traitor/classes/martyr.dm
+++ b/code/modules/antagonists/traitor/classes/martyr.dm
@@ -5,6 +5,7 @@
 	chaos = 5
 	threat = 5
 	min_players = 20
+	uplink_filters = list(/datum/uplink_item/stealthy_weapons/romerol_kit,/datum/uplink_item/bundles_TC/contract_kit)
 
 /datum/traitor_class/human/martyr/forge_objectives(datum/antagonist/traitor/T)
 	var/datum/objective/martyr/O = new

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -505,6 +505,9 @@
 
 /obj/machinery/smartfridge/chemistry/virology/preloaded
 	initial_contents = list(
+		/obj/item/reagent_containers/syringe/antiviral = 4,
+		/obj/item/reagent_containers/glass/bottle/cold = 1,
+		/obj/item/reagent_containers/glass/bottle/flu_virion = 1,
 		/obj/item/reagent_containers/glass/bottle/mutagen = 1,
 		/obj/item/reagent_containers/glass/bottle/sugar = 1,
 		/obj/item/reagent_containers/glass/bottle/plasma = 1,

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2154,7 +2154,6 @@
 
 //Misc reagents
 
-/*
 /datum/reagent/romerol
 	name = "Romerol"
 	// the REAL zombie powder
@@ -2176,7 +2175,6 @@
 		var/obj/item/organ/zombie_infection/nodamage/ZI = new()
 		ZI.Insert(H)
 	..()
-*/
 
 /datum/reagent/magillitis
 	name = "Magillitis"

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -231,7 +231,6 @@
 	desc = "A small bottle of lab made Zeolite, which removes radiation from people quickly as well as contamination on items."
 	list_reagents = list(/datum/reagent/fermi/zeolites = 30)
 
-/*
 // Viro bottles
 
 /obj/item/reagent_containers/glass/bottle/romerol
@@ -315,7 +314,6 @@
 	name = "BVAK bottle"
 	desc = "A small bottle containing Bio Virus Antidote Kit."
 	list_reagents = list(/datum/reagent/medicine/atropine = 5, /datum/reagent/medicine/epinephrine = 5, /datum/reagent/medicine/salbutamol = 10, /datum/reagent/medicine/spaceacillin = 10)
-*/
 
 //Oldstation.dmm chemical storage bottles
 

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -864,6 +864,12 @@
 	surgery = /datum/surgery/advanced/bioware/ligament_reinforcement
 	research_icon_state = "surgery_chest"
 
+/datum/design/surgery/necrotic_revival
+	name = "Necrotic Revival"
+	desc = "An experimental surgical procedure that stimulates the growth of a Romerol tumor inside the patient's brain. Requires zombie powder or rezadone."
+	id = "surgery_zombie"
+	surgery = /datum/surgery/advanced/necrotic_revival
+	research_icon_state = "surgery_head"
 
 /////////////////////////////////////////
 ////////////Medical Prosthetics//////////

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -65,7 +65,7 @@
 	display_name = "Alien Surgery"
 	description = "Abductors did nothing wrong."
 	prereq_ids = list("exp_surgery")
-	design_ids = list("surgery_brainwashing")
+	design_ids = list("surgery_brainwashing","surgery_zombie")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 */

--- a/code/modules/research/techweb/nodes/medical_nodes.dm
+++ b/code/modules/research/techweb/nodes/medical_nodes.dm
@@ -148,5 +148,5 @@
 	display_name = "Alien Surgery"
 	description = "Abductors did nothing wrong."
 	prereq_ids = list("exp_surgery", "alientech")
-	design_ids = list("surgery_brainwashing", "surgery_ext_dissection", "surgery_heal_combo_upgrade_femto")
+	design_ids = list("surgery_brainwashing","surgery_zombie", "surgery_ext_dissection", "surgery_heal_combo_upgrade_femto")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)

--- a/code/modules/surgery/advanced/necrotic_revival.dm
+++ b/code/modules/surgery/advanced/necrotic_revival.dm
@@ -1,4 +1,3 @@
-/*
 /datum/surgery/advanced/necrotic_revival
 	name = "Necrotic Revival"
 	desc = "An experimental surgical procedure that stimulates the growth of a Romerol tumor inside the patient's brain. Requires zombie powder or rezadone."
@@ -15,7 +14,6 @@
 	var/obj/item/organ/zombie_infection/ZI = target.getorganslot(ORGAN_SLOT_ZOMBIE)
 	if(ZI)
 		return FALSE
-*/
 
 /datum/surgery_step/bionecrosis
 	name = "start bionecrosis"

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -65,7 +65,7 @@
 		else
 			return FALSE
 
-	if(requires_trait== "UNETHICAL_PRACTITIONER") //brainwashing, viral bonding, combat implants
+	if(requires_trait== "UNETHICAL_PRACTITIONER") //brainwashing, romerol revivication, viral bonding, combat implants
 		if(HAS_TRAIT(user,TRAIT_UNETHICAL_PRACTITIONER)||HAS_TRAIT(user,TRAIT_ABDUCTOR_SCIENTIST_TRAINING))
 			return TRUE
 		else

--- a/code/modules/uplink/uplink_items/uplink_stealth.dm
+++ b/code/modules/uplink/uplink_items/uplink_stealth.dm
@@ -11,6 +11,7 @@
 	name = "Combat Gloves Plus"
 	desc = "A pair of gloves that are fireproof and shock resistant, however unlike the regular Combat Gloves this one uses nanotechnology \
 			to learn the abilities of krav maga to the wearer."
+	item = /obj/item/clothing/gloves/krav_maga/combatglovesplus
 	cost = 5
 	include_modes = list(/datum/game_mode/nuclear)
 	surplus = 0
@@ -18,6 +19,7 @@
 /datum/uplink_item/stealthy_weapons/cqc
 	name = "CQC Manual"
 	desc = "A manual that teaches a single user tactical Close-Quarters Combat before self-destructing."
+	item = /obj/item/book/granter/martial/cqc
 	include_modes = list(/datum/game_mode/nuclear)
 	cost = 13
 	surplus = 0
@@ -26,6 +28,7 @@
 	name = "Dart Pistol"
 	desc = "A miniaturized version of a normal syringe gun. It is very quiet when fired and can fit into any \
 			space a small item can."
+	item = /obj/item/gun/syringe/syndicate
 	cost = 4
 	surplus = 50
 
@@ -33,17 +36,20 @@
 	name = "Dehydrated Space Carp"
 	desc = "Looks like a plush toy carp, but just add water and it becomes a real-life space carp! Activate in \
 			your hand before use so it knows not to kill you."
+	item = /obj/item/toy/plush/carpplushie/dehy_carp
 	cost = 1
 
 /datum/uplink_item/stealthy_weapons/edagger
 	name = "Energy Dagger"
 	desc = "A dagger made of energy that looks and functions as a pen when off."
+	item = /obj/item/pen/edagger
 	cost = 2
 
 /datum/uplink_item/stealthy_weapons/martialarts
 	name = "Sleeping Carp Scroll"
 	desc = "This scroll contains the secrets of an ancient martial arts technique. You will master unarmed combat, \
 			gain skin as hard as steel and swat bullets from the air, but you also refuse to use dishonorable ranged weaponry."
+	item = /obj/item/book/granter/martial/carp
 	cost = 17
 	player_minimum = 20
 	surplus = 0
@@ -53,6 +59,7 @@
 	name = "Rising Bass Scroll"
 	desc = "This scroll contains the secrets of an ancient martial arts technique. You will become proficient in fleeing situations, \
 	and dodging all ranged weapon fire, but you will refuse to use dishonorable ranged weaponry."
+	item = /obj/item/book/granter/martial/bass
 	cost = 18
 	player_minimum = 20
 	surplus = 0
@@ -62,6 +69,7 @@
 	name = "Krav Maga Scroll"
 	desc = "This scroll contains the secrets of an ancient martial arts technique. You will gain special unarmed attacks for \
 			stealthy takedowns."
+	item = /obj/item/book/granter/martial/krav_maga
 	cost = 16
 	player_minimum = 25
 	surplus = 0
@@ -75,6 +83,7 @@
 		targets and cause them to slur as if inebriated. It can produce an \
 		infinite number of bolts, but takes time to automatically recharge \
 		after each shot."
+	item = /obj/item/gun/energy/kinetic_accelerator/crossbow
 	cost = 12
 	surplus = 50
 	exclude_modes = list(/datum/game_mode/nuclear)
@@ -86,12 +95,23 @@
 	cost = 6
 	surplus = 50
 
+/datum/uplink_item/stealthy_weapons/romerol_kit
+	name = "Romerol"
+	desc = "A highly experimental bioterror agent which creates dormant nodules to be etched into the grey matter of the brain. \
+			On death, these nodules take control of the dead body, causing limited revivification, \
+			along with slurred speech, aggression, and the ability to infect others with this agent."
+	item = /obj/item/storage/box/syndie_kit/romerol
+	cost = 25
+	cant_discount = TRUE
+	exclude_modes = list(/datum/game_mode/nuclear)
+
 /datum/uplink_item/stealthy_weapons/sleepy_pen
 	name = "Sleepy Pen"
 	desc = "A syringe disguised as a functional pen, filled with a potent mix of drugs, including a \
 			strong anesthetic and a chemical that prevents the target from speaking. \
 			The pen holds one dose of the mixture, and can be refilled with any chemicals. Note that before the target \
 			falls asleep, they will be able to move and act."
+	item = /obj/item/pen/sleepy
 	cost = 4
 	exclude_modes = list(/datum/game_mode/nuclear)
 
@@ -99,6 +119,7 @@
 	name = "Suppressor"
 	desc = "This suppressor will silence the shots of the weapon it is attached to for increased stealth and superior ambushing capability. \
 			It is compatible with many small ballistic guns including the Stechkin and C-20r, but not revolvers or energy guns."
+	item = /obj/item/suppressor
 	cost = 1
 	surplus = 10
 
@@ -106,10 +127,12 @@
 	name = "Syndicate Soap"
 	desc = "A sinister-looking surfactant used to clean blood stains to hide murders and prevent DNA analysis. \
 			You can also drop it underfoot to slip people."
+	item = /obj/item/soap/syndie
 	cost = 1
 	surplus = 50
 
 /datum/uplink_item/stealthy_weapons/soap_clusterbang
 	name = "Slipocalypse Clusterbang"
 	desc = "A traditional clusterbang grenade with a payload consisting entirely of Syndicate soap. Useful in any scenario!"
+	item = /obj/item/grenade/clusterbuster/soap
 	cost = 6

--- a/code/modules/vending/magivend.dm
+++ b/code/modules/vending/magivend.dm
@@ -13,6 +13,7 @@
 					/obj/item/clothing/suit/wizrobe/yellow = 1,
 					/obj/item/clothing/shoes/sandal/magic = 1,
 					/obj/item/staff = 2)
+	contraband = list(/obj/item/reagent_containers/glass/bottle/wizarditis = 1)	//No one can get to the machine to hack it anyways; for the lulz - Microwave
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50, "magic" = 100)
 	resistance_flags = FIRE_PROOF
 	default_price = PRICE_EXPENSIVE

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -82,7 +82,6 @@
 		user.adjustOrganLoss(ORGAN_SLOT_BRAIN, -hp_gained) // Zom Bee gibbers "BRAAAAISNSs!1!"
 		user.adjust_nutrition(hp_gained, NUTRITION_LEVEL_FULL)
 
-/*
 /obj/item/paper/guides/antag/romerol_instructions
 	info = "How to do necromancy with chemicals:<br>\
 	<ul>\
@@ -93,4 +92,3 @@
 	<li>???</li>\
 	<li>Complete assigned objectives amidst the chaos</li>\
 	</ul>"
-*/


### PR DESCRIPTION
Quite frankly, this wasn't a good PR to merge. It seems to remove a lot of unrelated stuff to romerol, completely undocumented, and not even completely.

For instance, what happens right now if an admin spawns an uplink and tries to buy CQC is that the game produces a runtime and that's that. CQC wasn't removed from the code, just from the uplink...but uplinks are unobtainable except by admins anyway, just like CQC is, so what was the point in removing it from the uplink?

also completely inexplicably it removes a lot of shit from the uplink (which makes no sense-uplinks are not obtainable anyway, so why make it so that an admin who spawns an uplink can't do anything but instead has to manually spawn it?

what's the logic in removing the virus bottles from the code itself? the only reasonable change there is rmeoving it from the smartfridge, frankly-they should still be adminspawnable if necessary

also, this doesn't even really do anything in the end. romerol wasn't removed as a chemical, and *romerol isn't even the source of the zombies lately*-THAT would be synthetic-derived zombie factor, which can show up in strange seeds. romerol is blacklisted from strange seeds, so not only does this PR break things, but it doesn't even fix the issue it was set out to solve

revert this and i'll just blacklist synthetic derived zombie factor and we won't have to worry about it again