### PR TITLE
Removal of magnum buckshot from the ammo bench

### DIFF
--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -282,14 +282,14 @@
 	materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 1500)
 	build_path = /obj/item/ammo_box/a556/jhp
 	category = list("initial", "Basic Ammo")
-
+/*
 /datum/design/ammolathe/magnumshot
 	name = "magnum buckshot shotgun box"
 	id = "magnumshot"
 	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1500)
 	build_path = /obj/item/ammo_box/shotgun/magnum
 	category = list("initial", "Basic Ammo")
-
+*/
 /datum/design/ammolathe/slugshot
 	name = "slug shotgun box"
 	id = "slugshot"


### PR DESCRIPTION
This is only a small part of a larger PR coming later that will remove or adjust most ammo types to no longer be straight upgrades or downgrades but instead sidegrades.

But magnum buckshot is bullshit, frankly. It's a straight upgrade over normal buckshot, it's obscenely strong, and...well, honestly, no real nerf is going to change that 'this ammo is the same as other ammo but even better' is bad game design.

Ammunition should be sidegrades or fill different roles rather than just be better or worse.

## Changelog
:cl:
del: Magnum buckshot is gone from the ammunition bench.
server: something server ops should know
/:cl:
