### PR TITLE
Return of Bitter drink

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -364,7 +364,7 @@
 	},
 /area/f13/wasteland)
 "all" = (
-/obj/structure/closet/crate/wicker,
+/obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirtcorner"
@@ -5378,6 +5378,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"dIj" = (
+/obj/structure/fermenting_barrel,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "dIR" = (
 /obj/structure/bus_door,
 /turf/open/indestructible/ground/outside/road{
@@ -7391,6 +7395,7 @@
 	},
 /area/f13/wasteland)
 "eVJ" = (
+/obj/machinery/light/floor,
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/oak,
 /area/f13/wasteland)
@@ -20914,6 +20919,7 @@
 	},
 /area/f13/building)
 "nyZ" = (
+/obj/machinery/light/floor,
 /obj/structure/table/wood/settler,
 /obj/structure/gallow,
 /turf/open/floor/wood/f13/oak,
@@ -22048,7 +22054,13 @@
 /area/f13/brotherhood)
 "ooh" = (
 /obj/structure/table/wood,
-/obj/item/roller,
+/obj/item/paper/bitterdrink{
+	pixel_x = -10
+	},
+/obj/item/reagent_containers/pill/patch/bitterdrink{
+	pixel_x = 6;
+	pixel_y = 6
+	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "oom" = (
@@ -32155,6 +32167,11 @@
 	icon_state = "outermaincornerouter"
 	},
 /area/f13/wasteland)
+"uMw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/roller,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "uMZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road{
@@ -53430,8 +53447,8 @@ qFk
 hsj
 nQY
 jnN
-uRJ
-uRJ
+dIj
+dIj
 tBN
 mvv
 mvv
@@ -99270,7 +99287,7 @@ fLB
 xXm
 ohf
 hom
-hbO
+uMw
 xfy
 hbO
 vHe

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -16135,6 +16135,13 @@
 	icon_state = "purplefull"
 	},
 /area/f13/enclave)
