### PR TITLE
Tweaks the NCR Armory

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -4002,7 +4002,7 @@
 /obj/structure/barricade/bars,
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
-	id = NCRArmoryNorth
+	id = "NCRArmoryNorth"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
@@ -23223,12 +23223,12 @@
 	},
 /obj/structure/table,
 /obj/machinery/button{
-	id = NCRArmoryNorth;
+	id = "NCRArmoryNorth";
 	pixel_x = -27;
 	pixel_y = 7
 	},
 /obj/machinery/button{
-	id = NCRArmorySouth;
+	id = "NCRArmorySouth";
 	pixel_x = -27;
 	pixel_y = -7
 	},
@@ -27467,7 +27467,7 @@
 /obj/structure/barricade/bars,
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
-	id = NCRArmorySouth
+	id = "NCRArmorySouth"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -2861,11 +2861,21 @@
 	},
 /area/f13/wasteland)
 "bTf" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle{
+	pixel_x = -4;
+	pixel_y = 12
 	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
+/obj/item/reagent_containers/glass/beaker/waterbottle{
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle{
+	pixel_x = -4;
+	pixel_y = 12
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
@@ -6193,9 +6203,14 @@
 /turf/open/floor/plating,
 /area/f13/building)
 "elT" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/rag/towel,
+/obj/item/reagent_containers/glass/rag/towel,
+/obj/item/reagent_containers/glass/rag/towel,
+/obj/item/reagent_containers/glass/rag/towel,
+/obj/item/reagent_containers/glass/rag/towel,
+/obj/item/reagent_containers/glass/rag/towel,
+/obj/item/reagent_containers/glass/rag/towel,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "eme" = (
@@ -6940,17 +6955,16 @@
 	},
 /area/f13/wasteland)
 "eJe" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
 	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/ncr)
 "eJn" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
@@ -10037,10 +10051,9 @@
 	},
 /area/f13/building)
 "gyh" = (
-/obj/structure/weightmachine/stacklifter,
-/obj/effect/turf_decal/stripes/white/full,
+/obj/structure/punching_bag,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/ncr)
 "gyi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bed/old,
