### PR TITLE
Enclave scientist removal revert, changes some things about them.

### DIFF
--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -23,7 +23,7 @@
 	var/rendered = begin_message + obj_message + end_message
 	deadchat_broadcast(rendered, follow_target = L, turf_target = get_turf(L), message_type=DEADCHAT_REGULAR)
 
-/proc/is_brainwashed(var/mob/living/L, var/datum/mind/M = L.mind)// FO13, better brainwashing detection, needed for examine.dm, fuck off its MY shitcode >:(
+/proc/is_brainwashed(mob/living/L, datum/mind/M = L.mind)// FO13, better brainwashing detection, needed for examine.dm, fuck off its MY shitcode >:(
 	if(L.mind && M.has_antag_datum(/datum/antagonist/brainwashed))
 		return istype(L)
 	else

--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -23,7 +23,7 @@
 	var/rendered = begin_message + obj_message + end_message
 	deadchat_broadcast(rendered, follow_target = L, turf_target = get_turf(L), message_type=DEADCHAT_REGULAR)
 
-/proc/is_brainwashed(mob/living/L, datum/mind/M = L.mind)// FO13, better brainwashing detection, needed for examine.dm, fuck off its MY shitcode >:(
+/proc/is_brainwashed(mob/living/L, datum/mind/M = L.mind)// FO13, better brainwashing detection, needed for examine.dm, fuck off its MY shitcode. >:(
 	if(L.mind && M.has_antag_datum(/datum/antagonist/brainwashed))
 		return istype(L)
 	else

--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -24,7 +24,7 @@
 	deadchat_broadcast(rendered, follow_target = L, turf_target = get_turf(L), message_type=DEADCHAT_REGULAR)
 
 /proc/is_brainwashed(var/mob/living/L, var/datum/mind/M = L.mind)// FO13, better brainwashing detection, needed for examine.dm, fuck off its MY shitcode >:(
-	if(M.has_antag_datum(/datum/antagonist/brainwashed)) // Runtimes if theres no mind, /shrug 
+	if(L.mind && M.has_antag_datum(/datum/antagonist/brainwashed))
 		return istype(L)
 	else
 		return

--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -23,6 +23,12 @@
 	var/rendered = begin_message + obj_message + end_message
 	deadchat_broadcast(rendered, follow_target = L, turf_target = get_turf(L), message_type=DEADCHAT_REGULAR)
 
+/proc/is_brainwashed(var/mob/living/L, var/datum/mind/M = L.mind)// FO13, better brainwashing detection, needed for examine.dm, fuck off its MY shitcode >:(
+	if(M.has_antag_datum(/datum/antagonist/brainwashed)) // Runtimes if theres no mind, /shrug 
+		return istype(L)
+	else
+		return
+
 /datum/antagonist/brainwashed
 	name = "Brainwashed Victim"
 	job_rank = ROLE_BRAINWASHED
@@ -42,7 +48,7 @@
 
 /datum/antagonist/brainwashed/farewell()
 	to_chat(owner, "<span class='warning'>Your mind suddenly clears...</span>")
-	to_chat(owner, "<big><span class='warning'><b>You feel the weight of the Directives disappear! You no longer have to obey them.</b></span></big>")
+	to_chat(owner, "<big><span class='warning'><b>You feel the weight of the Directives disappear! You forget what you did while under their influence, and how they came to be.</b></span></big>")
 	owner.announce_objectives()
 
 /datum/antagonist/brainwashed/admin_add(datum/mind/new_owner,mob/admin)

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -141,8 +141,7 @@
 	..()
 	if(visualsOnly)
 		return
-	ADD_TRAIT(H, TRAIT_UNETHICAL_PRACTITIONER, src) //enclave scientists can do pretty much everything, they've got the knowhow preserved by the enclave. a valuable asset to be defended
-	ADD_TRAIT(H, TRAIT_MEDICALEXPERT, src)          //ditto
+	ADD_TRAIT(H, TRAIT_MEDICALEXPERT, src)          //enclave scientists can do pretty much everything, they've got the knowhow preserved by the enclave. a valuable asset to be defended
 	ADD_TRAIT(H, TRAIT_CYBERNETICIST_EXPERT, src)    //ditto
 	ADD_TRAIT(H, TRAIT_SURGERY_HIGH, src)
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -141,12 +141,12 @@
 	..()
 	if(visualsOnly)
 		return