+"mOz" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "church"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "mOF" = (
 /mob/living/simple_animal/mouse{
 	faction = list("Wastelander");
@@ -16467,12 +16474,11 @@
 /turf/closed/wall/r_wall,
 /area/f13/tunnel)
 "ndk" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/ladder/unbreakable{
 	height = 1;
-	id = "church"
+	id = "S1"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "ndn" = (
 /obj/effect/decal/cleanable/dirt{
@@ -68770,7 +68776,7 @@ mPC
 bFQ
 ckx
 ckx
-tjd
+mOz
 vuv
 doL
 hvw
@@ -69234,7 +69240,7 @@ imo
 esh
 bpa
 kUN
-nBk
+ndk
 nBk
 nBk
 nBk
@@ -70055,7 +70061,7 @@ ckx
 ckx
 bEw
 uvE
-ndk
+ckx
 mTq
 ckx
 oUQ

--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -47,6 +47,13 @@
 	time = 35
 	category = CAT_MEDICAL
 
+/datum/crafting_recipe/bitterdrink
+	name = "Bottle Bitterdrink"
+	result = /obj/item/reagent_containers/pill/patch/bitterdrink
+	reqs = list(/datum/reagent/medicine/bitter_drink = 30)
+	time = 20
+	category = CAT_MEDICAL
+
 /datum/crafting_recipe/healpoultice
 	name = "Healing poultice"
 	result = /obj/item/reagent_containers/pill/patch/healpoultice

--- a/code/modules/fallout/reagents/alcohol.dm
+++ b/code/modules/fallout/reagents/alcohol.dm
@@ -89,6 +89,38 @@
 		. = TRUE
 	..()
 
+/datum/reagent/consumable/ethanol/yellowpulque
+	name = "Yellow pulque"
+	description = "An awful smelling yellow, thick pulque."
+	color = "#fdff73"
+	boozepwr = 50
+	taste_description = "puke and dirt"
+	glass_icon_state = "cognacglass"
+	glass_name = "yellow pulque"
+	glass_desc = "An awful smelling yellow, thick pulque."
+	var/last_added = 0
+	var/maximum_reachable = BLOOD_VOLUME_NORMAL - 10
+
+/datum/reagent/consumable/ethanol/yellowpulque/on_mob_life(mob/living/carbon/M)
+	M.adjustOxyLoss(-5*REAGENTS_EFFECT_MULTIPLIER, 0)
+	..()
+	. = TRUE
+
+/datum/reagent/consumable/ethanol/yellowpulque/on_mob_life(mob/living/carbon/M)
+	if(last_added)
+		M.blood_volume -= last_added
+		last_added = 0
+	if(M.blood_volume < maximum_reachable)	//Can only up to double your effective blood level.
+		var/amount_to_add = min(M.blood_volume, volume*5)
+		var/new_blood_level = min(M.blood_volume + amount_to_add, maximum_reachable)
+		last_added = new_blood_level - M.blood_volume
+		M.blood_volume = new_blood_level
+	if(prob(33))
+		M.adjustBruteLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER, 0)
+		M.adjustFireLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER, 0)
+		. = TRUE
+	..()
+
 /datum/reagent/consumable/ethanol/deathroach
 	name = "Deathroach"
 	description = "Distilled tobacco, for that two-in-one cancer blast!"

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -103,22 +103,28 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 	reagent_state = LIQUID
 	color ="#A9FBFB"
 	taste_description = "bitterness"
-	metabolization_rate = 0.4 * REAGENTS_METABOLISM //in between powder/stimpaks and poultice/superstims?
-	overdose_threshold = 30
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM //in between powder/stimpaks and poultice/superstims?
+	overdose_threshold = 31
+	var/heal_factor = -3 //Subtractive multiplier if you do not have the perk.
+	var/heal_factor_perk = -8 //Multiplier if you have the right perk.
 
-datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/M)
+/datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/carbon/M)
+	var/is_technophobe = FALSE
+	if(HAS_TRAIT(M, TRAIT_TECHNOPHOBE))
+		is_technophobe = TRUE
 	if(M.getBruteLoss() == 0 && M.getFireLoss() == 0)
 		metabolization_rate = 1000 * REAGENTS_METABOLISM //instant metabolise if it won't help you, prevents prehealing before combat
-	if(!M.reagents.has_reagent(/datum/reagent/medicine/stimpak) && !M.reagents.has_reagent(/datum/reagent/medicine/healing_powder)) //should prevent stacking with healing powder and stimpaks
-		M.adjustFireLoss(-3*REAGENTS_EFFECT_MULTIPLIER)
-		M.adjustBruteLoss(-3*REAGENTS_EFFECT_MULTIPLIER)
-		M.hallucination = max(M.hallucination, 5)
-		. = TRUE
+	var/heal_rate = (is_technophobe ? heal_factor_perk : heal_factor) * REAGENTS_EFFECT_MULTIPLIER
+	M.adjustFireLoss(heal_rate)
+	M.adjustBruteLoss(heal_rate)
+	M.adjustToxLoss(heal_rate)
+	M.hallucination = max(M.hallucination, is_technophobe ? 0 : 5)
+	. = TRUE
 	..()
 
 /datum/reagent/medicine/bitter_drink/overdose_process(mob/living/M)
-	M.adjustToxLoss(2*REAGENTS_EFFECT_MULTIPLIER)
-	M.adjustOxyLoss(4*REAGENTS_EFFECT_MULTIPLIER)
+	M.adjustToxLoss(1*REAGENTS_EFFECT_MULTIPLIER)
+	M.adjustOxyLoss(2*REAGENTS_EFFECT_MULTIPLIER)
 	..()
 	. = TRUE
 
@@ -142,6 +148,7 @@ datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/M)
 	var/heal_rate = (is_technophobe ? heal_factor_perk : heal_factor) * REAGENTS_EFFECT_MULTIPLIER
 	M.adjustFireLoss(heal_rate)
 	M.adjustBruteLoss(heal_rate)