@@ -13449,17 +13462,6 @@
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"iGU" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "iHj" = (
 /obj/structure/chair{
 	dir = 8
@@ -14878,11 +14880,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/ncr)
-"juV" = (
-/obj/structure/punching_bag,
-/obj/effect/turf_decal/stripes/white/full,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "jvg" = (
 /obj/machinery/light{
 	dir = 4;
@@ -14959,11 +14956,16 @@
 	},
 /area/f13/wasteland)
 "jxd" = (
-/obj/effect/turf_decal/stripes/white/line{
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/white/box,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/ncr)
 "jxg" = (
 /obj/structure/table/wood,
 /obj/item/flashlight{
@@ -15548,10 +15550,11 @@
 	},
 /area/f13/ncr)
 "jSN" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/effect/turf_decal/stripes/white/full,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/ncr)
 "jSO" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -16530,24 +16533,16 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "kzu" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/obj/item/reagent_containers/glass/beaker/waterbottle{
-	pixel_x = -4;
-	pixel_y = 12
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/white/box,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/item/reagent_containers/glass/beaker/waterbottle{
-	pixel_x = -4;
-	pixel_y = 12
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/item/reagent_containers/glass/beaker/waterbottle{
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/ncr)
 "kzB" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17919,8 +17914,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "lvS" = (
-/obj/structure/weightlifter,
-/obj/effect/turf_decal/stripes/white/full,
+/obj/structure/closet/crate/trashcart,
+/obj/item/mop,
+/obj/structure/mopbucket,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "lwc" = (
@@ -18392,13 +18392,6 @@
 	dir = 7;
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
-"lMn" = (
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "lMr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20290,10 +20283,6 @@
 	},
 /turf/closed/wall/f13/store,
 /area/f13/building)
-"ncX" = (
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "nda" = (
 /obj/machinery/workbench,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -20906,14 +20895,10 @@
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "nAr" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
-	},
+/obj/structure/weightmachine/stacklifter,
+/obj/effect/turf_decal/stripes/white/full,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/ncr)
 "nAz" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
@@ -21166,7 +21151,6 @@
 /area/f13/caves)
 "nLX" = (
 /obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/light,
 /obj/machinery/workbench/forge,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -24488,6 +24472,9 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
@@ -25830,6 +25817,9 @@
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
@@ -28538,16 +28528,6 @@
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"szS" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/mop,
-/obj/structure/mopbucket,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "sAe" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -28689,6 +28669,9 @@
 	color = "000000"
 	},
 /obj/item/storage/money_stack/ncr,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
 "sGI" = (
@@ -44755,10 +44738,10 @@ sGG
 odW
 odW
 odW
+jSN
 odW
 odW
-odW
-odW
+jSN
 rhr
 cpK
 cpK
@@ -45017,7 +45000,7 @@ rRi
 rRi
 rRi
 ezX
-cpK
+lvS
 cpK
 ezX
 ezX
@@ -45783,7 +45766,7 @@ qLO
 xdt
 xdt
 xdt
-xdt
+eJe
 xdt
 xdt
 qLO
@@ -46293,14 +46276,14 @@ jNs
 mfN
 xdt
 qQf
-uVw
+jxd
 uVw
 xdt
 idH
 pRS
 wUf
 xdt
-uVw
+jxd
 rhr
 cpK
 cpK
@@ -46559,7 +46542,7 @@ xdt
 xdt
 xdt
 rhr
-szS
+cpK
 cpK
 ezX
 ozh
@@ -47048,11 +47031,11 @@ hCg
 kGc
 xTq
 bTf
-gyh
-jxd
-jSN
-lMn
 cpK
+cpK
+cpK
+cpK
+elT
 stt
 unI
 hbW
@@ -47304,11 +47287,11 @@ bpD
 sqA
 kGc
 xTq
-elT
-iGU
 cpK
-kzu
-ncX
+nAr
+odW
+odW
+nAr
 cpK
 stt
 unI
@@ -47561,11 +47544,11 @@ bpD
 fyf
 kGc
 xTq
-elT
-gyh
 cpK
-lvS
-ncX
+gyh
+odW
+odW
+odW
 cpK
 stt
 unI
@@ -47818,11 +47801,11 @@ hCg
 fyf
 kGc
 xTq
-elT
 cpK
-cpK
-cpK
-ncX
+gyh
+odW
+odW
+odW
 cpK
 stt
 unI
@@ -47832,17 +47815,17 @@ hOl
 koD
 ezX
 uVw
-xdt
+eJe
 xdt
 fum
-xdt
+eJe
 uVw
 xdt
 uVw
-xdt
+eJe
 uVw
 xdt
-uVw
+kzu
 rhr
 cpK
 cpK
@@ -48075,10 +48058,10 @@ fyf
 fyf
 kGc
 xTq
-eJe
-juV
-juV
-juV
+cpK
+nAr
+odW
+odW
 nAr
 cpK
 stt
@@ -48332,12 +48315,12 @@ fyf
 fyf
 kGc
 xTq
+elT
 cpK
 cpK
 cpK
 cpK
-cpK
-cpK
+bTf
 stt
 unI
 hbW

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -2861,7 +2861,12 @@
 	},
 /area/f13/wasteland)
 "bTf" = (
-/obj/structure/table,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "bTh" = (
@@ -3984,11 +3989,13 @@
 	},
 /area/f13/wasteland)
 "cNF" = (
+/obj/structure/barricade/bars,
 /obj/structure/table/reinforced,
-/obj/item/taperecorder,
-/obj/item/pda/engineering,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/machinery/door/poddoor/shutters{
+	id = NCRArmoryNorth
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
 "cNI" = (
@@ -4438,15 +4445,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"dcj" = (
-/obj/structure/chair/wood,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/ncr)
 "dcH" = (
 /obj/structure/table/wood/settler,
 /obj/item/flashlight/lantern,
@@ -6195,15 +6193,8 @@
 /turf/open/floor/plating,
 /area/f13/building)
 "elT" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/pack/bbqsauce,
-/obj/item/reagent_containers/food/condiment/pack/bbqsauce,
-/obj/item/reagent_containers/food/condiment/pack/bbqsauce,
-/obj/item/reagent_containers/food/condiment/pack/bbqsauce,
-/obj/item/reagent_containers/food/condiment/pack/bbqsauce,
-/obj/item/reagent_containers/food/condiment/ketchup{
-	pixel_x = -11;
-	pixel_y = 4
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
@@ -6949,7 +6940,15 @@
 	},
 /area/f13/wasteland)
 "eJe" = (
-/obj/effect/turf_decal/stripes/white/line,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "eJn" = (
@@ -8214,12 +8213,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fum" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/stripes/white/box,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/glasses/welding,
+/obj/structure/rack,
+/obj/item/radio/headset/headset_ncr,
+/obj/item/radio/headset/headset_ncr,
+/obj/item/radio/headset/headset_ncr,
+/obj/item/radio/headset/headset_ncr,
+/obj/item/radio/headset/headset_ncr,
+/obj/item/radio/headset/headset_ncr,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -10027,15 +10037,10 @@
 	},
 /area/f13/building)
 "gyh" = (
-/obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/workbench,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/ncr)
+/obj/structure/weightmachine/stacklifter,
+/obj/effect/turf_decal/stripes/white/full,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "gyi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bed/old,
@@ -12596,12 +12601,14 @@
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
 "idH" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/stripes/white/box,
+/obj/machinery/autolathe,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/ncr)
 "idS" = (
 /obj/structure/curtain{
@@ -13443,18 +13450,16 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "iGU" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/ncr)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/rag/towel,
+/obj/item/reagent_containers/glass/rag/towel,
+/obj/item/reagent_containers/glass/rag/towel,
+/obj/item/reagent_containers/glass/rag/towel,
+/obj/item/reagent_containers/glass/rag/towel,
+/obj/item/reagent_containers/glass/rag/towel,
+/obj/item/reagent_containers/glass/rag/towel,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "iHj" = (
 /obj/structure/chair{
 	dir = 8
@@ -14874,11 +14879,10 @@
 	},
 /area/f13/ncr)
 "juV" = (
-/obj/effect/landmark/start/f13/ncrlogisticsofficer,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/ncr)
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/stripes/white/full,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "jvg" = (
 /obj/machinery/light{
 	dir = 4;
@@ -14955,9 +14959,6 @@
 	},
 /area/f13/wasteland)
 "jxd" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
@@ -15159,11 +15160,13 @@
 	},
 /area/f13/wasteland)
 "jFl" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/taperecorder,
+/obj/item/pda/engineering,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/ncr)
 "jFE" = (
 /obj/structure/table/wood,
 /obj/item/trash/sosjerky{
@@ -15545,7 +15548,7 @@
 	},
 /area/f13/ncr)
 "jSN" = (
-/obj/structure/weightlifter,
+/obj/structure/weightmachine/weightlifter,
 /obj/effect/turf_decal/stripes/white/full,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
@@ -16527,30 +16530,24 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "kzu" = (
-/obj/effect/turf_decal/stripes/white/box,
-/obj/structure/rack,
-/obj/item/radio/headset/headset_ncr,
-/obj/item/radio/headset/headset_ncr,
-/obj/item/radio/headset/headset_ncr,
-/obj/item/radio/headset/headset_ncr,
-/obj/item/radio/headset/headset_ncr,
-/obj/item/radio/headset/headset_ncr,
-/obj/item/clothing/mask/ncr_facewrap,
-/obj/item/clothing/mask/ncr_facewrap,
-/obj/item/clothing/mask/ncr_facewrap,
-/obj/item/clothing/mask/ncr_facewrap,
-/obj/item/clothing/mask/ncr_facewrap,
-/obj/item/clothing/mask/ncr_facewrap,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle{
+	pixel_x = -4;
+	pixel_y = 12
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/item/reagent_containers/glass/beaker/waterbottle{
+	pixel_x = -4;
+	pixel_y = 12
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
+/obj/item/reagent_containers/glass/beaker/waterbottle{
+	pixel_x = -4;
+	pixel_y = 12
 	},
-/area/f13/ncr)
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "kzB" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17922,22 +17919,8 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "lvS" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/obj/item/reagent_containers/glass/beaker/waterbottle{
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/glass/beaker/waterbottle{
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/glass/beaker/waterbottle{
-	pixel_x = -4;
-	pixel_y = 12
-	},
+/obj/structure/weightlifter,
+/obj/effect/turf_decal/stripes/white/full,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "lwc" = (
@@ -18411,15 +18394,12 @@
 	},
 /area/f13/wasteland)
 "lMn" = (
-/obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/autolathe/ammo,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/ncr)
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "lMr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit,
@@ -18486,11 +18466,10 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "lOY" = (
-/obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/autolathe,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
+/obj/effect/landmark/start/f13/ncrheavytrooper,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
@@ -18795,22 +18774,6 @@
 	},
 /turf/open/floor/plating,
 /area/f13/tunnel)
-"lZl" = (
-/obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/photocopier,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/ncr)
 "lZw" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -20328,14 +20291,9 @@
 /turf/closed/wall/f13/store,
 /area/f13/building)
 "ncX" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/item/storage/money_stack/ncr,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/ncr)
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "nda" = (
 /obj/machinery/workbench,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -20948,16 +20906,14 @@
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "nAr" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/light,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/ncr)
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "nAz" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
@@ -21062,15 +21018,6 @@
 "nGq" = (
 /turf/closed/wall/f13/store,
 /area/f13/wasteland)
-"nGs" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/ncr)
 "nHi" = (
 /obj/machinery/vending/snack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -21218,14 +21165,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "nLX" = (
-/obj/structure/bed,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/effect/turf_decal/stripes/white/box,
+/obj/machinery/light,
+/obj/machinery/workbench/forge,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/item/bedsheet/brown,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
 "nMd" = (
@@ -21327,11 +21274,14 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "nPy" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/effect/turf_decal/stripes/white/box,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/ncr)
 "nPF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -21353,10 +21303,11 @@
 	},
 /area/f13/wasteland)
 "nPZ" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/effect/turf_decal/stripes/white/full,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/effect/landmark/start/f13/ncrlogisticsofficer,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/ncr)
 "nQk" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -21365,18 +21316,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/building)