-	ADD_TRAIT(H, TRAIT_MEDICALEXPERT, src)          //enclave scientists can do pretty much everything, they've got the knowhow preserved by the enclave. a valuable asset to be defended
-	ADD_TRAIT(H, TRAIT_CYBERNETICIST_EXPERT, src)    //ditto
+	ADD_TRAIT(H, TRAIT_MEDICALEXPERT, src)
+	ADD_TRAIT(H, TRAIT_CYBERNETICIST_EXPERT, src)
 	ADD_TRAIT(H, TRAIT_SURGERY_HIGH, src)
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
 	ADD_TRAIT(H, TRAIT_MASTER_GUNSMITH, src)
-	ADD_TRAIT(H, TRAIT_UNETHICAL_PRACTITIONER, src)
+	ADD_TRAIT(H, TRAIT_UNETHICAL_PRACTITIONER, src) // Brainwashing
 	
 
 /datum/job/wasteland/enclavelt

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -11,7 +11,7 @@
 	forbids = ""
 	enforces = ""
 	supervisors = "the United States Government."
-	selection_color = "#162b2c"
+	selection_color = "#323232"
 	exp_type = EXP_TYPE_FALLOUT
 	exp_requirements = 600
 
@@ -53,7 +53,7 @@
 	forbids = ""
 	enforces = ""
 	supervisors = "the United States Government."
-	selection_color = "#162b2c"
+	selection_color = "#323232"
 	exp_requirements = 1200
 	exp_type = EXP_TYPE_FALLOUT
 	access = list(ACCESS_ENCLAVE)
@@ -102,7 +102,7 @@
 	forbids = "Leaving the base while still habitable"
 	enforces = ""
 	supervisors = "the United States Government."
-	selection_color = "#162b2c"
+	selection_color = "#323232"
 	exp_requirements = 1400
 	exp_type = EXP_TYPE_FALLOUT
 	access = list(ACCESS_ENCLAVE)
@@ -157,7 +157,7 @@
 	forbids = ""
 	enforces = ""
 	supervisors = "the United States Government."
-	selection_color = "#162b2c"
+	selection_color = "#323232"
 	exp_requirements = 1500
 	exp_type = EXP_TYPE_ENCLAVE
 

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -99,7 +99,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	description = "You're responsible for the maintenance of the base, the knowledge you've accumulated over the years is the only thing keeping the remnants alive. You've dabbled in enough to be considered a Professor in proficiency, but they call you Doctor. Support your dwindling forces and listen to the Lieutenant."
-	forbids = "Leaving the base while still habitable"
+	forbids = "The Enclave forbids you from leaving the base while still habitable"
 	enforces = ""
 	supervisors = "the United States Government."
 	selection_color = "#323232"

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -146,6 +146,8 @@
 	ADD_TRAIT(H, TRAIT_SURGERY_HIGH, src)
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
 	ADD_TRAIT(H, TRAIT_MASTER_GUNSMITH, src)
+	ADD_TRAIT(H, TRAIT_UNETHICAL_PRACTITIONER, src)
+	
 
 /datum/job/wasteland/enclavelt
 	title = "Enclave Lieutenant"

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -99,7 +99,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	description = "You're responsible for the maintenance of the base, the knowledge you've accumulated over the years is the only thing keeping the remnants alive. You've dabbled in enough to be considered a Professor in proficiency, but they call you Doctor. Support your dwindling forces and listen to the Lieutenant."
-	forbids = ""
+	forbids = "Leaving the base while still habitable"
 	enforces = ""
 	supervisors = "the United States Government."
 	selection_color = "#162b2c"

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -96,8 +96,8 @@
 	title = "Enclave Scientist"
 	flag = F13USSCIENTIST
 	faction = "Enclave"
-	total_positions = 0
-	spawn_positions = 0
+	total_positions = 1
+	spawn_positions = 1
 	description = "You're responsible for the maintenance of the base, the knowledge you've accumulated over the years is the only thing keeping the remnants alive. You've dabbled in enough to be considered a Professor in proficiency, but they call you Doctor. Support your dwindling forces and listen to the Lieutenant."
 	forbids = ""
 	enforces = ""

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -98,6 +98,8 @@
 			var/obj/item/implant/hijack/H = user.getImplant(/obj/item/implant/hijack)
 			if (H && !H.stealthmode && H.toggled)
 				. += "<b><font color=orange>[t_His] eyes are flickering a bright yellow!</font></b>"