+	M.adjustToxLoss(heal_rate)
 	M.hallucination = max(M.hallucination, is_technophobe ? 0 : 5)
 	. = TRUE
 	..()

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -8,7 +8,7 @@
 	pressure_resistance = 2 * ONE_ATMOSPHERE
 	max_integrity = 300
 	var/open = FALSE
-	var/speed_multiplier = 1 //How fast it distills. Defaults to 100% (1.0). Lower is better.
+	var/speed_multiplier = 4 //How fast it distills. Defaults to 100% (1.0). Lower is better.
 
 /obj/structure/fermenting_barrel/Initialize()
 	create_reagents(300, DRAINABLE | AMOUNT_VISIBLE) //Bluespace beakers, but without the portability or efficiency in circuits.

--- a/code/modules/paperwork/paper_premade.dm
+++ b/code/modules/paperwork/paper_premade.dm
@@ -236,3 +236,22 @@
 	name = "URGENT!"
 	info = "A hastily written note has been scribbled here... <br><br> Please use the ore redemption machine in the cargo office for smelting. PLEASE! <br><br>--The Research Staff"
 
+////// Fortune 13
+
+/obj/item/paper/bitterdrink
+	name = "Recipe for Bitterdrink"
+	info = {"Bitter drink is a useful healing drink primarily carried by legionaries and is regularly consumed by wounded soldiers on the Legion's long forced marches. It is a rather simple recipe for slaves.
+	<br>
+	<b>Step 1
+	<br>
+	Aquire Xander root,broc flowers,barrel cactii and bottles of Sarsaparilla.
+	<br>
+	Step 2
+	<br> 
+	Ferment Xander root,barrel cactii and broc flowers seperate. 
+	<br>
+	<b>Step 3
+	<br>
+	Mix the fermented results of Xander root, barrel cactii,broc flowers and Sarsaparilla together in a large glass beaker.</b>
+	<br>
+	Bitter drink should be the result which can then be bottled by crafting. It is a very potent drink, so more than two should not be consumed."}

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -383,3 +383,9 @@
 	results = list(/datum/reagent/medicine/mentat = 3)
 	required_reagents = list(/datum/reagent/medicine/neurine = 1, /datum/reagent/cellulose = 1)
 	required_temp = 451
+
+/datum/chemical_reaction/bitterdrink
+	name = "Bitter drink"
+	id = /datum/reagent/medicine/bitter_drink
+	results = list(/datum/reagent/medicine/bitter_drink = 30)
+	required_reagents = list(/datum/reagent/consumable/ethanol/salgam = 10 , /datum/reagent/consumable/ethanol/brocbrew = 10 , /datum/reagent/consumable/sunset = 10 , /datum/reagent/consumable/ethanol/yellowpulque = 10) 

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -76,3 +76,10 @@
 	list_reagents = null
 	icon_state = "bandaid_healingpowder"
 	self_delay = 0
+
+/obj/item/reagent_containers/pill/patch/bitterdrink
+	name = "Bitter drink"
+	desc = "A strong herbal healing concoction which enables wounded soldiers and travelers to tend to their wounds without stopping during journeys."
+	list_reagents = list(/datum/reagent/medicine/bitter_drink = 15) 
+	icon_state = "Voodoo"
+	self_delay = 0


### PR DESCRIPTION
## About The Pull Request
Reintroduces bitter drink for legion and tribals.
Ferment Xander root, broc flowers, barrel cactus and add sarsaparilla and receive bitter drink. Bottle it and you’re good to go.
Placed a fermenting barrel in tribal camp and legion base.
Added a little recipe to the medical clinic of legion

// Also fixed the one ladder at the school that leads nowhere.

## Changelog
🆑
add: Bitter drink + recipe
add : Fermenting barrel to legion + tribals
/🆑