-"nQu" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/landmark/start/f13/ncrheavytrooper,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/ncr)
 "nQP" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/brahmin,
@@ -21718,15 +21657,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "odW" = (
-/obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/light,
-/obj/machinery/workbench/forge,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
 "odZ" = (
 /obj/structure/flora/grass/wasteland,
@@ -21821,15 +21752,6 @@
 /obj/machinery/light/broken,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"ohV" = (
-/obj/effect/turf_decal/stripes/white/box,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/ncr)
 "oil" = (
 /obj/machinery/computer/shuttle/northbunkerelevator,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22006,19 +21928,6 @@
 	pixel_y = -6
 	},
 /turf/open/floor/carpet/black,
-/area/f13/ncr)
-"onx" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/stamp,
-/obj/item/stamp/denied,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
 /area/f13/ncr)
 "onQ" = (
 /obj/structure/table,
@@ -23274,8 +23183,13 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "pfb" = (
-/obj/structure/barricade/bars,
-/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start/f13/ncrcombatengineer,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
@@ -23320,9 +23234,20 @@
 	},
 /area/f13/ncr)
 "pfp" = (
-/obj/structure/barricade/bars,
-/obj/structure/table/reinforced,
-/obj/item/folder/red,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/table,
+/obj/machinery/button{
+	id = NCRArmoryNorth;
+	pixel_x = -27;
+	pixel_y = 7
+	},
+/obj/machinery/button{
+	id = NCRArmorySouth;
+	pixel_x = -27;
+	pixel_y = -7
+	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
@@ -24365,10 +24290,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "pMu" = (
-/obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
+/obj/structure/table,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/pen,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
@@ -24554,14 +24483,8 @@
 	},
 /area/f13/wasteland)
 "pRS" = (
-/obj/structure/decoration/rag{
-	icon_state = "flag_ncr";
-	name = "NCR banner";
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/effect/turf_decal/stripes/white/box,
+/obj/machinery/workbench,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -25904,14 +25827,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "qLO" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/ncr)
 "qLT" = (
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/wasteland)
@@ -27507,17 +27428,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"rPR" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/ncr)
 "rQb" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
 /obj/effect/decal/cleanable/blood/drip,
@@ -27564,12 +27474,15 @@
 	},
 /area/f13/building)
 "rRi" = (
-/obj/machinery/grill{
-	desc = "I am your captain. You are on guard duty.";
-	name = "Captain Pawolski Memorial Grill"
+/obj/structure/barricade/bars,
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = NCRArmorySouth
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/ncr)
 "rRt" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -27776,14 +27689,9 @@
 	},
 /area/f13/radiation)
 "rZK" = (
-/obj/structure/filingcabinet,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/ncr)
+/obj/structure/table,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "rZO" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -28704,10 +28612,16 @@
 	},
 /area/f13/wasteland)
 "sCz" = (
-/obj/structure/punching_bag,
-/obj/effect/turf_decal/stripes/white/full,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/structure/bed,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/item/bedsheet/brown,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/ncr)
 "sCG" = (
 /obj/effect/turf_decal/arrows,
 /turf/open/floor/f13{
@@ -28771,12 +28685,12 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "sGG" = (
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
+/obj/item/storage/money_stack/ncr,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/ncr)
 "sGI" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/destructible/tribal_torch/lit,
@@ -29615,17 +29529,12 @@
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
 "thW" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/ncr)
 "tin" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -30587,14 +30496,12 @@
 	},
 /area/f13/building)
 "tNa" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/ketchup{
+	pixel_x = -11;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/condiment/pack/bbqsauce,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "tNm" = (
@@ -30815,17 +30722,12 @@
 	},
 /area/f13/ncr)
 "tUk" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/grill{
+	desc = "I am your captain. You are on guard duty.";
+	name = "Captain Pawolski Memorial Grill"
 	},