+		else if(is_brainwashed(src)) //FO13 Change
+			. += "<b><font color=red>[t_His] eyes have a far away and dazed look to them.</font></b>"
 
 	//ears
 	if(ears && !(SLOT_EARS in obscured))

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
@@ -56,7 +56,7 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 	impure_chem 			= /datum/reagent/impure/SDGFtox
 	inverse_chem_val 		= 0.5
 	inverse_chem		= /datum/reagent/impure/SDZF
-	can_synth = TRUE
+	can_synth = FALSE // NO MORE FUCKING ZOMBIES! -FO13
 	value = REAGENT_VALUE_RARE
 
 
@@ -334,7 +334,7 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 	color = "#a502e0" // rgb: 96, 0, 255
 	metabolization_rate = 0.2 * REAGENTS_METABOLISM
 	var/startHunger
-	can_synth = TRUE
+	can_synth = FALSE // NO MORE FUCKING ZOMBIES! -FO13
 	taste_description = "a weird chemical fleshy flavour"
 	chemical_flags = REAGENT_SNEAKYNAME
 	value = REAGENT_VALUE_RARE
@@ -396,3 +396,4 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 			M.adjustToxLoss(2, 0)
 			M.reagents.remove_reagent(type, 1)
 	..()
+*/

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
@@ -34,7 +34,7 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 	5.2 Additionally, this chem is a soft buff to changelings, which apparently need a buff!
 	5.3 Other similar things exist already though in the codebase; impostors, split personalites, abductors, ect.
 6. Giving this to someone without concent is against space law and gets you sent to gulag.
-*/
+ // Comment end removed here and placed at bottom to disable SDGF as a whole. ~FO13
 
 #define POLICYCONFIG_SDGF "SDGF"
 #define POLICYCONFIG_SDGF_GOOD "SDGF_ALIGNED"

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -134,6 +134,7 @@
 
 
 //serum
+/* disable SDGF as a whole. ~FO13
 /datum/chemical_reaction/fermi/SDGF
 	name = "Synthetic-derived growth factor"
 	id = /datum/reagent/fermi/SDGF
@@ -172,7 +173,7 @@
 		S.color = "#810010"
 	my_atom.reagents.clear_reagents()
 	my_atom.visible_message("<span class='warning'>An horrifying tumoural mass forms in [my_atom]!</span>")
-
+*/
 /*
 /datum/chemical_reaction/fermi/astral
 	name = "Astrogen"


### PR DESCRIPTION
## About The Pull Request

Does as the title says

## Why It's Good For The Game

While I can't speak for enclave balancing, as I'm a BoS/Wastelander main and have never played Enclave, I can say with a decent bit of certainty (At least in my opinion) straight up removing the Enclave Scientist was a bad and sloppy idea.

While no concerns were directly listed in the removal PR, they generally seem to be:
-Constant zombies being made
-Brainwashing
-"He Hur me maxcap base's"
-Just an extra Enclave soldier

The first one was "Handled" in a PR that removes Romerol, except they aren't using Romerol, and it had a lot of un-documented changes. As such that PR currently has a reversion queued, and upon that being merged I'll be adding a removal of SDZF to this PR.

Brainwashing has a helpful "They have a dazed look in their eyes"  examination text if they are not wearing a mask. 

And finally, they now have a forbid text that very clearly tells them not to leave the base, preventing them from just becoming another Enclave soldier, and instead just a dude living in their moms basement, albeit accompanied by some potentially world ending technology.

## Changelog
:cl:
add: Added back the Enclave Scientist slot.
add: Brainwashed victims now have a special, cult like examine text.
tweak: Tweaked the scientists traits.
tweak: The scientist can no longer leave the Enclave base, unless it is destroyed.
tweak: Backround color of the role selection.
del: Removes the ability to get SDGF and similar.
admin: Please, ban shitter's that don't follow their objective's / forbid text.
/:cl:
