### PR TITLE
Annihilates ALL chemical-based combat (and cleans up research nodes)

### DIFF
--- a/code/modules/research/techweb/nodes/syndicate_nodes.dm
+++ b/code/modules/research/techweb/nodes/syndicate_nodes.dm
@@ -3,7 +3,7 @@
 	id = "syndicate_basic"
 	display_name = "Illegal Technology"
 	description = "Dangerous research used to create dangerous objects."
-	prereq_ids = list("adv_engi", "adv_weaponry", "explosive_weapons")
+	prereq_ids = list("adv_engi", "adv_weaponry")
 	design_ids = list("decloner", "borg_syndicate_module", "suppressor", "donksofttoyvendor", "donksoft_refill", "syndiesleeper")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	hidden = TRUE
@@ -22,7 +22,7 @@
 	display_name = "Advanced Non-Standard Ballistics"
 	description = "Ballistic ammunition for non-standard firearms. Usually the ones you don't have nor want to be involved with."
 	design_ids = list("10mm","10mmap","10mminc","10mmhp","sl357","sl357ap","pistolm9mm","m45","bolt_clip")
-	prereq_ids = list("syndicate_basic","explosive_weapons")
+	prereq_ids = list("syndicate_basic")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 25000) //This gives sec lethal mags/clips for guns from traitors, space, or anything in between.
 
 //Helpers for debugging/balancing the techweb in its entirety!

--- a/code/modules/research/techweb/nodes/weaponry_nodes.dm
+++ b/code/modules/research/techweb/nodes/weaponry_nodes.dm
@@ -40,9 +40,7 @@
 	prereq_ids = list("weaponry", "adv_weaponry", "emp_adv")
 	design_ids = list("magrifle", "magpistol", "mag_magrifle", "mag_magrifle_nl", "mag_magpistol", "mag_magpistol_nl")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
-*/
 
-/* To finish removing rpaid syringe guns this bit needs to be commented out too.
 /datum/techweb_node/medical_weapons
 	id = "medical_weapons"
 	display_name = "Medical Weaponry"
@@ -50,8 +48,6 @@
 	prereq_ids = list("adv_biotech", "adv_weaponry")
 	design_ids = list("rapidsyringe", "shotgundartcryostatis")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
-*/
-
 /datum/techweb_node/beam_weapons
 	id = "beam_weapons"
 	display_name = "Beam Weaponry"
@@ -60,7 +56,6 @@
 	design_ids = list("temp_gun")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
-/*
 /datum/techweb_node/adv_beam_weapons
 	id = "adv_beam_weapons"
 	display_name = "Advanced Beam Weaponry"
@@ -68,7 +63,6 @@
 	prereq_ids = list("beam_weapons")
 	design_ids = list("beamrifle")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3250) // Sniper
-*/
 
 /datum/techweb_node/explosive_weapons
 	id = "explosive_weapons"
@@ -78,7 +72,6 @@
 	design_ids = list("large_Grenade", "pyro_Grenade", "adv_Grenade")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2750)
 
-/*
 /datum/techweb_node/ballistic_weapons
 	id = "ballistic_weapons"
 	display_name = "Ballistic Weaponry"
@@ -86,7 +79,6 @@
 	prereq_ids = list("weaponry")
 	design_ids = list("mag_oldsmg", "mag_oldsmg_ap", "mag_oldsmg_ic", "mag_oldsmg_rubber", "mag_oldsmg_tx")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2750)
-*/
 
 /datum/techweb_node/exotic_ammo
 	id = "exotic_ammo"
@@ -96,7 +88,6 @@
 	design_ids = list("techshotshell")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3500)
 
-/*
 /datum/techweb_node/gravity_gun
 	id = "gravity_gun"
 	display_name = "One-point Bluespace-gravitational Manipulator"


### PR DESCRIPTION
This removes the ability to research chemical grenades and rapid syringe guns entirely. The removal for the casing recipe is in https://github.com/nokele/Fortune13/pull/109

If you don't like this, go and hit the thumbs down button. You did it last time. Go and show me just how much you despise the removal of thy powergaming. You know who you are.

![yes](https://user-images.githubusercontent.com/76002401/122508876-f0c3d080-cfbf-11eb-9ec2-06704dcec195.gif)