-/obj/effect/landmark/start/f13/ncrcombatengineer,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/ncr)
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "tUp" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13{
@@ -30916,11 +30818,6 @@
 /obj/structure/simple_door/tent,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"tXe" = (
-/obj/structure/weightmachine/stacklifter,
-/obj/effect/turf_decal/stripes/white/full,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "tXt" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -31462,15 +31359,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"uqF" = (
-/obj/effect/landmark/start/f13/ncrcombatengineer,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/ncr)
 "uqW" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
@@ -32446,15 +32334,12 @@
 	},
 /area/f13/wasteland)
 "uVw" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/white/box,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "uVy" = (
 /obj/structure/fence/corner/wooden{
@@ -35454,7 +35339,8 @@
 	},
 /area/f13/brotherhood)
 "wUf" = (
-/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/stripes/white/box,
+/obj/machinery/autolathe/ammo,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -39225,8 +39111,8 @@ kzs
 dsn
 uzU
 kzs
-tUk
-uqF
+siS
+kzs
 kzs
 vcY
 xbV
@@ -44860,29 +44746,29 @@ hbW
 xzM
 xzM
 koD
-cpK
-jxd
-tXe
-nPy
-nPZ
+rhr
+rhr
+rhr
+ezX
+ezX
 sGG
+odW
+odW
+odW
+odW
+odW
+odW
+odW
 rhr
-rhr
-rhr
-rhr
-rhr
-cpK
-cpK
-bTf
 cpK
 cpK
 cpK
 cpK
 cpK
 cpK
-cpK
-cpK
-cpK
+rZK
+tNa
+tUk
 cpK
 cpK
 cpK
@@ -45117,20 +45003,20 @@ hbW
 hOl
 xzM
 koD
-cpK
-jFl
-tNa
-cpK
-lvS
-eJe
 rhr
-cNF
+jFl
 jiR
 wjR
+ezX
 rhr
-cpK
-cpK
-elT
+cNF
+cNF
+cNF
+rhr
+rRi
+rRi
+rRi
+ezX
 cpK
 cpK
 ezX
@@ -45374,20 +45260,20 @@ hbW
 hOl
 hOl
 koD
-cpK
-jFl
-tXe
-cpK
-jSN
-eJe
 rhr
 iuE
 szG
 wjR
-raV
-cpK
-cpK
-rRi
+rhr
+xdt
+xdt
+pfb
+xdt
+pfp
+xdt
+pfb
+xdt
+ezX
 cpK
 cpK
 ezX
@@ -45631,20 +45517,20 @@ hbW
 sgz
 hOl
 koD
-cpK
-jFl
-cpK
-cpK
-cpK
-eJe
 rhr
 wjR
-juV
+nPZ
 wjR
-rhr
-cpK
-cpK
-cpK
+raV
+xdt
+xdt
+xdt
+xdt
+pMu
+xdt
+xdt
+xdt
+ezX
 cpK
 cpK
 ezX
@@ -45888,20 +45774,20 @@ hbW
 hOl
 hOl
 koD
-cpK
+rhr
 thW
 sCz
-sCz
-sCz
+wjR
+rhr
+qLO
+xdt
+xdt
+xdt
+xdt
+xdt
+xdt
 qLO
 rhr
-wjR
-nLX
-uug
-rhr
-cpK
-cpK
-cpK
 cpK
 cpK
 ezX
@@ -46148,14 +46034,14 @@ ePz
 ezX
 ezX
 ezX
+raV
+rhr
 ezX
 rhr
-rhr
-ezX
 raV
 ezX
-ezX
-ezX
+rhr
+rhr
 raV
 rhr
 ezX
@@ -46405,16 +46291,16 @@ koD
 ezX
 jNs
 mfN
-qQf
-qQf
 xdt
-xdt
+qQf
+uVw
+uVw
 xdt
 idH
-ezX
+pRS
 wUf
 xdt
-nGs
+uVw
 rhr
 cpK
 cpK
@@ -46665,13 +46551,13 @@ xdt
 xdt
 xdt
 xdt
-lMn
 xdt
-nAr
-ezX
-pMu
 xdt
-nGs
+xdt
+xdt
+xdt
+xdt
+xdt
 rhr
 szS
 cpK
@@ -46917,19 +46803,19 @@ sgz
 hOl
 koD
 ezX
-qQf
-qQf
-qQf
-qQf
+nLX
 xdt
-gyh
+xdt
+xdt
+xdt
+xdt
+xdt
+xdt
+xdt
+xdt
 xdt
 xdt
 raV
-xdt
-xdt
-ncX
-ezX
 cpK
 cpK
 ezX
@@ -47161,11 +47047,11 @@ aBH
 hCg
 kGc
 xTq
-cpK
-cpK
-gdY
-uaf
-uaf
+bTf
+gyh
+jxd
+jSN
+lMn
 cpK
 stt
 unI
@@ -47174,19 +47060,19 @@ sgz
 hOl
 koD
 rhr
-xdt
-xdt
-xdt
+nPy
 xdt
 xdt
 lOY
 xdt
-odW
-ezX
-pRS
+lOY
 xdt
-rPR
-rhr
+xdt
+xdt
+xdt
+xdt
+xdt
+raV
 cpK
 cpK
 ezX
@@ -47418,11 +47304,11 @@ bpD
 sqA
 kGc
 xTq
+elT
+iGU
 cpK
-gdY
-uaf
-uaf
-uaf
+kzu
+ncX
 cpK
 stt
 unI
@@ -47431,18 +47317,18 @@ dmL
 xzM
 koD
 rhr
-qQf
-qQf
-qQf
-qQf
-xdt
-xdt
-xdt
-ohV
-pfb
 uVw
 xdt
-nQu
+xdt
+uVw
+xdt
+uVw
+xdt
+uVw
+xdt
+uVw
+xdt
+uVw
 ezX
 cpK
 cpK
@@ -47675,11 +47561,11 @@ bpD
 fyf
 kGc
 xTq
+elT
+gyh
 cpK
-qGZ
-mKu
-trd
-uaf
+lvS
+ncX
 cpK
 stt
 unI
@@ -47688,18 +47574,18 @@ hOl
 hOl
 koD
 rhr
-xdt
-xdt
-xdt
-xdt
-xdt
-xdt
-xdt
-dcj
-pfp
 uVw
 xdt
-rPR
+xdt
+uVw
+xdt
+uVw
+xdt
+uVw
+xdt
+uVw
+xdt
+uVw
 rhr
 cpK
 cpK
@@ -47932,11 +47818,11 @@ hCg
 fyf
 kGc
 xTq
+elT
 cpK
-nPX
-fyf
-kdJ
-cam
+cpK
+cpK
+ncX
 cpK
 stt
 unI
@@ -47945,18 +47831,18 @@ sgz
 hOl
 koD
 ezX
-qQf
-iGU
-qQf
-fum
-kzu
-lZl
-rZK
-onx
-pfb
 uVw
 xdt
-nQu
+xdt
+fum
+xdt
+uVw
+xdt
+uVw
+xdt
+uVw
+xdt
+uVw
 rhr
 cpK
 cpK
@@ -48189,11 +48075,11 @@ fyf
 fyf
 kGc
 xTq
-cpK
-eme
-yeJ
-lae
-cpK
+eJe
+juV
+juV
+juV
+nAr
 cpK
 stt
 unI


### PR DESCRIPTION
## About The Pull Request

Modifies the NCR armory, making it more open and encouraging people to RP.

## Why It's Good For The Game

With the expanded room it's easier to sort stuff and make it look nice, and the two windows allow for anyone not working in the armory to come up and ask for gear, as opposed to literally everyone just running into the armory whenever they want, and grabbing whatever they want. Having a few people manage it properly will hopefully cause some good RP, as well as giving the Logistics officer a better purpose. (Literally did not know they even existed before I decided to play around in SDMM)

Here's a picture.
![NCRArmory1](https://user-images.githubusercontent.com/53537549/122226646-2cf21680-ce84-11eb-858c-88fabf74d249.png)


## Changelog
:cl:
tweak: Tweaked the NCR armory, it's now more open and has 2 trading desks with shutters.
/:cl:
