### PR TITLE
The Yuma Mall

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -93,12 +93,6 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"adz" = (
-/obj/structure/tires,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/wasteland)
 "adD" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/road{
@@ -664,14 +658,6 @@
 	},
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"arE" = (
-/obj/structure/table/wood/settler,
-/obj/item/storage/box/matches,
-/obj/item/reagent_containers/food/snacks/meat/slab/molerat,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
 /area/f13/wasteland)
 "arT" = (
 /obj/machinery/vending/cola,
@@ -1278,12 +1264,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
-"aLc" = (
-/obj/item/reagent_containers/food/snacks/f13/canned/dog,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/wasteland)
 "aLg" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/attachments,
@@ -2830,12 +2810,6 @@
 /obj/item/reagent_containers/food/snacks/breadhard,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"bDM" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
-	},
-/area/f13/wasteland)
 "bDO" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
@@ -2966,6 +2940,12 @@
 "bIp" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/brotherhood)
+"bIv" = (
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/building)
 "bIF" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical"
@@ -4298,6 +4278,12 @@
 /obj/structure/billboard/cola,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"cFg" = (
+/obj/item/reagent_containers/food/snacks/f13/canned/dog,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "cFq" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -5333,10 +5319,15 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"djt" = (
-/obj/structure/campfire/barrel,
-/turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+"djG" = (
+/obj/effect/decal/marking,
+/obj/structure/barricade/tentclothcorner{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "djI" = (
 /obj/machinery/workbench,
 /turf/open/floor/f13/wood,
@@ -5899,12 +5890,6 @@
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"dzS" = (
-/obj/structure/campfire/barrel,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/wasteland)
 "dAg" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3"
@@ -6039,15 +6024,6 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "bar"
-	},
-/area/f13/building)
-"dDe" = (
-/obj/effect/decal/marking,
-/obj/structure/barricade/tentclothedge{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
 	},
 /area/f13/building)
 "dDh" = (
@@ -6409,6 +6385,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"dOO" = (
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/wasteland)
 "dOW" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road{
@@ -6429,6 +6411,14 @@
 /obj/item/pen,
 /obj/structure/table,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"dQP" = (
+/obj/structure/simple_door/tentflap_cloth{
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
 /area/f13/building)
 "dRd" = (
 /obj/item/seeds/pumpkin,
@@ -6725,6 +6715,15 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"eat" = (
+/obj/structure/car/rubbish2,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor2"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "eaA" = (
 /obj/structure/closet/crate/large,
 /obj/item/stack/sheet/mineral/wood/fifty,
@@ -7784,6 +7783,12 @@
 	icon_state = "rubbleplate"
 	},
 /area/f13/building)
+"eEt" = (
+/obj/structure/tires,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "eEz" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8150,6 +8155,17 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
+"eNO" = (
+/obj/structure/table/wood/settler,
+/obj/item/storage/fancy/cigarettes/cigpack_pyramid,
+/obj/item/reagent_containers/food/drinks/beer/light{
+	desc = "An old bottle of beer, scavenged and somehow unbroken. The label has been sun-bleached to the point of being illegible.";
+	name = "Salvaged Beer"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
+	},
+/area/f13/wasteland)
 "eNT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -8435,15 +8451,6 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/village)
-"eUJ" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/building)
 "eUQ" = (
 /mob/living/simple_animal/hostile/gecko,
 /obj/effect/decal/cleanable/dirt,
@@ -9878,10 +9885,6 @@
 "fMu" = (
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
-"fMI" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
 "fMO" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -10894,6 +10897,14 @@
 "gnk" = (
 /turf/open/floor/f13,
 /area/f13/building)
+"gnv" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor2"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "gny" = (
 /obj/structure/rack,
 /obj/item/toy/cattoy,
@@ -12936,6 +12947,12 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"hsb" = (
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "shadowleft"
+	},
+/area/f13/wasteland)
 "hsh" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -13248,12 +13265,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"hzV" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "shadowleft"
-	},
-/area/f13/wasteland)
 "hAk" = (
 /turf/open/floor/carpet,
 /area/f13/building)
@@ -13687,12 +13698,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
-"hLn" = (
-/obj/structure/barricade/tentclothedge,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
-	},
-/area/f13/building)
 "hLs" = (
 /obj/structure/rack,
 /obj/item/shovel/spade,
@@ -14290,6 +14295,17 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/ncr)
+"ieb" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/closet,
+/obj/item/crafting/wonderglue,
+/obj/item/radio/off,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "iel" = (
 /mob/living/simple_animal/hostile/raider/firefighter,
 /turf/open/indestructible/ground/outside/dirt{
@@ -15282,13 +15298,6 @@
 	icon_state = "rubbleplate"
 	},
 /area/f13/wasteland)
-"iIW" = (
-/obj/effect/decal/marking,
-/obj/structure/barricade/tentclothcorner,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/building)
 "iJc" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -15937,6 +15946,12 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
+"iXe" = (
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
+	},
+/area/f13/wasteland)
 "iXi" = (
 /obj/machinery/light,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -16778,6 +16793,15 @@
 "jvr" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/caves)
+"jvu" = (
+/obj/structure/closet/cardboard,
+/obj/item/crafting/coffee_pot,
+/obj/item/reagent_containers/food/drinks/bottle/instacoffee,
+/obj/item/seeds/coffee/robusta,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "jvw" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
@@ -17223,14 +17247,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"jJq" = (
-/obj/structure/simple_door/tentflap_cloth{
-	pixel_y = -3
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/building)
 "jJB" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowright"
@@ -17497,12 +17513,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
-"jRh" = (
-/obj/item/ammo_casing/c9mm,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/wasteland)
 "jRn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -19515,6 +19525,15 @@
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
+"kZZ" = (
+/obj/effect/decal/marking,
+/obj/structure/barricade/tentclothcorner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/building)
 "lae" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -20960,6 +20979,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"lTt" = (
+/obj/structure/closet/cardboard,
+/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
+/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2right"
+	},
+/area/f13/wasteland)
 "lTv" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -21136,6 +21163,16 @@
 "lYu" = (
 /mob/living/simple_animal/chick,
 /turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"lYF" = (
+/obj/structure/closet/cardboard,
+/obj/item/storage/briefcase,
+/obj/item/clothing/suit/jacket/leather,
+/obj/item/clothing/head/cowboyhat/black,
+/obj/item/clothing/under/f13/cowboyg,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "topshadowleft"
+	},
 /area/f13/wasteland)
 "lYX" = (
 /obj/machinery/power/smes,
@@ -21412,6 +21449,22 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"mhj" = (
+/obj/effect/decal/marking,
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/wasteland)
+"mhu" = (
+/obj/effect/decal/marking,
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/building)
 "mhJ" = (
@@ -21985,12 +22038,6 @@
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop2"
-	},
-/area/f13/wasteland)
-"mBc" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland)
 "mBd" = (
@@ -22836,6 +22883,13 @@
 	},
 /turf/closed/wall/f13/store,
 /area/f13/building)
+"ncY" = (
+/obj/effect/decal/marking,
+/obj/structure/barricade/tentclothcorner,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "nda" = (
 /obj/machinery/workbench,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -22887,6 +22941,15 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"neW" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/building)
 "neZ" = (
@@ -23305,17 +23368,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"nsk" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/item/flashlight/seclite,
-/obj/item/clothing/head/f13/police,
-/obj/item/clothing/under/f13/police,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "nss" = (
 /obj/structure/chair/stool/retro/backed{
 	dir = 1
@@ -23526,15 +23578,6 @@
 /obj/item/seeds/poppy/broc,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
-"nzV" = (
-/obj/structure/car/rubbish2,
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor2"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/wasteland)
 "nAh" = (
 /obj/machinery/light/small,
 /turf/open/water,
@@ -23637,13 +23680,6 @@
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
-	},
-/area/f13/wasteland)
-"nDG" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
 "nDJ" = (
@@ -24158,6 +24194,12 @@
 	icon_state = "horizontaltopbordertop3"
 	},
 /area/f13/tunnel)
+"nUa" = (
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "nUc" = (
 /obj/structure/chair/bench,
 /obj/machinery/light/small,
@@ -24236,6 +24278,12 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
+"nWm" = (
+/obj/item/ammo_casing/c9mm,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
 /area/f13/wasteland)
 "nWu" = (
 /obj/machinery/deepfryer,
@@ -24414,6 +24462,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"odA" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland)
 "odJ" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical,
@@ -25588,6 +25640,17 @@
 /obj/item/clothing/head/helmet/f13/raidercombathelmet,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"oOa" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/flashlight/seclite,
+/obj/item/clothing/head/f13/police,
+/obj/item/clothing/under/f13/police,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "oOi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -26370,6 +26433,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"pko" = (
+/obj/structure/campfire,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "pkL" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall/f13/supermart,
@@ -26896,6 +26965,15 @@
 "pAm" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
+"pAx" = (
+/obj/effect/decal/marking,
+/obj/structure/barricade/tentclothedge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "pAA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26971,12 +27049,6 @@
 "pCX" = (
 /obj/machinery/grill,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"pDa" = (
-/obj/structure/campfire,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
 /area/f13/wasteland)
 "pDi" = (
 /obj/structure/table,
@@ -28095,17 +28167,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"qev" = (
-/obj/structure/table/wood/settler,
-/obj/item/storage/fancy/cigarettes/cigpack_pyramid,
-/obj/item/reagent_containers/food/drinks/beer/light{
-	desc = "An old bottle of beer, scavenged and somehow unbroken. The label has been sun-bleached to the point of being illegible.";
-	name = "Salvaged Beer"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0"
-	},
-/area/f13/wasteland)
 "qeM" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -29115,15 +29176,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"qIF" = (
-/obj/effect/decal/marking,
-/obj/structure/barricade/tentclothedge{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/building)
 "qJv" = (
 /obj/structure/fence/corner/wooden{
 	dir = 1
@@ -29140,14 +29192,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
-"qJW" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor2"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/wasteland)
 "qJZ" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/f13{
@@ -29966,16 +30010,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"rfy" = (
-/obj/structure/closet/cardboard,
-/obj/item/storage/briefcase,
-/obj/item/clothing/suit/jacket/leather,
-/obj/item/clothing/head/cowboyhat/black,
-/obj/item/clothing/under/f13/cowboyg,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "topshadowleft"
-	},
-/area/f13/wasteland)
 "rfI" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/clothing_middle,
@@ -30150,6 +30184,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
+"rlQ" = (
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "rmd" = (
 /obj/structure/closet/crate/freezer,
 /turf/open/indestructible/ground/outside/road{
@@ -30775,15 +30815,6 @@
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
-	},
-/area/f13/building)
-"rHz" = (
-/obj/effect/decal/marking,
-/obj/structure/barricade/tentclothcorner{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/building)
 "rHO" = (
@@ -32007,17 +32038,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"srf" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/closet,
-/obj/item/crafting/wonderglue,
-/obj/item/radio/off,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "srj" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_west_south"
@@ -32495,6 +32515,13 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/building)
+"sHt" = (
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerbordercorner"
+	},
+/area/f13/wasteland)
 "sHu" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt{
@@ -32843,13 +32870,6 @@
 /mob/living/simple_animal/hostile/ghoul/soldier/armored,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
-"sSc" = (
-/obj/effect/mob_spawn/human/corpse/raidermelee,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerbordercorner"
-	},
-/area/f13/wasteland)
 "sSr" = (
 /turf/open/floor/wood/f13/old/ruinedstraightnorth,
 /area/f13/wasteland)
@@ -33551,13 +33571,6 @@
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"tlE" = (
-/obj/effect/decal/marking,
-/obj/item/stack/sheet/mineral/wood,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
-	},
-/area/f13/wasteland)
 "tlI" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -33615,6 +33628,17 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"tnK" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/remains/human,
+/obj/item/reagent_containers/pill/patch/jet,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "tom" = (
 /obj/structure/toilet{
 	dir = 1
@@ -34073,6 +34097,15 @@
 /obj/item/clothing/head/helmet/f13/deathskull,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"tBo" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "tBA" = (
 /obj/structure/rack,
 /obj/item/storage/wallet,
@@ -34353,15 +34386,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"tKa" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/wreck/trash/two_barrels,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "tKk" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -34470,6 +34494,13 @@
 	},
 /obj/item/reagent_containers/food/condiment/pack/bbqsauce,
 /turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
+"tNj" = (
+/obj/structure/wreck/bus/rusted,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor2"
+	},
+/turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "tNm" = (
 /obj/structure/rack,
@@ -34812,6 +34843,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"tVK" = (
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland)
 "tVQ" = (
 /obj/machinery/plantgenes,
 /turf/open/floor/f13{
@@ -35492,14 +35527,6 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/ncr)
-"uql" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/building)
 "uqE" = (
 /obj/effect/decal/remains/human,
 /obj/item/ammo_casing/caseless{
@@ -35645,6 +35672,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"utB" = (
+/obj/structure/table/wood/settler,
+/obj/item/storage/box/matches,
+/obj/item/reagent_containers/food/snacks/meat/slab/molerat,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "utT" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/curtain{
@@ -36931,14 +36966,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
-"vcD" = (
-/obj/structure/closet/cardboard,
-/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
-/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2right"
-	},
-/area/f13/wasteland)
 "vcF" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -37013,15 +37040,6 @@
 	icon_state = "verticalrightborderright3"
 	},
 /area/f13/wasteland)
-"veI" = (
-/obj/effect/decal/marking,
-/obj/structure/barricade/tentclothcorner{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/building)
 "veO" = (
 /obj/structure/closet/cabinet,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -37093,6 +37111,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"vgE" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "vhm" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticaltop"
@@ -38147,15 +38172,6 @@
 	icon_state = "verticalinnermain2top"
 	},
 /area/f13/wasteland)
-"vNA" = (
-/obj/effect/decal/marking,
-/obj/structure/barricade/tentclothcorner{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
-	},
-/area/f13/building)
 "vNG" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/vomit,
@@ -38614,13 +38630,6 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainright"
 	},
-/area/f13/wasteland)
-"wfo" = (
-/obj/structure/wreck/bus/rusted,
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor2"
-	},
-/turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "wfr" = (
 /obj/machinery/light/small{
@@ -39471,17 +39480,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"wES" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/remains/human,
-/obj/item/reagent_containers/pill/patch/jet,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/wasteland)
 "wEX" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/carpet,
@@ -39553,6 +39551,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
+	},
+/area/f13/building)
+"wGI" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/building)
 "wGJ" = (
@@ -41658,12 +41664,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/ncr)
-"xKI" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/wasteland)
 "xKV" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -41949,15 +41949,15 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
-"xUF" = (
-/obj/structure/closet/cardboard,
-/obj/item/crafting/coffee_pot,
-/obj/item/reagent_containers/food/drinks/bottle/instacoffee,
-/obj/item/seeds/coffee/robusta,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
+"xUx" = (
+/obj/effect/decal/marking,
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
 	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/building)
 "xUO" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -93271,7 +93271,7 @@ otv
 nYW
 otv
 nFT
-nsk
+oOa
 mbm
 ioH
 ktB
@@ -93513,7 +93513,7 @@ nZD
 otv
 tjO
 jwK
-srf
+ieb
 qZd
 rZS
 amD
@@ -94305,7 +94305,7 @@ jPU
 hbW
 ehN
 uFk
-wES
+tnK
 ehN
 gmX
 uFw
@@ -94561,10 +94561,10 @@ izb
 wPL
 hbW
 ehN
-aLc
-dzS
+cFg
+rlQ
 ehN
-jRh
+nWm
 idu
 idu
 idu
@@ -94818,9 +94818,9 @@ hqw
 wcq
 hbW
 ehN
-nDG
+vgE
 uFk
-jRh
+nWm
 ehN
 ehN
 ehN
@@ -95071,7 +95071,7 @@ dit
 dmF
 uPH
 tZC
-tKa
+tBo
 ioH
 hbW
 ehN
@@ -96867,7 +96867,7 @@ vTj
 hAk
 qEZ
 iiF
-sSc
+sHt
 ybI
 ybI
 ybI
@@ -97125,7 +97125,7 @@ hAk
 mvC
 iiF
 unI
-rfy
+lYF
 idu
 idu
 idu
@@ -97133,9 +97133,9 @@ idu
 idu
 idu
 idu
-mBc
-qev
-hzV
+iXe
+eNO
+hsb
 koD
 unI
 hbW
@@ -97390,9 +97390,9 @@ ubg
 sQX
 sQX
 ehN
-xKI
-arE
-bDM
+nUa
+utB
+dOO
 koD
 jnK
 hbW
@@ -97642,14 +97642,14 @@ unI
 eeh
 iaL
 iaL
-djt
-vcD
+tVK
+lTt
 sQX
 sQX
 ehN
 iaL
 iaL
-tlE
+mhj
 koD
 unI
 hbW
@@ -97899,12 +97899,12 @@ unI
 hbW
 ehN
 ehN
-fMI
+odA
 sQX
 blM
 sQX
 ehN
-pDa
+pko
 ehN
 sWr
 koD
@@ -98158,7 +98158,7 @@ ehN
 ehN
 sQX
 sQX
-wfo
+tNj
 hOl
 ehN
 jni
@@ -98418,9 +98418,9 @@ sQX
 ubg
 cdc
 ubg
-iIW
-qIF
-vNA
+ncY
+pAx
+xUx
 koD
 ajD
 hbW
@@ -98675,9 +98675,9 @@ ubg
 cdc
 cdc
 ehN
-jJq
+dQP
 fPH
-hLn
+bIv
 koD
 jIB
 hbW
@@ -98932,9 +98932,9 @@ cdc
 cdc
 bJB
 ehN
-eUJ
-uql
-hLn
+neW
+wGI
+bIv
 koD
 ofX
 hbW
@@ -99189,9 +99189,9 @@ apk
 bJB
 kLy
 ehN
-veI
-dDe
-rHz
+djG
+mhu
+kZZ
 koD
 unI
 hbW
@@ -99443,11 +99443,11 @@ dte
 bhC
 ehN
 ehN
-qJW
-adz
+gnv
+eEt
 ehN
 ehN
-nzV
+eat
 gmX
 koD
 unI
@@ -100218,7 +100218,7 @@ ehN
 ehN
 ehN
 ehN
-xUF
+jvu
 gmX
 koD
 pBv

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -93,6 +93,12 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"adz" = (
+/obj/structure/tires,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "adD" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/road{
@@ -148,6 +154,11 @@
 	icon_state = "rubbleplate"
 	},
 /area/f13/wasteland)
+"afB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "afL" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -200,6 +211,18 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"agW" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "agX" = (
 /obj/structure/fence/wooden{
 	dir = 1
@@ -228,6 +251,13 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
+/area/f13/building)
+"ahI" = (
+/mob/living/simple_animal/hostile/handy,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/wood_tiled,
 /area/f13/building)
 "ahK" = (
 /obj/structure/chair/wood/modern{
@@ -412,6 +442,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"amD" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/junk/micro,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "anb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -425,10 +464,37 @@
 /turf/open/floor/wood/f13/stage_l,
 /area/f13/bar)
 "anq" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	termtag = "Business"
 	},
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"ans" = (
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/sign/poster/contraband/have_a_puff,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
+"any" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/tree/wasteland,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "anA" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
@@ -496,6 +562,14 @@
 	icon_state = "horizontalinnermain2right"
 	},
 /area/f13/wasteland)
+"apm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Business"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/building)
 "apt" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/inside/mountain,
@@ -519,6 +593,25 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"aqy" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ricksoutdoorshutters";
+	layer = 11;
+	name = "Ricks Outdoor Goods"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"aqB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/building)
 "aqD" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 5;
@@ -571,6 +664,14 @@
 	},
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"arE" = (
+/obj/structure/table/wood/settler,
+/obj/item/storage/box/matches,
+/obj/item/reagent_containers/food/snacks/meat/slab/molerat,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
 /area/f13/wasteland)
 "arT" = (
 /obj/machinery/vending/cola,
@@ -634,10 +735,23 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"atI" = (
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/wasteland)
 "atL" = (
 /obj/structure/billboard/cola,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"atT" = (
+/obj/structure/rack,
+/obj/item/clothing/glasses/regular,
+/obj/item/clothing/glasses/regular,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/building)
 "atV" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/light/small,
@@ -710,6 +824,16 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"avP" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/spawner/lootdrop/trash,
+/obj/machinery/door/window/westright,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "awj" = (
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife,
@@ -794,6 +918,10 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"ayD" = (
+/obj/structure/sign/poster/prewar/poster74,
+/turf/closed/wall/f13/supermart,
+/area/f13/building)
 "ayE" = (
 /obj/item/storage/money_stack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -806,6 +934,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"azv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "azz" = (
 /obj/item/ammo_casing/a556,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -1001,6 +1135,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"aGc" = (
+/obj/structure/table,
+/obj/item/trash/f13/electronic/toaster,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
+"aGS" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/mob_spawn/human/corpse/raider,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "aHo" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -1047,6 +1200,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"aIy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/building)
 "aIN" = (
 /obj/structure/closet/crate/bin,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -1074,6 +1232,14 @@
 	icon_state = "verticalleftborderright2"
 	},
 /area/f13/wasteland)
+"aJd" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/carpet,
+/area/f13/building)
 "aJe" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13{
@@ -1085,6 +1251,17 @@
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
+"aJN" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "aKs" = (
 /obj/item/clothing/shoes/sneakers/black,
 /turf/open/floor/f13/wood,
@@ -1101,6 +1278,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
+"aLc" = (
+/obj/item/reagent_containers/food/snacks/f13/canned/dog,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "aLg" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/attachments,
@@ -1135,6 +1318,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"aMb" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/building)
 "aMl" = (
 /obj/structure/chair/bench,
 /obj/machinery/light/small{
@@ -1211,6 +1399,11 @@
 "aOc" = (
 /obj/structure/simple_door/dirtyglass,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"aOg" = (
+/obj/machinery/washing_machine,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
 "aOE" = (
 /obj/structure/displaycase,
@@ -1460,6 +1653,15 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/brotherhood)
+"aWj" = (
+/obj/structure/rack,
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/storage/box/papersack,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "aWz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt{
@@ -1473,6 +1675,11 @@
 	icon_state = "sheetUSA"
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"aWV" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
 "aXu" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -1596,6 +1803,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"aZQ" = (
+/obj/structure/fluff/railing{
+	dir = 5
+	},
+/turf/open/water,
+/area/f13/building)
 "bal" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -1610,6 +1823,34 @@
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"bbj" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white/side{
+	dir = 4
+	},
+/area/f13/building)
+"bbp" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table/wood,
+/obj/item/clothing/mask/cigarette/dromedary,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
+"bbq" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/spawner/lootdrop/trash,
+/obj/machinery/button/door{
+	id = "jewellershutters";
+	name = "Prestige Jewellers shutters";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "bby" = (
 /obj/structure/decoration/vent,
 /turf/closed/wall/f13/wood,
@@ -1673,6 +1914,27 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt"
+	},
+/area/f13/building)
+"bcX" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/closet/cardboard,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"bdp" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table/wood,
+/obj/item/newspaper,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
 "bdG" = (
@@ -1834,6 +2096,16 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"bka" = (
+/obj/structure/toilet,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "bkc" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -1890,6 +2162,14 @@
 /obj/structure/decoration/shock,
 /turf/closed/wall/rust,
 /area/f13/caves)
+"blM" = (
+/obj/structure/flora/grass/wasteland{
+	pixel_x = -3
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "hole"
+	},
+/area/f13/wasteland)
 "blS" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small/broken{
@@ -2134,6 +2414,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"brK" = (
+/obj/item/gun/ballistic/automatic/pistol/ninemil,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "brZ" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -2248,6 +2538,17 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"bvV" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "bwn" = (
@@ -2476,12 +2777,34 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"bBZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/machinery/light{
+	pixel_x = 16
+	},
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white/side,
+/area/f13/building)
 "bCG" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/brotherhood)
+"bDl" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "bDr" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/worn,
@@ -2490,11 +2813,29 @@
 /obj/item/clothing/under/f13/bluedress,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"bDt" = (
+/obj/structure/displaycase,
+/obj/item/clothing/glasses/monocle,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 4;
+	pixel_y = -16
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "bDy" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/breadhard,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"bDM" = (
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/wasteland)
 "bDO" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
@@ -2625,6 +2966,17 @@
 "bIp" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/brotherhood)
+"bIF" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barbariancomicshutters";
+	layer = 11;
+	name = "Barbarians Dungeon Comics"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "bIX" = (
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/indestructible/ground/outside/ruins{
@@ -2654,11 +3006,27 @@
 	icon_state = "horizontalinnermain2right"
 	},
 /area/f13/wasteland)
+"bJC" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "bKa" = (
 /obj/item/clothing/head/rice_hat,
 /obj/structure/displaycase,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
+	},
+/area/f13/building)
+"bKn" = (
+/obj/machinery/door/window/eastleft,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/building)
 "bKv" = (
@@ -2736,10 +3104,39 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"bNA" = (
+/obj/item/stack/sheet/mineral/wood,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 6;
+	icon_state = "rubble"
+	},
+/area/f13/wasteland)
+"bNL" = (
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/wood/f13/old/ruinedstraightnorth,
+/area/f13/wasteland)
 "bOe" = (
 /obj/structure/debris/v3,
 /turf/open/water,
 /area/f13/caves)
+"bOj" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "sullivanssuitsshutters";
+	layer = 11;
+	name = "Sullivans Suits"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "bOq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -2826,6 +3223,12 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"bQX" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "bRb" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/f13/leatherarmor,
@@ -2836,6 +3239,10 @@
 /obj/effect/spawner/lootdrop/clothing_low,
 /obj/item/storage/bag/plants,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"bRi" = (
+/obj/structure/debris/v2,
+/turf/closed/wall/f13/ruins,
 /area/f13/building)
 "bRq" = (
 /obj/structure/chair/bench{
@@ -2944,6 +3351,17 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
+"bUL" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleslab"
+	},
+/area/f13/wasteland)
 "bUR" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/floor/wood/f13/oak,
@@ -3038,6 +3456,16 @@
 	icon_state = "bar"
 	},
 /area/f13/bar)
+"bZN" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table,
+/obj/item/storage/fancy/cigarettes/cigpack_greytort,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "bZT" = (
 /obj/structure/chair/f13chair2{
 	dir = 1
@@ -3097,6 +3525,10 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"ccE" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "ccF" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -3420,6 +3852,17 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"cnJ" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/spawner/lootdrop/trash,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "cnL" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb,
@@ -3440,6 +3883,10 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
+"cok" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "cos" = (
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
@@ -3522,6 +3969,18 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"crb" = (
+/obj/structure/debris/v2,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleplate"
+	},
+/area/f13/building)
 "crp" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/f13{
@@ -3718,6 +4177,15 @@
 /mob/living/simple_animal/hostile/wolf/alpha,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"cAg" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "cAs" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 8;
@@ -3736,6 +4204,14 @@
 /obj/item/clothing/gloves/color/latex/nitrile,
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"cBq" = (
+/obj/structure/rack,
+/obj/item/storage/backpack,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "cBC" = (
 /obj/machinery/light/small{
@@ -3822,6 +4298,21 @@
 /obj/structure/billboard/cola,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"cFq" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/item/gun/ballistic/automatic/pistol/beretta,
+/obj/item/clothing/head/f13/police,
+/obj/item/clothing/under/f13/police,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "cGj" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -3869,6 +4360,15 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland)
+"cGS" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "cGV" = (
 /obj/structure/barricade/wooden,
 /turf/closed/mineral/random/low_chance,
@@ -3901,11 +4401,35 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/building)
+"cHw" = (
+/obj/structure/barricade/bars{
+	layer = 5
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "cHF" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/wood/fifty,
 /obj/item/assembly/igniter,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"cHL" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "jewellershutters";
+	layer = 11;
+	name = "Prestige Jewellers"
+	},
+/turf/open/floor/wood/wood_tiled,
 /area/f13/building)
 "cIh" = (
 /obj/structure/closet,
@@ -4145,6 +4669,13 @@
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"cQH" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/f13/oakbroken,
+/area/f13/building)
 "cRh" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
@@ -4193,6 +4724,12 @@
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"cSL" = (
+/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/cheesie,
+/turf/open/floor/carpet,
+/area/f13/building)
 "cST" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/dirt,
@@ -4205,10 +4742,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/brotherhood)
+"cTl" = (
+/obj/structure/sign/poster/contraband/the_griffin{
+	pixel_y = 32
+	},
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/carpet,
+/area/f13/building)
 "cTp" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"cTy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "aesculapius"
+	},
+/area/f13/building)
 "cTK" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -4348,6 +4902,13 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/building)
+"cXe" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "cXh" = (
 /obj/machinery/power/smes,
 /obj/structure/cable{
@@ -4365,6 +4926,12 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"cXp" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
 "cXU" = (
 /obj/machinery/door/airlock/hatch{
 	req_access_txt = "120"
@@ -4401,6 +4968,18 @@
 /obj/structure/sign/poster/contraband/pinup_vixen,
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
+"cYX" = (
+/obj/structure/table/wood,
+/obj/structure/junk/small/tv{
+	desc = "Advertisements would've played on this tv before the bombs dropped.";
+	name = "pre-war advertising television";
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/turf/open/floor/wood/f13/old{
+	icon_state = "housebase"
+	},
+/area/f13/building)
 "cYY" = (
 /obj/machinery/vending/coffee,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4474,7 +5053,8 @@
 "dbH" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left"
+	dir = 4;
+	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland)
 "dbI" = (
@@ -4540,6 +5120,15 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/city)
+"dea" = (
+/obj/item/stack/sheet/mineral/wood,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/old{
+	icon_state = "housebase"
+	},
+/area/f13/wasteland)
 "deE" = (
 /obj/structure/chair/wood/modern{
 	dir = 8;
@@ -4598,6 +5187,16 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"dgp" = (
+/obj/item/paper/pamphlet{
+	desc = "a trashy prewar comic book";
+	name = "prewar comic book"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/carpet,
+/area/f13/building)
 "dgs" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -4662,6 +5261,14 @@
 	},
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"dhQ" = (
+/obj/structure/displaycase,
+/obj/item/clothing/gloves/ring/silver,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "did" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -4691,6 +5298,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"diH" = (
+/obj/structure/rack,
+/obj/item/stack/medical/gauze,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/building)
 "diK" = (
 /obj/structure/car/rubbish1,
 /turf/closed/mineral/random/low_chance,
@@ -4719,6 +5332,10 @@
 	tame = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"djt" = (
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "djI" = (
 /obj/machinery/workbench,
@@ -4825,9 +5442,24 @@
 /obj/structure/chair/wood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"dlY" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/carpet,
+/area/f13/building)
 "dmm" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
+"dmF" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "dmJ" = (
 /obj/structure/simple_door/metal/store{
@@ -4863,6 +5495,21 @@
 	icon_state = "verticalleftborderright2"
 	},
 /area/f13/building)
+"dnt" = (
+/obj/structure/urinal{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/corner{
+	dir = 8
+	},
+/area/f13/building)
 "dnA" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -4887,6 +5534,13 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
+/area/f13/building)
+"doD" = (
+/obj/structure/chair/right{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
 "doM" = (
 /obj/structure/ore_box,
@@ -4926,6 +5580,21 @@
 	dir = 6
 	},
 /area/f13/building)
+"dpE" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "dpG" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/f13{
@@ -4953,6 +5622,14 @@
 "dqn" = (
 /obj/item/clothing/under/f13/cowboyg,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"dqr" = (
+/obj/structure/displaycase,
+/obj/item/clothing/accessory/necklace,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/wood_tiled,
 /area/f13/building)
 "dre" = (
 /obj/structure/table/wood/settler,
@@ -4997,6 +5674,13 @@
 /obj/structure/bed/mattress,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"dsS" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "dsW" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
@@ -5048,6 +5732,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"dum" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2right"
+	},
+/area/f13/wasteland)
 "dux" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/desert,
@@ -5109,6 +5799,13 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
+"dwy" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "dwP" = (
 /obj/structure/table/wood/fancy/royalblack,
 /turf/open/floor/wood/f13/oak,
@@ -5202,6 +5899,12 @@
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"dzS" = (
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "dAg" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3"
@@ -5283,6 +5986,31 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"dBP" = (
+/obj/structure/rack,
+/obj/item/clothing/head/fedora/det_hat,
+/obj/item/clothing/head/fedora,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
+"dCb" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "loading2";
+	layer = 11;
+	name = "Loading Bay 2"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "dCc" = (
 /obj/structure/flora/tree/tall{
 	layer = 2;
@@ -5311,6 +6039,15 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "bar"
+	},
+/area/f13/building)
+"dDe" = (
+/obj/effect/decal/marking,
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/building)
 "dDh" = (
@@ -5353,6 +6090,14 @@
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"dDM" = (
+/obj/machinery/vending/nukacolavendfull,
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "dEc" = (
 /obj/structure/closet/cabinet/anchored,
 /obj/item/clothing/under/f13/wayfarer/hunter,
@@ -5406,6 +6151,12 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"dGL" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oakbroken4,
 /area/f13/building)
 "dGQ" = (
 /obj/structure/table/reinforced,
@@ -5504,6 +6255,15 @@
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
+"dKs" = (
+/obj/structure/simple_door/house,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "dKA" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -5581,6 +6341,16 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"dNv" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 4;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "dNT" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright1"
@@ -5711,6 +6481,24 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"dSn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	pixel_x = 16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building)
+"dSB" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "dSY" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -5841,6 +6629,20 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"dXp" = (
+/obj/structure/sign/poster/contraband/pinup_vixen{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = 16
+	},
+/obj/item/toy/talking/AI,
+/turf/open/floor/carpet,
+/area/f13/building)
 "dXy" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2"
@@ -5872,6 +6674,19 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/ncr)
+"dZs" = (
+/obj/structure/window/fulltile/house{
+	dir = 2
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "mallfrontshutter";
+	layer = 11;
+	name = "Yuma mall"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "dZE" = (
 /obj/structure/fireplace,
 /turf/open/floor/carpet/black,
@@ -5889,6 +6704,19 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
+/area/f13/building)
+"dZZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
+"eai" = (
+/obj/structure/displaycase,
+/obj/item/clothing/gloves/ring,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/wood_tiled,
 /area/f13/building)
 "ean" = (
 /obj/structure/table/wood,
@@ -5939,6 +6767,19 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"ebI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/drinks/bottle/instacocoa,
+/obj/item/reagent_containers/food/drinks/bottle/instacoffee,
+/obj/item/reagent_containers/food/drinks/bottle/instatea,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/drinks/bottle/cream,
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "ebK" = (
 /obj/item/trash/cheesie,
 /turf/open/floor/f13/wood,
@@ -6008,6 +6849,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"eeh" = (
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
+	},
+/area/f13/wasteland)
 "eei" = (
 /obj/item/chair/stool/retro/black,
 /turf/open/indestructible/ground/outside/dirt,
@@ -6315,6 +7162,23 @@
 /obj/structure/decoration/clock/old,
 /turf/closed/wall/f13/store,
 /area/f13/building)
+"enF" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
+"enG" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/f13/building)
 "enL" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder{
@@ -6333,6 +7197,15 @@
 /obj/structure/mopbucket,
 /obj/item/mop,
 /turf/open/floor/plasteel/floorgrime,
+/area/f13/building)
+"eof" = (
+/mob/living/simple_animal/hostile/handy,
+/obj/effect/turf_decal/box/white,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/closet/cardboard,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
 "eoi" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -6378,6 +7251,10 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"ept" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "epF" = (
 /obj/item/clothing/under/f13/police,
 /obj/item/clothing/head/f13/police,
@@ -6429,6 +7306,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"eqC" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "eqF" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -6519,6 +7401,19 @@
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland)
+"etU" = (
+/obj/structure/rack,
+/obj/item/clothing/under/f13/cowboyb,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/clothing/suit/f13/vest,
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = 16
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "etV" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6526,6 +7421,14 @@
 	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
+"eue" = (
+/obj/item/chair/stool,
+/obj/item/paper/crumpled,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/carpet,
+/area/f13/building)
 "euj" = (
 /obj/structure/fence{
 	dir = 4
@@ -6653,6 +7556,15 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"exC" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "exL" = (
 /obj/item/twohanded/required/kirbyplants/dead,
@@ -6861,6 +7773,17 @@
 /obj/item/stack/f13Cash/random/med,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"eDV" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleplate"
+	},
+/area/f13/building)
 "eEz" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6934,6 +7857,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"eGG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/f13/building)
 "eHj" = (
 /obj/structure/closet,
 /obj/item/restraints/handcuffs,
@@ -6989,6 +7916,12 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"eIN" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white/side,
+/area/f13/building)
 "eIU" = (
 /obj/machinery/light/small,
 /obj/item/storage/trash_stack,
@@ -7035,6 +7968,16 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"eJs" = (
+/obj/structure/simple_door/metal/dirtystore,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ricksoutdoorshutters";
+	layer = 11;
+	name = "Ricks Outdoor Goods"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "eJv" = (
 /obj/structure/table/reinforced,
 /obj/item/phone,
@@ -7111,6 +8054,12 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"eKT" = (
+/obj/structure/simple_door/metal/dirtystore,
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "eLe" = (
 /obj/structure/sink{
 	pixel_y = 15
@@ -7316,6 +8265,9 @@
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/f13,
 /area/f13/building)
+"eQN" = (
+/turf/open/floor/wood/f13/old/ruinedstraightwest,
+/area/f13/wasteland)
 "eQR" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
@@ -7363,6 +8315,19 @@
 /obj/item/storage/pill_bottle/chem_tin/radx,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"eSy" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/storage/trash_stack,
+/obj/machinery/light/broken{
+	dir = 4;
+	pixel_y = -16
+	},
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubblepillar"
+	},
+/area/f13/wasteland)
 "eST" = (
 /obj/structure/rack,
 /obj/item/claymore/machete/warclub,
@@ -7375,11 +8340,36 @@
 	icon_state = "horizontaltopbordertopright"
 	},
 /area/f13/wasteland)
+"eSZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = 16
+	},
+/obj/structure/sign/poster/prewar/poster90{
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building)
 "eTq" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"eTA" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "eTJ" = (
 /obj/machinery/light/small,
 /obj/effect/decal/remains/human,
@@ -7445,6 +8435,15 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/village)
+"eUJ" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "eUQ" = (
 /mob/living/simple_animal/hostile/gecko,
 /obj/effect/decal/cleanable/dirt,
@@ -7552,6 +8551,21 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"eYy" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/junk/cabinet,
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleplate"
+	},
+/area/f13/building)
 "eYz" = (
 /obj/machinery/smartfridge/bottlerack/seedbin,
 /turf/open/floor/wood/f13/oak,
@@ -7688,6 +8702,8 @@
 /obj/item/storage/box/papersack,
 /obj/item/storage/box/papersack,
 /obj/item/storage/box/papersack,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -7795,6 +8811,16 @@
 	icon_state = "hole"
 	},
 /area/f13/wasteland)
+"feK" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
 "feL" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8162,6 +9188,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"fqv" = (
+/obj/structure/rack,
+/obj/item/storage/fancy/cigarettes/cigpack_robustgold,
+/obj/item/storage/fancy/cigarettes/cigpack_greytort,
+/obj/item/storage/fancy/cigarettes/cigpack_pyramid,
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "fqD" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -8394,12 +9432,25 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"fxh" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubblepillar"
+	},
+/area/f13/building)
 "fxx" = (
 /obj/item/picket_sign,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland)
+"fxD" = (
+/obj/structure/chalkboard,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "fxK" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/f13/police,
@@ -8415,6 +9466,15 @@
 "fyf" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"fyh" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/trash/raisins,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "fyo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -8577,6 +9637,13 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"fDc" = (
+/obj/structure/debris/v1,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/closed/wall/f13/ruins,
+/area/f13/building)
 "fDi" = (
 /obj/structure/window/fulltile/house/broken,
 /turf/open/floor/f13/wood,
@@ -8635,10 +9702,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "fGc" = (
-/obj/structure/car/rubbish2,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outermaincornerinner"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
 "fGh" = (
@@ -8665,6 +9733,19 @@
 	icon_state = "verticaloutermaintop"
 	},
 /area/f13/wasteland)
+"fHE" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ricksoutdoorshutters";
+	layer = 11;
+	name = "Ricks Outdoor Goods"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "fIn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cargocrate,
@@ -8744,6 +9825,17 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"fKD" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/button/door{
+	id = "ricksoutdoorshutters";
+	name = "Ricks Outdoor goods shutters";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "fKN" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -8786,12 +9878,21 @@
 "fMu" = (
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
+"fMI" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland)
 "fMO" = (
-/obj/item/ammo_casing/c10mm/ap{
-	dir = 5
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "fNb" = (
 /obj/item/shovel,
 /turf/open/indestructible/ground/inside/mountain,
@@ -9053,6 +10154,11 @@
 /mob/living/simple_animal/hostile/handy,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"fTN" = (
+/obj/item/toy/plush/beeplushie,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/f13/building)
 "fTT" = (
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/inside/mountain,
@@ -9061,9 +10167,27 @@
 /obj/structure/nest/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"fTZ" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "topshadowright"
+	},
+/area/f13/wasteland)
 "fUb" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"fUm" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -9237,6 +10361,18 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"gak" = (
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/obj/item/paper,
+/obj/item/pen,
+/obj/item/toy/figure/borg,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/carpet,
+/area/f13/building)
 "gaD" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 4
@@ -9347,6 +10483,15 @@
 "gcK" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"gdc" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/papersack,
+/obj/structure/window{
+	dir = 4
+	},
+/obj/item/stack/sheet/cardboard/twenty,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "gdJ" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
@@ -9538,6 +10683,18 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
+/area/f13/building)
+"giR" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table_frame,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/open/floor/wood/wood_tiled,
 /area/f13/building)
 "giX" = (
 /obj/machinery/vending/dinnerware,
@@ -9770,6 +10927,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"goM" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain2bottom"
+	},
+/area/f13/wasteland)
 "goO" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -9870,6 +11033,19 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/tunnel)
+"gqI" = (
+/obj/structure/table,
+/obj/item/stock_parts/manipulator/pico,
+/obj/item/stock_parts/manipulator/pico,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
 "grc" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -9896,6 +11072,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
+"grx" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/chair/office,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "grz" = (
 /obj/structure/fence{
 	dir = 8;
@@ -9999,6 +11184,29 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"gtD" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"gtM" = (
+/obj/structure/rack,
+/obj/item/storage/pill_bottle/mannitol,
+/obj/item/storage/pill_bottle/chem_tin/fixer,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/reagent_containers/hypospray/medipen/psycho,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building)
 "gtU" = (
 /obj/structure/fence{
 	dir = 1;
@@ -10018,6 +11226,18 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/village)
+"gut" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	pixel_x = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
+/area/f13/building)
 "guw" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -10084,6 +11304,14 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building)
+"gvT" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "topshadowleft"
+	},
+/area/f13/wasteland)
 "gvW" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
@@ -10092,6 +11320,17 @@
 /obj/structure/sink/puddle,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"gwp" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/closet/cardboard,
+/obj/item/stack/rods/twentyfive,
+/obj/item/radio/off,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "gwJ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -10105,6 +11344,12 @@
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"gxo" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "gxt" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plating,
@@ -10197,6 +11442,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"gBa" = (
+/obj/structure/simple_door/metal/dirtystore,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "jewellershutters";
+	layer = 11;
+	name = "Prestige Jewellers"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "gBd" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -10211,6 +11468,15 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"gBB" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "gBW" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -10257,6 +11523,12 @@
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"gCM" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oakbroken,
+/area/f13/building)
 "gCU" = (
 /obj/structure/toilet{
 	dir = 8
@@ -10452,6 +11724,31 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"gLK" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/wreck/trash/one_barrel,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"gLS" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
+"gLW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/clothing/head/bearpelt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "gLY" = (
 /obj/structure/chair/stool/retro,
 /turf/open/floor/wood/f13/oak,
@@ -10547,6 +11844,18 @@
 	icon_state = "gibbear1"
 	},
 /turf/open/floor/f13,
+/area/f13/building)
+"gOU" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/twohanded/sledgehammer,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "gPd" = (
 /obj/item/storage/fancy/rollingpapers,
@@ -10654,6 +11963,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/farm)
+"gSm" = (
+/obj/structure/flora/tree/wasteland,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "gSt" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerpavementcorner"
@@ -10665,6 +11979,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"gSB" = (
+/obj/structure/flora/tree/tall,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland)
 "gSG" = (
 /obj/machinery/microwave/stove,
 /obj/machinery/button/door{
@@ -10674,6 +11994,13 @@
 	req_one_access_txt = "28"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
+"gSS" = (
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "gTz" = (
 /obj/structure/closet,
@@ -10695,6 +12022,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
+"gTJ" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/carpet,
+/area/f13/building)
 "gTM" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -10712,6 +12043,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"gTU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "gVh" = (
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt,
@@ -10919,6 +12256,17 @@
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"hbj" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "sullivanssuitsshutters";
+	layer = 11;
+	name = "Sullivans Suits"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "hbm" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/brotherhood)
@@ -10954,6 +12302,14 @@
 /obj/item/pickaxe,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"hcw" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/flare,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hcI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -10992,6 +12348,23 @@
 /obj/effect/spawner/lootdrop/f13/cash_legion_low,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"hdF" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/chair/stool,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "hdW" = (
 /obj/structure/closet/crate/medical,
 /obj/item/reagent_containers/blood/radaway,
@@ -11020,16 +12393,24 @@
 	},
 /area/f13/wasteland)
 "heB" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain2bottom"
-	},
+/obj/structure/tires/five,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "heK" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"heS" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "heZ" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/ruins{
@@ -11164,6 +12545,20 @@
 /obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"hiq" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/sosjerky/ration,
+/obj/item/reagent_containers/food/snacks/sosjerky/ration,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/reagent_containers/food/snacks/meatsalted,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hiG" = (
 /obj/structure/decoration/clock{
 	pixel_y = 30
@@ -11249,6 +12644,15 @@
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"hkm" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/bottle/instacoffee,
+/obj/item/crafting/coffee_pot,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
 "hkr" = (
 /obj/structure/tires/two,
 /obj/effect/decal/cleanable/oil,
@@ -11374,6 +12778,22 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"hpa" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building)
+"hpb" = (
+/obj/structure/table,
+/obj/item/stock_parts/matter_bin/super,
+/obj/item/stock_parts/matter_bin/super,
+/obj/item/stock_parts/matter_bin/super,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
 "hpc" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/f13/wood,
@@ -11442,6 +12862,17 @@
 	icon_state = "booth_west_north"
 	},
 /turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"hqw" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "hqH" = (
 /obj/structure/tires/five{
@@ -11791,6 +13222,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
+"hzF" = (
+/obj/structure/simple_door/metal/dirtystore,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "hzG" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -11807,6 +13247,15 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"hzV" = (
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "shadowleft"
+	},
+/area/f13/wasteland)
+"hAk" = (
+/turf/open/floor/carpet,
 /area/f13/building)
 "hAC" = (
 /turf/open/indestructible/ground/outside/desert{
@@ -11958,6 +13407,14 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
+"hEN" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table/wood,
+/obj/item/storage/box/matches,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "hFb" = (
 /obj/structure/sink{
 	dir = 8
@@ -12081,6 +13538,18 @@
 	icon_state = "dirt"
 	},
 /area/f13/ncr)
+"hHV" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "pharmacyshutters";
+	layer = 11;
+	name = "Friendly Pharm"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/building)
 "hHY" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -12196,6 +13665,17 @@
 	},
 /turf/open/floor/plating,
 /area/f13/building)
+"hKL" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/chair/f13chair2{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "hKY" = (
 /obj/structure/table/wood,
 /obj/item/folder/yellow,
@@ -12207,6 +13687,12 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
+"hLn" = (
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/building)
 "hLs" = (
 /obj/structure/rack,
 /obj/item/shovel/spade,
@@ -12227,6 +13713,22 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/wasteland)
+"hLC" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "loading2";
+	layer = 11;
+	name = "Loading Bay 2"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "hMz" = (
 /obj/structure/stone_tile/block/burnt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12378,6 +13880,13 @@
 /obj/item/stack/ore/iron,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"hSz" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hSD" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -12608,6 +14117,15 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"hZx" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white/side{
+	dir = 4
+	},
+/area/f13/building)
 "hZD" = (
 /obj/structure/chair,
 /turf/open/floor/f13,
@@ -12667,6 +14185,12 @@
 /obj/structure/stone_tile/block/cracked,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"iaL" = (
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "ibi" = (
 /obj/structure/table/glass,
 /obj/item/radio/intercom,
@@ -12687,6 +14211,18 @@
 /obj/item/clothing/under/f13/mprostitute,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"ibJ" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "ibZ" = (
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/indestructible/ground/outside/road{
@@ -12831,6 +14367,12 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"ihF" = (
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "iic" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink/kitchen{
@@ -12865,6 +14407,15 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"iiF" = (
+/obj/structure/simple_door/metal/dirtystore,
+/obj/machinery/door/poddoor/shutters{
+	id = "mallfrontshutter";
+	layer = 11;
+	name = "Yuma mall"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "iiN" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -12890,6 +14441,17 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"ikg" = (
+/obj/structure/table,
+/obj/item/stock_parts/micro_laser/quadultra,
+/obj/item/clothing/glasses/regular/hipster,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "iku" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -12901,6 +14463,18 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/molerat,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"ilf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy,
+/obj/structure/closet/cardboard,
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/obj/item/trash/f13/electronic/toaster,
+/turf/open/floor/plasteel/f13/vault_floor/red/white/corner{
+	dir = 8
+	},
 /area/f13/building)
 "ill" = (
 /obj/structure/flora/rock/pile/largejungle,
@@ -13025,6 +14599,12 @@
 /obj/structure/stacklifter,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"ioH" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/closed/wall/f13/supermart,
+/area/f13/building)
 "ioP" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -13350,6 +14930,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"izb" = (
+/obj/effect/turf_decal/vg_decals/numbers/one,
+/obj/structure/car/rubbish1,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "izr" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -13422,6 +15012,11 @@
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"iBJ" = (
+/obj/structure/fluff/railing,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "iBK" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -13681,6 +15276,19 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"iII" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleplate"
+	},
+/area/f13/wasteland)
+"iIW" = (
+/obj/effect/decal/marking,
+/obj/structure/barricade/tentclothcorner,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "iJc" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -13703,6 +15311,13 @@
 /obj/item/clothing/under/f13/raiderharness,
 /obj/item/clothing/under/f13/raiderharness,
 /turf/open/floor/f13,
+/area/f13/building)
+"iJq" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
 "iJG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13737,6 +15352,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"iKc" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "iKm" = (
 /obj/machinery/workbench,
 /turf/open/floor/f13/wood,
@@ -13836,6 +15458,16 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/legion)
+"iMQ" = (
+/obj/structure/table/wood,
+/obj/item/paper/pamphlet{
+	desc = "a trashy prewar comic book";
+	name = "prewar comic book"
+	},
+/obj/item/evidencebag,
+/obj/item/clothing/gloves/color/latex,
+/turf/open/floor/carpet,
+/area/f13/building)
 "iNb" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -14008,6 +15640,21 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/f13,
 /area/f13/building)
+"iRk" = (
+/obj/item/dice/d20,
+/obj/item/pen,
+/obj/item/toy/figure/borg,
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	pixel_x = -16
+	},
+/turf/open/floor/carpet,
+/area/f13/building)
 "iRl" = (
 /obj/structure/table/booth,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -14039,6 +15686,20 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/village)
+"iRx" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	pixel_x = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
+	dir = 6
+	},
+/area/f13/building)
 "iRy" = (
 /obj/structure/chair/wood,
 /turf/open/floor/f13{
@@ -14195,6 +15856,22 @@
 /obj/structure/chair/f13chair2,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"iUX" = (
+/obj/structure/rack,
+/obj/item/clothing/under/rank/civilian/lawyer/really_black/skirt,
+/obj/item/clothing/under/rank/civilian/lawyer/black/alt/skirt,
+/obj/machinery/light{
+	pixel_x = -16
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
+"iVh" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_east_south"
+	},
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "iVo" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -14228,6 +15905,24 @@
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"iWm" = (
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
+"iWn" = (
+/obj/structure/rack,
+/obj/item/clothing/under/dress/redeveninggown,
+/obj/structure/rack,
+/obj/item/clothing/under/blacktango,
+/obj/item/clothing/gloves/evening/black,
+/obj/item/clothing/gloves/evening,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "iWV" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/helmet/f13/raider/eyebot,
@@ -14261,6 +15956,11 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/legion)
+"iYo" = (
+/turf/open/floor/wood/f13/old{
+	icon_state = "housebase"
+	},
+/area/f13/building)
 "iYv" = (
 /obj/structure/chair/stool{
 	icon_state = "bench_center"
@@ -14330,6 +16030,14 @@
 	},
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"iZJ" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/joy,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/carpet,
 /area/f13/building)
 "jae" = (
 /obj/effect/decal/marking{
@@ -14523,6 +16231,11 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"jeW" = (
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/f13/building)
 "jfj" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -14583,6 +16296,12 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"jgF" = (
+/obj/structure/rack,
+/obj/item/clothing/under/rank/civilian/lawyer/black/alt,
+/obj/item/clothing/under/lawyer/blacksuit,
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "jgG" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14699,6 +16418,13 @@
 /obj/item/pen/charcoal,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"jkn" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/bundle/f13/aer12,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "jkr" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -14874,6 +16600,15 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"jod" = (
+/obj/structure/rack,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/storage/box/actionfigure,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/figure/borg,
+/turf/open/floor/carpet,
+/area/f13/building)
 "joX" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_r,
@@ -14955,6 +16690,22 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"jsz" = (
+/obj/structure/displaycase,
+/obj/item/twohanded/fireaxe/boneaxe,
+/obj/item/clothing/head/helmet/knight/f13/metal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/carpet,
+/area/f13/building)
+"jsZ" = (
+/obj/structure/table,
+/obj/item/storage/part_replacer,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
 "jtc" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -14964,6 +16715,14 @@
 /obj/structure/chair/wood/fancy,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"jto" = (
+/mob/living/simple_animal/hostile/handy,
+/obj/effect/turf_decal/box/white,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
 "jts" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -15016,6 +16775,9 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/building)
+"jvr" = (
+/turf/closed/wall/f13/supermart,
+/area/f13/caves)
 "jvw" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
@@ -15052,6 +16814,16 @@
 /obj/item/flashlight/flare/torch,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"jwK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/f13/sugarbombs,
+/obj/item/trash/f13/crisps,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "jwM" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 8
@@ -15115,6 +16887,16 @@
 "jxo" = (
 /obj/item/twohanded/required/kirbyplants/photosynthetic,
 /turf/open/floor/plasteel/grimy,
+/area/f13/building)
+"jxp" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/closet,
+/obj/item/crafting/lunchbox,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "jxq" = (
 /turf/open/floor/f13/wood{
@@ -15194,6 +16976,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"jAb" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/red/white/side{
+	dir = 4
+	},
+/area/f13/building)
 "jAi" = (
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/wood/f13/carpet,
@@ -15227,6 +17018,18 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"jBy" = (
+/obj/structure/rack,
+/obj/item/book/granter/trait/trekking,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "jBH" = (
@@ -15328,6 +17131,17 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/ncr)
+"jGU" = (
+/obj/item/clothing/under/f13/petrochico,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/closet/cardboard,
+/obj/item/crafting/lunchbox,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "jGV" = (
 /obj/structure/table,
 /obj/item/kitchen/knife/butcher,
@@ -15341,6 +17155,7 @@
 /obj/machinery/light/broken{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -15351,6 +17166,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"jHO" = (
+/obj/structure/simple_door/metal/dirtystore,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "sullivanssuitsshutters";
+	layer = 11;
+	name = "Sullivans Suits"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "jIe" = (
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/dirt,
@@ -15398,6 +17223,14 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"jJq" = (
+/obj/structure/simple_door/tentflap_cloth{
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "jJB" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowright"
@@ -15478,6 +17311,15 @@
 "jMj" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/radiation)
+"jMB" = (
+/obj/structure/rack,
+/obj/item/paper/pamphlet{
+	desc = "a trashy prewar comic book";
+	name = "prewar comic book"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/f13/building)
 "jMC" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -15556,6 +17398,27 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"jOz" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/button/door{
+	id = "loading2";
+	name = "Loading Bay 2";
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/machinery/button/door{
+	id = "loading1";
+	name = "Loading Bay 1";
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "jOH" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/shovel,
@@ -15565,6 +17428,22 @@
 /obj/item/chair/wood,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"jPU" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "loading1";
+	layer = 11;
+	name = "Loading Bay 1"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "jQd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -15618,6 +17497,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
+"jRh" = (
+/obj/item/ammo_casing/c9mm,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "jRn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -15679,6 +17564,14 @@
 /obj/machinery/light/small,
 /turf/open/water,
 /area/f13/caves)
+"jSx" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/red/white/side{
+	dir = 4
+	},
+/area/f13/building)
 "jSD" = (
 /obj/structure/window/spawner,
 /obj/structure/rack,
@@ -15739,12 +17632,27 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"jUb" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
+	dir = 10
+	},
+/area/f13/building)
 "jUe" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
+"jUl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/building)
 "jUm" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowhorizontal"
@@ -15780,6 +17688,10 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
+/area/f13/building)
+"jVs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/supermart,
 /area/f13/building)
 "jVC" = (
 /obj/structure/window/fulltile/house{
@@ -15873,6 +17785,18 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"jXb" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbroken"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "mallfrontshutter";
+	layer = 11;
+	name = "Yuma mall"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "jXf" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/barber{
@@ -15937,6 +17861,13 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
+"jZB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	pixel_x = -16
+	},
+/turf/open/floor/carpet,
+/area/f13/building)
 "jZE" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2bottom"
@@ -16013,6 +17944,24 @@
 	icon_state = "cross2"
 	},
 /area/f13/wasteland)
+"kbz" = (
+/obj/structure/rack,
+/obj/item/storage/backpack/satchel/leather,
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
+"kbD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 1;
+	pixel_x = 16
+	},
+/obj/structure/sign/poster/prewar/poster67{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building)
 "kbF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/retro/backed{
@@ -16136,6 +18085,17 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"kfj" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "kfo" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -16223,6 +18183,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"khu" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/storage/box/papersack,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "khy" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -16244,6 +18212,11 @@
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland)
+"khI" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/carpet,
+/area/f13/building)
 "khU" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13/wood{
@@ -16295,6 +18268,21 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"kle" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
+/area/f13/building)
+"klh" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "klp" = (
 /obj/structure/closet/fridge/standard,
 /obj/item/storage/box/ingredients/american,
@@ -16344,6 +18332,14 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"koe" = (
+/obj/structure/table,
+/obj/item/circuitboard/machine/chem_heater,
+/obj/item/circuitboard/machine/chem_master,
+/obj/item/circuitboard/machine/chem_dispenser,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
 "kow" = (
 /obj/machinery/processor,
@@ -16443,6 +18439,18 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"kqF" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/newspaper,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "krb" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/f13/wood,
@@ -16519,6 +18527,21 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"ksX" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/closet/cardboard,
+/obj/item/stack/sheet/plastic/twenty,
+/obj/item/stack/rods/ten,
+/obj/item/stack/rods/ten,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "ktB" = (
 /turf/closed/indestructible/rock,
 /area/f13/caves)
@@ -16572,6 +18595,20 @@
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"kvG" = (
+/obj/structure/toilet,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/mob/living/simple_animal/hostile/ghoul,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "kwi" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -16772,6 +18809,17 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"kDp" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/button/door{
+	id = "barbariancomicshutters";
+	name = "Barbarians Dungeon Comics shutters";
+	pixel_y = -32
+	},
+/turf/open/floor/carpet,
+/area/f13/building)
 "kDQ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -16947,6 +18995,15 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"kIf" = (
+/obj/structure/table/reinforced,
+/obj/item/bodypart/l_leg/robot,
+/obj/item/screwdriver,
+/obj/item/bodypart/r_arm/robot,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "kIl" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/f13{
@@ -16977,6 +19034,13 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kJC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/red/white/side{
+	dir = 4
+	},
+/area/f13/building)
 "kKe" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -17006,6 +19070,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"kLg" = (
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
+/area/f13/building)
+"kLu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/building)
 "kLv" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -17015,6 +19087,14 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
+"kLy" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "hole"
+	},
+/area/f13/wasteland)
 "kLS" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/indestructible/ground/outside/road{
@@ -17208,6 +19288,24 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"kUf" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"kUj" = (
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "kUk" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -17305,6 +19403,15 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kVV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/fishingrod,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "kWC" = (
 /obj/structure/table/wood,
 /obj/item/storage/backpack/satchel/leather,
@@ -17359,11 +19466,28 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"kYG" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "kYH" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"kYQ" = (
+/obj/effect/turf_decal/vg_decals/numbers/two,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "kZb" = (
 /obj/structure/fence/wooden{
@@ -17382,6 +19506,15 @@
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"kZQ" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "lae" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -17412,6 +19545,13 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
+"lcV" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "lda" = (
 /obj/structure/decoration/clock{
 	pixel_y = 30
@@ -17595,6 +19735,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"lgB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/red/white/side{
+	dir = 4
+	},
+/area/f13/building)
 "lgI" = (
 /obj/structure/simple_door/metal/fence{
 	door_type = "fence_wood";
@@ -17894,11 +20040,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "lqQ" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2right"
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "mallfrontshutter";
+	name = "front shutters"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "lqU" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -18205,10 +20355,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "lAD" = (
-/obj/structure/table/wood,
-/obj/item/defibrillator/primitive, 
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "lAJ" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib3-old"
@@ -18237,6 +20394,17 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"lBT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/gun/ballistic/automatic/varmint,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/ammo_box/magazine/m556/rifle/small,
+/obj/item/ammo_box/magazine/m556/rifle/small,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "lBY" = (
 /obj/structure/bed/dogbed{
 	pixel_x = -10;
@@ -18314,6 +20482,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"lDM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/box/drinkingglasses,
+/obj/structure/rack,
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "lDN" = (
 /obj/structure/curtain{
 	color = "#c40e0e"
@@ -18346,6 +20524,14 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"lFh" = (
+/obj/item/stack/cable_coil,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "lFm" = (
 /obj/structure/chair/office,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -18381,6 +20567,11 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"lGq" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/diy,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
 "lGH" = (
 /mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/wood/f13/old,
@@ -18639,6 +20830,11 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"lPR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "lPT" = (
 /turf/closed/wall/f13/wood,
 /area/f13/wasteland)
@@ -18733,6 +20929,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"lSw" = (
+/obj/structure/table/wood,
+/obj/item/toy/figure/borg,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/carpet,
+/area/f13/building)
 "lSD" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -18826,6 +21030,14 @@
 "lUk" = (
 /obj/structure/decoration/clock/old/active,
 /turf/closed/wall/f13/store,
+/area/f13/building)
+"lUs" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white/side{
+	dir = 8
+	},
 /area/f13/building)
 "lUt" = (
 /obj/structure/rack,
@@ -18956,6 +21168,15 @@
 	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland)
+"maa" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/chair/f13chair2,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "mas" = (
 /obj/item/chair/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -18991,13 +21212,14 @@
 	},
 /area/f13/building)
 "mbm" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
+/obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "mbo" = (
 /obj/structure/cable{
 	icon_state = "1-10"
@@ -19288,6 +21510,17 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"mle" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white/side{
+	dir = 4
+	},
+/area/f13/building)
 "mlm" = (
 /obj/structure/simple_door/fakeglass,
 /turf/open/floor/f13{
@@ -19368,6 +21601,14 @@
 	dir = 1
 	},
 /area/f13/building)
+"mof" = (
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/diamond,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "moi" = (
 /obj/item/ammo_casing/caseless{
 	dir = 10;
@@ -19380,6 +21621,12 @@
 	icon_state = "outermaincornerouter"
 	},
 /area/f13/wasteland)
+"moz" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/carpet,
+/area/f13/building)
 "moA" = (
 /obj/structure/chair{
 	dir = 8;
@@ -19491,6 +21738,18 @@
 /obj/item/clothing/shoes/sneakers/brown,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"msf" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/obj/item/storage/belt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "msw" = (
 /obj/structure/rack,
 /obj/item/storage/belt,
@@ -19582,6 +21841,10 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"mvC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "mvJ" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -19683,6 +21946,24 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"mzL" = (
+/obj/structure/debris/v1{
+	pixel_x = -16
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubblepillar"
+	},
+/area/f13/building)
+"mzW" = (
+/obj/machinery/door/window/eastleft,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "mzY" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -19706,6 +21987,12 @@
 	icon_state = "horizontalbottombordertop2"
 	},
 /area/f13/wasteland)
+"mBc" = (
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
+	},
+/area/f13/wasteland)
 "mBd" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/outside/desert,
@@ -19725,6 +22012,16 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2"
 	},
+/area/f13/building)
+"mBZ" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/storage/box/papersack,
+/obj/machinery/light/broken{
+	pixel_x = 16
+	},
+/turf/open/floor/carpet,
 /area/f13/building)
 "mCf" = (
 /obj/structure/decoration/rag{
@@ -19759,6 +22056,12 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"mEE" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "mEK" = (
 /obj/structure/simple_door/metal/fence{
 	dir = 8
@@ -19820,6 +22123,16 @@
 /obj/structure/closet/crate/bin,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"mHk" = (
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/kitchen/knife/combat,
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleplate"
+	},
+/area/f13/wasteland)
 "mHt" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	icon_state = "floor5-old"
@@ -19832,6 +22145,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"mHB" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/f13/building)
 "mHS" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/plasteel/barber{
@@ -19919,6 +22236,10 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/tunnel)
+"mKk" = (
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/wood/f13/old/ruinedstraightsouth,
+/area/f13/wasteland)
 "mKm" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/meat/slab/gecko,
@@ -19983,6 +22304,22 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"mMk" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
+"mMu" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"mMB" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/supermart,
+/area/f13/caves)
 "mNi" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/indestructible/ground/outside/ruins,
@@ -20020,6 +22357,15 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"mOq" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "mOv" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -20214,6 +22560,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mVp" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "mVv" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -20261,6 +22616,19 @@
 /obj/item/kitchen/knife/combat/bone,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
+"mWE" = (
+/obj/item/stock_parts/scanning_module/triphasic,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
+"mWI" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/wasteland)
 "mWN" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -20270,6 +22638,10 @@
 /obj/structure/reagent_dispensers/barrel/two,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"mXy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "mXA" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/city)
@@ -20378,6 +22750,12 @@
 "nax" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/city)
+"naI" = (
+/obj/structure/rack,
+/obj/item/clothing/neck/tie/black,
+/obj/item/clothing/accessory/pocketprotector/full,
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "naP" = (
 /obj/structure/chair{
 	dir = 8
@@ -20583,6 +22961,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
+"ngU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "ngX" = (
 /obj/structure/chair/wood/modern{
 	dir = 1
@@ -20724,10 +23109,24 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"nmm" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/storage/trash_stack,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "nmq" = (
 /obj/structure/sign/poster/contraband/pinup_topless,
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
+"nmN" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/building)
 "nmS" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -20740,6 +23139,22 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood)
+"nnf" = (
+/obj/structure/rack,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/button/door{
+	id = "sullivanssuitsshutters";
+	name = "Sullivans Suits shutters";
+	pixel_y = -32
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "nnn" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/shower{
@@ -20749,6 +23164,10 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
+/area/f13/building)
+"nnH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_tiled,
 /area/f13/building)
 "nnP" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -20791,6 +23210,16 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
+/area/f13/building)
+"npI" = (
+/obj/structure/simple_door/metal/dirtystore,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/poddoor/shutters{
+	id = "genatomicsshutters";
+	layer = 11;
+	name = "General Atomics"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
 "npL" = (
 /obj/item/clothing/suit/f13/duster,
@@ -20876,6 +23305,17 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"nsk" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/flashlight/seclite,
+/obj/item/clothing/head/f13/police,
+/obj/item/clothing/under/f13/police,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "nss" = (
 /obj/structure/chair/stool/retro/backed{
 	dir = 1
@@ -20924,6 +23364,12 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
+"nvq" = (
+/obj/structure/displaycase,
+/obj/item/toy/katana,
+/obj/item/clothing/under/costume/schoolgirl/red,
+/turf/open/floor/carpet,
+/area/f13/building)
 "nvr" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20950,6 +23396,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"nwC" = (
+/obj/machinery/workbench,
+/obj/item/crafting/reloader,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "nwQ" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 4
@@ -21003,6 +23457,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/city)
+"nxU" = (
+/obj/item/paper/crumpled,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "nxY" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -21010,6 +23471,17 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"nxZ" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "nyc" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
@@ -21054,6 +23526,15 @@
 /obj/item/seeds/poppy/broc,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
+"nzV" = (
+/obj/structure/car/rubbish2,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor2"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "nAh" = (
 /obj/machinery/light/small,
 /turf/open/water,
@@ -21098,6 +23579,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"nCo" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/chair/stool,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "nCS" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -21120,6 +23615,15 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"nDg" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticaltop"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
+	},
+/area/f13/wasteland)
 "nDk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/two_tire,
@@ -21127,6 +23631,21 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/brotherhood)
+"nDx" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
+	},
+/area/f13/wasteland)
+"nDG" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "nDJ" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/stone_tile/slab/burnt,
@@ -21176,6 +23695,26 @@
 	icon_state = "shadowleft"
 	},
 /area/f13/wasteland)
+"nFT" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/fo13colored/Red{
+	dir = 8
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"nFV" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubble"
+	},
+/area/f13/wasteland)
 "nGq" = (
 /turf/closed/wall/f13/store,
 /area/f13/wasteland)
@@ -21204,6 +23743,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"nHI" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/vending/nukacolavendfull,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "nHL" = (
 /obj/structure/rack,
 /obj/item/seeds/xander,
@@ -21268,6 +23816,15 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/building)
+"nJq" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/rack,
+/obj/item/circuitboard/computer/arcade/battle,
+/obj/item/circuitboard/computer/arcade/orion_trail,
+/turf/open/floor/carpet,
 /area/f13/building)
 "nJT" = (
 /obj/machinery/light/small,
@@ -21371,6 +23928,17 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"nNo" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "nNB" = (
 /obj/structure/table/wood/settler,
 /obj/item/paper,
@@ -21708,6 +24276,17 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
+"nYW" = (
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "nZr" = (
 /mob/living/simple_animal/hostile/wolf,
 /turf/open/indestructible/ground/outside/desert,
@@ -21715,6 +24294,16 @@
 "nZy" = (
 /obj/effect/landmark/start/f13/deputy,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"nZD" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/wreck/trash/one_barrel,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "nZJ" = (
 /obj/structure/car/rubbish3,
@@ -21928,6 +24517,17 @@
 /obj/machinery/light/broken,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"ohY" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "genatomicsshutters";
+	layer = 11;
+	name = "General Atomics"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
 "oil" = (
 /obj/machinery/computer/shuttle/northbunkerelevator,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -21956,6 +24556,8 @@
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -22075,6 +24677,17 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"omq" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "sullivanssuitsshutters";
+	layer = 11;
+	name = "Sullivans Suits"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "omF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -22140,16 +24753,16 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "ooh" = (
-/obj/structure/table/wood,
-/obj/item/paper/bitterdrink{
-	pixel_x = -10
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/item/reagent_containers/pill/patch/bitterdrink{
-	pixel_x = 6;
-	pixel_y = 6
+/obj/structure/closet/cardboard,
+/obj/item/crafting/abraxo,
+/obj/item/kitchen/knife/cosmicdirty,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/building)
 "oom" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -22243,6 +24856,22 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"orw" = (
+/obj/structure/toilet,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "orG" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
@@ -22267,6 +24896,12 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"osD" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_east_south"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "osF" = (
 /obj/item/clothing/head/helmet/f13/deathskull,
 /obj/item/clothing/head/helmet/f13/deathskull,
@@ -22293,9 +24928,28 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "otv" = (
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/supermart,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"otH" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/kitchen/knife/combat,
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleplate"
+	},
+/area/f13/building)
 "otI" = (
 /obj/structure/rack,
 /obj/item/seeds/chili,
@@ -22539,6 +25193,16 @@
 "oAV" = (
 /turf/open/floor/wood/f13/stage_bl,
 /area/f13/building)
+"oBf" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "oBj" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -22619,6 +25283,15 @@
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"oFD" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "oFP" = (
 /turf/closed/wall/f13/tentwall,
 /area/f13/building)
@@ -22696,6 +25369,13 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"oHn" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_east_north"
+	},
+/obj/item/newspaper,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "oHu" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -22721,6 +25401,17 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"oIi" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "oIm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/barber{
@@ -22818,6 +25509,14 @@
 	icon_state = "horizontalbottomborderbottom3"
 	},
 /area/f13/wasteland)
+"oKW" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
+"oLm" = (
+/obj/structure/simple_door/house,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
+/area/f13/building)
 "oLL" = (
 /obj/structure/closet/crate/bin,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22889,6 +25588,22 @@
 /obj/item/clothing/head/helmet/f13/raidercombathelmet,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"oOi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 1;
+	pixel_x = 16
+	},
+/obj/item/gun/ballistic/shotgun/remington,
+/obj/item/attachments/scope,
+/obj/item/ammo_box/a308,
+/obj/item/ammo_box/a308,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "oON" = (
 /obj/machinery/button/door{
 	id = "soupkitchen";
@@ -22908,6 +25623,14 @@
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
+"oPl" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "oPB" = (
 /obj/structure/fence{
 	dir = 4
@@ -23053,6 +25776,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"oTY" = (
+/obj/item/mop,
+/obj/structure/mopbucket,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
+	dir = 4
+	},
+/area/f13/building)
 "oUo" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
@@ -23156,6 +25889,14 @@
 /obj/item/kitchen/knife/bowie,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"oXR" = (
+/obj/structure/fluff/railing,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "oXV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -23174,6 +25915,13 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/tunnel)
+"oZf" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerbordercorner"
+	},
+/area/f13/wasteland)
 "oZg" = (
 /mob/living/simple_animal/chick,
 /turf/open/indestructible/ground/inside/mountain,
@@ -23200,6 +25948,17 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/building)
+"pal" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/flashlight{
+	icon_state = "seclite"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "pao" = (
 /obj/structure/chair/left,
@@ -23337,6 +26096,12 @@
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"pdR" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "pea" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -23534,6 +26299,14 @@
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"piA" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3"
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland)
 "piN" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -23548,6 +26321,17 @@
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
+/area/f13/building)
+"pjc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/obj/effect/spawner/lootdrop/trash,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
 "pjD" = (
 /obj/structure/table,
@@ -23630,6 +26414,17 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"pmW" = (
+/obj/structure/decoration/train{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/snack,
+/turf/open/floor/carpet,
+/area/f13/building)
 "pne" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13{
@@ -24121,6 +26916,13 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"pBj" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "pBp" = (
 /obj/structure/simple_door/metal/fence,
 /obj/structure/decoration/rag,
@@ -24170,6 +26972,12 @@
 /obj/machinery/grill,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"pDa" = (
+/obj/structure/campfire,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "pDi" = (
 /obj/structure/table,
 /obj/structure/table,
@@ -24178,12 +26986,31 @@
 	},
 /turf/open/floor/plating,
 /area/f13/tunnel)
+"pDv" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleslab"
+	},
+/area/f13/wasteland)
 "pDJ" = (
 /obj/structure/lamp_post/quadra,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2bottom"
 	},
 /area/f13/wasteland)
+"pDO" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "pDR" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/f13{
@@ -24261,6 +27088,26 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
+"pGH" = (
+/obj/structure/rack,
+/obj/item/paper/pamphlet{
+	desc = "a trashy prewar comic book";
+	name = "prewar comic book"
+	},
+/obj/item/paper/pamphlet{
+	desc = "a trashy prewar comic book";
+	name = "prewar comic book"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 1;
+	pixel_x = 16
+	},
+/turf/open/floor/carpet,
+/area/f13/building)
 "pGM" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
@@ -24350,6 +27197,23 @@
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"pIM" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/obj/machinery/light/broken{
+	dir = 1;
+	pixel_x = 16
+	},
+/obj/structure/closet/cardboard,
+/mob/living/simple_animal/hostile/handy,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
 "pIO" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -24386,6 +27250,11 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
+/area/f13/wasteland)
+"pJU" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
 "pJY" = (
 /obj/machinery/light/small/broken{
@@ -24472,6 +27341,21 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/caves)
+"pLz" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbroken"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "mallfrontshutter";
+	layer = 11;
+	name = "Yuma mall"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "pLD" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/dirt{
@@ -24518,6 +27402,25 @@
 "pMI" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/wasteland)
+"pMR" = (
+/obj/structure/simple_door/house,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"pNl" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Security"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "pNw" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -24601,6 +27504,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"pOS" = (
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "pPe" = (
 /obj/structure/fence{
 	dir = 4
@@ -24638,6 +27548,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"pQp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/obj/item/clothing/head/fedora/det_hat,
+/obj/item/clothing/under/f13/cowboyt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "pQx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -24651,6 +27568,15 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/legion)
+"pQM" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/closet/cardboard,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "pQX" = (
 /obj/structure/fence/post{
 	desc = "A wooden post.";
@@ -24804,6 +27730,24 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/building)
+"pUQ" = (
+/obj/structure/fluff/railing{
+	dir = 9
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/water,
+/area/f13/building)
+"pUR" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Business"
+	},
+/obj/machinery/light/broken{
+	pixel_x = 16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
 "pVD" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -24885,6 +27829,19 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
+/area/f13/building)
+"pXC" = (
+/obj/machinery/door/window/eastleft{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building)
 "pXR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25081,6 +28038,14 @@
 	icon_state = "horizontaltopborderbottom2"
 	},
 /area/f13/wasteland)
+"qdB" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "qdD" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
@@ -25130,6 +28095,17 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"qev" = (
+/obj/structure/table/wood/settler,
+/obj/item/storage/fancy/cigarettes/cigpack_pyramid,
+/obj/item/reagent_containers/food/drinks/beer/light{
+	desc = "An old bottle of beer, scavenged and somehow unbroken. The label has been sun-bleached to the point of being illegible.";
+	name = "Salvaged Beer"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
+	},
+/area/f13/wasteland)
 "qeM" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -25154,6 +28130,24 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/tunnel)
+"qfu" = (
+/obj/structure/simple_door/house,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"qfA" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	layer = 6;
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland)
 "qfV" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
@@ -25249,6 +28243,11 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"qjl" = (
+/obj/structure/table/glass,
+/obj/machinery/light/broken,
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "qjm" = (
 /obj/structure/fence{
 	dir = 4
@@ -25288,6 +28287,14 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
+/area/f13/building)
+"qku" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "qkL" = (
 /obj/machinery/light/small{
@@ -25365,6 +28372,27 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"qnb" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"qnt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building)
 "qnz" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/outside/road{
@@ -25469,6 +28497,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"qqa" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "qqK" = (
 /obj/structure/closet/bus,
 /turf/open/indestructible/ground/outside/road{
@@ -25513,6 +28549,16 @@
 "qrR" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
+"qsh" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "qsp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -25550,6 +28596,15 @@
 	icon_state = "verticalleftborderleftbottom"
 	},
 /area/f13/wasteland)
+"quv" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/effect/decal/cleanable/robot_debris/limb,
+/obj/effect/turf_decal/box/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
 "qvN" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -25589,6 +28644,13 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"qwf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "qwi" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/radiation)
@@ -25668,6 +28730,18 @@
 	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
+"qyS" = (
+/obj/structure/table/reinforced,
+/obj/item/bodypart/r_leg/robot,
+/obj/item/trash/f13/electronic/toaster,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/button/door{
+	id = "genatomicsshutters";
+	name = "General Atomics shutters";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "qyZ" = (
 /obj/structure/punching_bag,
 /turf/open/floor/f13/wood{
@@ -25702,6 +28776,12 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
+"qzK" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
+/area/f13/building)
 "qzL" = (
 /obj/machinery/light{
 	dir = 1
@@ -25815,6 +28895,18 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"qDr" = (
+/obj/structure/displaycase,
+/obj/item/clothing/neck/necklace/dope,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "qDs" = (
 /obj/structure/chair/stool,
 /turf/open/floor/f13/wood,
@@ -25878,6 +28970,9 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"qEZ" = (
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "qFk" = (
 /turf/closed/wall/f13/wood,
 /area/f13/village)
@@ -25910,6 +29005,20 @@
 /obj/item/stack/ore/slag,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland)
+"qGF" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbroken"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "mallfrontshutter";
+	layer = 11;
+	name = "Yuma mall"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "qGI" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -26006,6 +29115,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"qIF" = (
+/obj/effect/decal/marking,
+/obj/structure/barricade/tentclothedge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "qJv" = (
 /obj/structure/fence/corner/wooden{
 	dir = 1
@@ -26022,12 +29140,35 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
+"qJW" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor2"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "qJZ" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"qKu" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
+"qKw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "qKD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/glass/bucket{
@@ -26036,6 +29177,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"qKI" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "qKU" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -26186,6 +29331,20 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"qOx" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "qOA" = (
 /obj/structure/chair/booth{
 	dir = 8
@@ -26304,6 +29463,22 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"qQx" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/storage/box/papersack,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/building)
+"qQB" = (
+/obj/structure/rack,
+/obj/item/kitchen/knife/combat,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "qQD" = (
 /obj/machinery/deepfryer,
 /obj/machinery/light/small{
@@ -26469,6 +29644,21 @@
 /obj/structure/simple_door/wood,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
+"qVC" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/closet/cardboard,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/glass/ten,
+/obj/item/stack/sheet/glass/ten,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "qWZ" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/f13{
@@ -26488,6 +29678,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"qYr" = (
+/obj/structure/fluff/railing{
+	dir = 6
+	},
+/turf/open/water,
+/area/f13/building)
 "qYD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -26514,6 +29710,17 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
+"qZd" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/closet,
+/obj/item/storage/backpack/duffelbag,
+/obj/item/clothing/head/soft/grey,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "qZe" = (
 /obj/machinery/chem_master/primitive,
 /turf/open/floor/f13/wood,
@@ -26526,6 +29733,11 @@
 /obj/structure/statue/wood/headstonewood,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"qZF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "qZN" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/ruins{
@@ -26617,12 +29829,30 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"rcj" = (
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
 "rck" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
 	pixel_y = -3
 	},
 /turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
+"rcm" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/chair,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "rco" = (
 /obj/structure/fireplace{
@@ -26691,6 +29921,16 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
+"ree" = (
+/obj/machinery/light/lampost{
+	dir = 1;
+	pixel_x = -32
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
 "reg" = (
 /obj/machinery/mineral/wasteland_vendor/crafting{
 	icon_state = "parts_idle"
@@ -26726,6 +29966,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"rfy" = (
+/obj/structure/closet/cardboard,
+/obj/item/storage/briefcase,
+/obj/item/clothing/suit/jacket/leather,
+/obj/item/clothing/head/cowboyhat/black,
+/obj/item/clothing/under/f13/cowboyg,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "topshadowleft"
+	},
+/area/f13/wasteland)
 "rfI" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/clothing_middle,
@@ -26892,6 +30142,20 @@
 	icon_state = "verticalrightborderlefttop"
 	},
 /area/f13/wasteland)
+"rlO" = (
+/obj/structure/simple_door/house,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
+"rmd" = (
+/obj/structure/closet/crate/freezer,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "topshadowright"
+	},
+/area/f13/wasteland)
 "rmo" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -26927,6 +30191,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"rnd" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/trash/candy,
+/obj/item/trash/cheesie,
+/turf/open/floor/carpet,
+/area/f13/building)
 "rns" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -27203,6 +30475,27 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"ryA" = (
+/obj/structure/toilet,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
+"ryE" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table/wood,
+/obj/structure/sign/poster/contraband/donut_corp,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "ryH" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -27229,11 +30522,24 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"rza" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
+/obj/item/storage/fancy/cigarettes/cigpack_pyramid,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "rzz" = (
 /obj/machinery/mineral/stacking_unit_console{
 	machinedir = 5
 	},
 /turf/closed/wall/r_wall/rust,
+/area/f13/building)
+"rzE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
 "rzR" = (
 /obj/machinery/light{
@@ -27323,6 +30629,14 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"rCA" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "rCC" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -27463,6 +30777,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"rHz" = (
+/obj/effect/decal/marking,
+/obj/structure/barricade/tentclothcorner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/building)
 "rHO" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -27500,6 +30823,28 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"rIq" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	layer = 6;
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
+/area/f13/wasteland)
+"rIu" = (
+/obj/structure/urinal{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
+/area/f13/building)
 "rIF" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/f13/wood,
@@ -27535,11 +30880,29 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"rKd" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/donut_corp,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "rKB" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"rKC" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building)
 "rKS" = (
 /obj/structure/wreck/trash/one_tire,
 /obj/machinery/light/small{
@@ -27656,6 +31019,18 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"rPI" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 4;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "rQb" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
 /obj/effect/decal/cleanable/blood/drip,
@@ -27726,6 +31101,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"rRP" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/carpet,
+/area/f13/building)
 "rRR" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleftbottom"
@@ -27757,6 +31137,33 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"rSW" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 5;
+	icon_state = "rubble"
+	},
+/area/f13/wasteland)
+"rTr" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/storage/trash_stack,
+/obj/item/storage/bag/trash,
+/obj/item/trash/syndi_cakes,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "rTt" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
@@ -27890,6 +31297,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"rYl" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "rYn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/vetlegionary,
@@ -27924,6 +31338,19 @@
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
 	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"rZS" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/closet,
+/obj/item/crafting/lunchbox,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -27984,6 +31411,8 @@
 	dir = 4;
 	termtag = "Business"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -28024,6 +31453,21 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"sdK" = (
+/obj/structure/rack,
+/obj/structure/sign/poster/official/foam_force_ad{
+	pixel_y = 32
+	},
+/obj/item/ammo_box/magazine/toy/pistol,
+/obj/item/gun/ballistic/automatic/toy/pistol,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/dualsaber/toy,
+/obj/machinery/light/broken{
+	dir = 1;
+	pixel_x = 16
+	},
+/turf/open/floor/carpet,
+/area/f13/building)
 "sed" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -28154,6 +31598,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"sgs" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
+/area/f13/building)
 "sgw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hydroponics/constructable,
@@ -28291,6 +31742,13 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"sjA" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/candy,
+/obj/item/reagent_containers/food/snacks/candy,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/building)
 "sjX" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/light/small{
@@ -28343,6 +31801,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"slJ" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/storage/box/papersack,
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "slT" = (
 /obj/item/clothing/head/helmet/f13/rustedcowboyhat,
 /obj/item/clothing/suit/armor/f13/rustedcowboy,
@@ -28459,6 +31925,10 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plating/tunnel,
 /area/f13/village)
+"soD" = (
+/obj/structure/simple_door/house,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "soY" = (
 /obj/structure/fence{
 	dir = 4
@@ -28479,11 +31949,23 @@
 /obj/item/storage/bag/ore,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"spA" = (
+/obj/item/trash/tray,
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleplate"
+	},
+/area/f13/wasteland)
 "spL" = (
 /obj/machinery/light/broken{
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"spR" = (
+/obj/structure/table,
+/obj/item/trash/f13/electronic/toaster,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
 "spV" = (
 /obj/structure/barricade/tentclothedge,
@@ -28525,6 +32007,23 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"srf" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/closet,
+/obj/item/crafting/wonderglue,
+/obj/item/radio/off,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"srj" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "srp" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -28586,6 +32085,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"stF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/red/white/side,
+/area/f13/building)
 "stG" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubble"
@@ -28617,6 +32121,22 @@
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
+/area/f13/building)
+"suC" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
+	},
+/obj/structure/mirror{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
 /area/f13/building)
 "suP" = (
 /mob/living/simple_animal/hostile/ghoul,
@@ -28656,6 +32176,27 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"svR" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/wasteland)
+"swk" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "genatomicsshutters";
+	layer = 11;
+	name = "General Atomics"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
 "swl" = (
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/condiment/flour,
@@ -28871,6 +32412,12 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"sEf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/dice/d20,
+/turf/open/floor/carpet,
+/area/f13/building)
 "sEx" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -28980,9 +32527,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "sIM" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "sIO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
@@ -29167,6 +32721,24 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"sOi" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave,
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
+"sPr" = (
+/obj/structure/chair/office/dark,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
 "sPu" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/road,
@@ -29271,6 +32843,13 @@
 /mob/living/simple_animal/hostile/ghoul/soldier/armored,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
+"sSc" = (
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerbordercorner"
+	},
+/area/f13/wasteland)
 "sSr" = (
 /turf/open/floor/wood/f13/old/ruinedstraightnorth,
 /area/f13/wasteland)
@@ -29376,6 +32955,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"sVw" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
+	dir = 8
+	},
+/area/f13/building)
 "sVD" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
@@ -29393,6 +32980,32 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"sWg" = (
+/obj/structure/rack,
+/obj/structure/sign/poster/contraband/masked_men{
+	pixel_y = 32
+	},
+/obj/item/paper/pamphlet{
+	desc = "a trashy prewar comic book";
+	name = "prewar comic book"
+	},
+/obj/item/paper/pamphlet{
+	desc = "a trashy prewar comic book";
+	name = "prewar comic book"
+	},
+/obj/item/paper/pamphlet{
+	desc = "a trashy prewar comic book";
+	name = "prewar comic book"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/f13/building)
+"sWr" = (
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
 /area/f13/wasteland)
 "sWv" = (
 /obj/structure/table/reinforced,
@@ -29572,6 +33185,7 @@
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -29790,22 +33404,61 @@
 /obj/item/instrument/guitar,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"tiz" = (
+/obj/structure/rack,
+/obj/item/clothing/head/cowboyhat,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "tjB" = (
 /obj/item/ammo_casing/a50MG,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
+"tjO" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/storage/bag/trash,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "tjQ" = (
 /obj/structure/closet,
 /obj/item/reagent_containers/pill/patch/jet,
 /obj/item/reagent_containers/pill/patch/jet,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"tjR" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "tka" = (
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"tkc" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical"
+	},
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "jewellershutters";
+	layer = 11;
+	name = "Prestige Jewellers"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "tkh" = (
 /obj/structure/chair,
 /turf/open/floor/f13{
@@ -29816,6 +33469,15 @@
 /mob/living/simple_animal/hostile/handy,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"tkv" = (
+/obj/structure/flora/tree/tall{
+	layer = 2;
+	pixel_y = 9
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
+/area/f13/wasteland)
 "tkO" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13{
@@ -29888,6 +33550,13 @@
 	},
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"tlE" = (
+/obj/effect/decal/marking,
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
 /area/f13/wasteland)
 "tlI" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
@@ -30391,11 +34060,31 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"tAZ" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleplate"
+	},
+/area/f13/wasteland)
 "tBm" = (
 /obj/structure/table/wood/settler,
 /obj/item/clothing/head/helmet/f13/deathskull,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"tBA" = (
+/obj/structure/rack,
+/obj/item/storage/wallet,
+/obj/machinery/light/broken{
+	dir = 1;
+	pixel_x = 16
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "tBN" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
@@ -30427,6 +34116,15 @@
 	icon_state = "verticalrightborderleft2top"
 	},
 /area/f13/wasteland)
+"tCL" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/vending/cola/red,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "tCQ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/indestructible/ground/outside/dirt{
@@ -30496,6 +34194,20 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
+/area/f13/building)
+"tFo" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"tFL" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	pixel_x = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
 /area/f13/building)
 "tFP" = (
 /obj/structure/rack,
@@ -30641,6 +34353,15 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"tKa" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "tKk" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -30716,6 +34437,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"tLS" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/wood/f13/old/ruinedcornerbl,
+/area/f13/wasteland)
 "tLW" = (
 /obj/structure/destructible/tribal_torch,
 /obj{
@@ -30760,6 +34485,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"tNz" = (
+/obj/structure/rack,
+/obj/item/toy/plush/lizardplushie,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/building)
 "tNA" = (
 /obj/item/key,
 /turf/open/indestructible/ground/outside/desert,
@@ -30816,6 +34547,19 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"tOW" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/closet,
+/obj/item/clothing/under/f13/petrochico,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "tPs" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/inside/mountain,
@@ -30829,6 +34573,14 @@
 	icon_state = "horizontalinnermain3"
 	},
 /area/f13/wasteland)
+"tPz" = (
+/obj/structure/table,
+/obj/item/circuitboard/machine/smartfridge,
+/obj/item/circuitboard/machine/biogenerator,
+/obj/item/circuitboard/machine/seed_extractor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
 "tQl" = (
 /obj/structure/chair/wood/modern{
 	dir = 1
@@ -30853,6 +34605,17 @@
 /area/f13/village)
 "tQw" = (
 /turf/open/floor/plasteel/dark,
+/area/f13/building)
+"tQK" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/building)
 "tQU" = (
 /obj/structure/mirror,
@@ -30970,6 +34733,14 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"tUo" = (
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "tUp" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13{
@@ -31021,8 +34792,18 @@
 /obj/item/reagent_containers/food/snacks/grown/potato,
 /obj/item/reagent_containers/food/snacks/grown/potato,
 /obj/item/reagent_containers/food/snacks/store/cheesewheel,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"tVB" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "tVJ" = (
@@ -31132,6 +34913,31 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"tZs" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "genatomicsshutters";
+	layer = 11;
+	name = "General Atomics"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
+"tZC" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_bigboss,
+/obj/item/lighter,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "tZI" = (
 /obj/structure/table/wood/poker,
 /obj/effect/holodeck_effect/cards,
@@ -31155,6 +34961,15 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"uaj" = (
+/obj/structure/simple_door/house,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "uar" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/f13/wood,
@@ -31192,6 +35007,18 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
+"ubW" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Business"
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = 16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
 "ucs" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -31296,6 +35123,16 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"ufD" = (
+/obj/structure/table/wood,
+/obj/structure/junk/small/tv{
+	desc = "Advertisements would've played on this tv before the bombs dropped.";
+	name = "pre-war advertising television";
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "ufN" = (
 /obj/structure/rack,
 /obj/item/clothing/neck/tie,
@@ -31325,6 +35162,20 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_bl,
 /area/f13/bar)
+"ugM" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "loading2";
+	layer = 11;
+	name = "Loading Bay 2"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "uhh" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/light/small{
@@ -31347,6 +35198,15 @@
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"uhl" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "uhq" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -31372,6 +35232,12 @@
 	},
 /turf/open/floor/plating,
 /area/f13/tunnel)
+"uhQ" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_east_north"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "uhY" = (
 /obj/effect/landmark/start/f13/venator,
 /turf/open/floor/carpet/black,
@@ -31397,6 +35263,15 @@
 /obj/structure/dresser,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
+"ujl" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "ujC" = (
@@ -31478,6 +35353,16 @@
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
+/area/f13/building)
+"umF" = (
+/obj/structure/simple_door/metal/dirtystore,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barbariancomicshutters";
+	layer = 11;
+	name = "Barbarians Dungeon Comics"
+	},
+/turf/open/floor/wood/wood_tiled,
 /area/f13/building)
 "umS" = (
 /obj/structure/table/wood/fancy/black,
@@ -31588,11 +35473,17 @@
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "uqe" = (
-/obj/structure/simple_door/metal/store,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
+/obj/structure/table,
+/obj/structure/junk/small/tv{
+	desc = "Advertisements would've played on this tv before the bombs dropped.";
+	name = "pre-war advertising television";
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
 "uqf" = (
 /turf/open/floor/wood/f13/stage_t,
@@ -31601,6 +35492,14 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/ncr)
+"uql" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "uqE" = (
 /obj/effect/decal/remains/human,
 /obj/item/ammo_casing/caseless{
@@ -31621,6 +35520,15 @@
 	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland)
+"urq" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/storage/box/lights/tubes,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "urt" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/syringe/medx,
@@ -31692,6 +35600,22 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"usb" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table/wood,
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/obj/item/storage/fancy/cigarettes/cigars/cohiba,
+/obj/item/storage/fancy/cigarettes/cigars,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "use" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/indestructible/ground/outside/road{
@@ -31757,6 +35681,16 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/village)
+"uvj" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	termtag = "Business"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "uvk" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13{
@@ -31799,6 +35733,16 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 8;
 	icon_state = "rubblecorner"
+	},
+/area/f13/wasteland)
+"uwG" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = -6
+	},
+/obj/item/kitchen/knife/combat,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
 "uwQ" = (
@@ -31918,6 +35862,21 @@
 /obj/structure/car,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"uAL" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/obj/item/locked_box/weapon/ammo/tier1,
+/obj/item/locked_box/weapon/ammo/tier2,
+/obj/item/locked_box/weapon/range/tier1,
+/obj/item/locked_box/weapon/range/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "uBx" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_br,
@@ -31974,11 +35933,24 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"uCX" = (
+/obj/structure/table/wood,
+/obj/item/clothing/head/fedora,
+/obj/item/clothing/glasses/regular/jamjar,
+/turf/open/floor/carpet,
+/area/f13/building)
 "uDk" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
+/area/f13/building)
+"uDt" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
 /area/f13/building)
 "uDw" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -32016,6 +35988,17 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"uEc" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/cigarette/pipe,
+/obj/item/clothing/mask/cigarette/pipe/cobpipe,
+/obj/item/lighter,
+/obj/item/storage/box/matches,
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "uEg" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -32024,6 +36007,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
+"uEj" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "uEK" = (
 /obj/structure/table/wood,
 /obj/item/pda,
@@ -32041,6 +36033,18 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"uFk" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 7
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "uFn" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -32061,6 +36065,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"uFw" = (
+/obj/structure/fence/corner,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
 "uFB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -32355,6 +36366,17 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"uOD" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "uOF" = (
 /obj/structure/decoration/rag{
 	layer = 2.5;
@@ -32399,6 +36421,16 @@
 /obj/effect/holodeck_effect/cards,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
+"uPH" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/toy/crayon/spraycan,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "uPP" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 4;
@@ -32409,6 +36441,17 @@
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"uPY" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/closet/cardboard,
+/obj/item/reagent_containers/food/snacks/no_raisin/healthy,
+/obj/item/reagent_containers/food/snacks/no_raisin/healthy,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "uQe" = (
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -32430,6 +36473,11 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"uQN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "uQY" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -32439,6 +36487,12 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"uRH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/red/white/side{
+	dir = 8
+	},
+/area/f13/building)
 "uRJ" = (
 /turf/open/floor/f13/wood,
 /area/f13/village)
@@ -32451,6 +36505,16 @@
 /obj/structure/sign/poster/prewar/poster90,
 /turf/closed/wall/r_wall/rust,
 /area/f13/ncr)
+"uSl" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "uSm" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -32573,6 +36637,15 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"uUE" = (
+/obj/machinery/washing_machine,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
 "uUL" = (
 /obj/item/flag,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -32585,6 +36658,17 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"uUT" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/closet/cardboard,
+/obj/item/stack/cable_coil,
+/obj/item/clothing/head/soft/grey,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "uVo" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop3"
@@ -32689,6 +36773,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"uXN" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ricksoutdoorshutters";
+	layer = 11;
+	name = "Ricks Outdoor Goods"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "uXV" = (
 /obj/item/stack/sheet/mineral/wood/five,
 /turf/open/indestructible/ground/outside/ruins{
@@ -32828,6 +36924,21 @@
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
+"vcx" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
+"vcD" = (
+/obj/structure/closet/cardboard,
+/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
+/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2right"
+	},
+/area/f13/wasteland)
 "vcF" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -32865,6 +36976,18 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"vdu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/button/door{
+	id = "pharmacyshutters";
+	name = "Friendly Pharm shutters";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/building)
 "ves" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -32890,6 +37013,15 @@
 	icon_state = "verticalrightborderright3"
 	},
 /area/f13/wasteland)
+"veI" = (
+/obj/effect/decal/marking,
+/obj/structure/barricade/tentclothcorner{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "veO" = (
 /obj/structure/closet/cabinet,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -33007,6 +37139,16 @@
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"vic" = (
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "vim" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -33109,6 +37251,19 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"vkY" = (
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
+"vle" = (
+/obj/structure/rack,
+/obj/item/toy/plush/carpplushie,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/carpet,
+/area/f13/building)
 "vly" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/inside/dirt,
@@ -33171,6 +37326,15 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"vof" = (
+/obj/item/bodypart/l_arm/robot,
+/obj/structure/chair/office/dark,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "vom" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -33270,6 +37434,17 @@
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"vsn" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "vsU" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/light/broken,
@@ -33420,6 +37595,18 @@
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"vxX" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "vya" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/cobweb,
@@ -33537,6 +37724,17 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/wood,
 /area/f13/building)
+"vCh" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table/wood,
+/obj/item/storage/box/papersack,
+/obj/structure/window{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "vCi" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
@@ -33648,6 +37846,21 @@
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"vFC" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/clothing/suit/apron/chef,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
+"vFE" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
 "vFL" = (
 /obj/effect/landmark/start/f13/ncroffduty,
 /turf/open/floor/f13{
@@ -33681,6 +37894,12 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"vHa" = (
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "vHb" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/brahmin,
@@ -33867,6 +38086,15 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"vMs" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleplate"
+	},
+/area/f13/wasteland)
 "vMu" = (
 /obj/machinery/light{
 	dir = 4;
@@ -33919,11 +38147,26 @@
 	icon_state = "verticalinnermain2top"
 	},
 /area/f13/wasteland)
+"vNA" = (
+/obj/effect/decal/marking,
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/building)
 "vNG" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/vomit,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"vNR" = (
+/obj/structure/chair/left,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/building)
 "vOe" = (
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/desert,
@@ -34038,11 +38281,28 @@
 /obj/structure/flora/wasteplant/wild_xander,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"vTj" = (
+/obj/structure/car/rubbish2,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/carpet,
+/area/f13/building)
 "vTr" = (
 /obj/structure/table/wood/settler,
 /obj/item/lipstick,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"vTz" = (
+/obj/structure/simple_door/house,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "vTH" = (
 /obj/structure/chair/office,
 /obj/effect/decal/cleanable/dirt,
@@ -34075,6 +38335,21 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"vVa" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/f13/autumn,
+/obj/item/clothing/suit/toggle/lawyer/black,
+/obj/machinery/light{
+	pixel_x = -16
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "vVx" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/barber{
@@ -34243,11 +38518,42 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
+"wcj" = (
+/obj/item/trash/candy,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building)
+"wcq" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "loading1";
+	layer = 11;
+	name = "Loading Bay 1"
+	},
+/obj/structure/reagent_dispensers/barrel,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "wcu" = (
 /obj/structure/barricade/bars,
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"wcw" = (
+/obj/structure/rack,
+/obj/item/clothing/shoes/workboots/mining,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "wcA" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -34289,8 +38595,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"weW" = (
+/obj/structure/bus_door,
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 6;
+	icon_state = "rubble"
+	},
+/area/f13/wasteland)
 "weY" = (
 /obj/machinery/light/broken,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -34300,6 +38614,13 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainright"
 	},
+/area/f13/wasteland)
+"wfo" = (
+/obj/structure/wreck/bus/rusted,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor2"
+	},
+/turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "wfr" = (
 /obj/machinery/light/small{
@@ -34320,6 +38641,12 @@
 /obj/item/seeds/poppy/broc,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"wfz" = (
+/obj/structure/table,
+/obj/item/trash/tray,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/building)
 "wfG" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/mountain,
@@ -34358,10 +38685,32 @@
 /obj/structure/table/booth,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
+"wiC" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/decal/remains/human,
+/obj/item/clothing/head/soft/grey,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "wiU" = (
 /obj/structure/grille/broken,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"wiW" = (
+/obj/structure/fluff/railing{
+	dir = 10
+	},
+/turf/open/water,
+/area/f13/building)
 "wjd" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/Retro_Biker_Vest,
@@ -34470,6 +38819,15 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"wmx" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/stack/cable_coil,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "wmI" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -34561,10 +38919,10 @@
 	},
 /area/f13/wasteland)
 "woT" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain2bottom"
-	},
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "woX" = (
 /obj/structure/barricade/sandbags,
@@ -34673,6 +39031,17 @@
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"wrV" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "wso" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -34743,6 +39112,18 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"wuO" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/under/f13/bennys,
+/obj/item/clothing/under/f13/detectivealt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "wuQ" = (
 /obj/machinery/light/small{
@@ -34928,6 +39309,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"wzN" = (
+/obj/structure/chair/office/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/building)
 "wAU" = (
 /obj/structure/rack,
 /obj/item/taperecorder,
@@ -35085,6 +39471,27 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"wES" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/remains/human,
+/obj/item/reagent_containers/pill/patch/jet,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
+"wEX" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/carpet,
+/area/f13/building)
+"wFh" = (
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/wasteland)
 "wFo" = (
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/f13/wood,
@@ -35141,6 +39548,12 @@
 	pixel_y = 18
 	},
 /turf/open/floor/carpet/black,
+/area/f13/building)
+"wGC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/building)
 "wGJ" = (
 /turf/open/indestructible/ground/outside/road{
@@ -35305,6 +39718,15 @@
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"wLX" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
+/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "wMa" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -35331,6 +39753,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
+"wNn" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Business"
+	},
+/turf/open/floor/carpet,
+/area/f13/building)
 "wNq" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -35363,6 +39793,16 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"wOj" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/closet,
+/obj/item/crafting/wonderglue,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "wOo" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/barber{
@@ -35441,6 +39881,31 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"wPG" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
+"wPL" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "loading1";
+	layer = 11;
+	name = "Loading Bay 1"
+	},
+/obj/structure/reagent_dispensers/barrel/four,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "wPP" = (
 /obj/machinery/microwave/stove,
 /obj/effect/decal/cleanable/salt,
@@ -35467,6 +39932,15 @@
 	pixel_y = -9
 	},
 /turf/open/floor/carpet/black,
+/area/f13/building)
+"wQk" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	pixel_x = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/building)
 "wQm" = (
 /obj/item/storage/trash_stack,
@@ -35502,6 +39976,27 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"wRq" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "pharmacyshutters";
+	layer = 11;
+	name = "Friendly Pharm"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/building)
+"wRr" = (
+/obj/machinery/light/lampost{
+	dir = 1;
+	pixel_x = -32
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
 "wRG" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -35549,6 +40044,15 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"wSx" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "wSA" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -35583,6 +40087,8 @@
 /obj/machinery/chem_dispenser/drinks{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -35629,6 +40135,15 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"wUR" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/twohanded/baseball,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "wUW" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
@@ -35846,6 +40361,11 @@
 /obj/item/mining_scanner,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"xbx" = (
+/mob/living/simple_animal/hostile/handy,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "xbA" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -36072,6 +40592,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"xgu" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	pixel_x = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
+/area/f13/building)
 "xgB" = (
 /obj/structure/chair{
 	dir = 4
@@ -36097,8 +40626,12 @@
 	},
 /area/f13/wasteland)
 "xgX" = (
-/turf/closed/wall/f13/supermart,
-/area/f13/caves)
+/obj/structure/fence/corner,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerbordercorner"
+	},
+/area/f13/wasteland)
 "xhd" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -36264,6 +40797,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"xmS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/building)
 "xmV" = (
 /obj/structure/decoration/rag{
 	icon_state = "flag_ncr";
@@ -36345,6 +40882,12 @@
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"xoN" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "xpg" = (
 /obj/structure/barricade/tentclothedge,
 /turf/open/indestructible/ground/outside/dirt{
@@ -36363,6 +40906,18 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"xpo" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
+	},
+/obj/structure/mirror{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/corner{
+	dir = 4
+	},
 /area/f13/building)
 "xpA" = (
 /obj/structure/fence/handrail{
@@ -36474,6 +41029,14 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"xsh" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/storage/toolbox/drone,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "xsj" = (
 /obj/structure/decoration/vent,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -36728,6 +41291,14 @@
 /obj/structure/stone_tile/center,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"xzr" = (
+/obj/structure/displaycase,
+/obj/item/clothing/gloves/ring/diamond,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "xzM" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innershade"
@@ -36746,6 +41317,12 @@
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"xBx" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/closed/wall/f13/ruins,
+/area/f13/building)
 "xBC" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -36764,6 +41341,13 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
+/area/f13/building)
+"xBR" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "xCo" = (
 /obj/item/flag/bos,
@@ -36822,6 +41406,15 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"xFI" = (
+/obj/structure/simple_door/metal/dirtystore,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "pharmacyshutters";
+	layer = 11;
+	name = "Friendly Pharm"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/building)
 "xFL" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/f13{
@@ -36884,6 +41477,14 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"xGR" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "xHc" = (
 /obj/structure/fence{
 	dir = 4
@@ -37016,10 +41617,25 @@
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"xKg" = (
+/obj/structure/simple_door/house,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "xKi" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"xKq" = (
+/obj/structure/rack,
+/obj/item/storage/pill_bottle/happy,
+/obj/item/storage/pill_bottle/chem_tin/mentats,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building)
 "xKr" = (
 /obj/structure/closet/crate/miningcar,
 /turf/open/indestructible/ground/inside/mountain,
@@ -37029,12 +41645,25 @@
 	icon_state = "verticaloutermain2"
 	},
 /area/f13/wasteland)
+"xKE" = (
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "xKH" = (
 /obj/structure/table,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/ncr)
+"xKI" = (
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "xKV" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -37137,6 +41766,13 @@
 /obj/structure/weightlifter,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"xOD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "xOZ" = (
 /obj/structure/table/wood/settler,
 /obj/item/stack/sheet/cloth,
@@ -37159,6 +41795,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"xPD" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/building)
 "xPI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
@@ -37307,6 +41949,15 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
+"xUF" = (
+/obj/structure/closet/cardboard,
+/obj/item/crafting/coffee_pot,
+/obj/item/reagent_containers/food/drinks/bottle/instacoffee,
+/obj/item/seeds/coffee/robusta,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "xUO" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -37545,6 +42196,10 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"ybC" = (
+/obj/item/trash/f13/porknbeans,
+/turf/open/floor/wood/f13/old/ruinedstraightsouth,
+/area/f13/wasteland)
 "ybI" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
@@ -37566,6 +42221,13 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"yci" = (
+/obj/machinery/autolathe/constructionlathe,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/glass/ten,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "ycn" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor6";
@@ -37576,6 +42238,21 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/village)
+"ycI" = (
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"ycP" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
+	},
+/obj/item/storage/box/papersack,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "ydq" = (
 /obj/structure/chair/bench,
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
@@ -37611,6 +42288,12 @@
 	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland)
+"yet" = (
+/obj/structure/rack,
+/obj/item/clothing/under/suit/charcoal,
+/obj/item/clothing/under/suit/navy,
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "yev" = (
 /obj/structure/chair/stool{
 	dir = 8;
@@ -37648,6 +42331,16 @@
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
+"yfi" = (
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Business"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
 "yga" = (
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -37724,6 +42417,18 @@
 /obj/structure/simple_door/fakeglass,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
+"yio" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barbariancomicshutters";
+	layer = 11;
+	name = "Barbarians Dungeon Comics"
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/building)
 "yiq" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -56131,7 +60836,7 @@ gcK
 ktB
 gcK
 gcK
-anq
+gcK
 gcK
 ktB
 gcK
@@ -58449,13 +63154,13 @@ dXy
 erY
 usx
 usx
-dhC
+azv
 weY
 cuz
 qAx
 pao
 hbY
-nYH
+doD
 qpq
 unI
 hbW
@@ -58711,8 +63416,8 @@ dhC
 ogj
 iOg
 iOg
-iOg
-iOg
+xmS
+kLu
 hRZ
 pBv
 hbW
@@ -58968,8 +63673,8 @@ dhC
 ogj
 iOg
 iOg
-iOg
-iOg
+xmS
+kLu
 xkf
 jIB
 hbW
@@ -59226,7 +63931,7 @@ ogj
 iOg
 iOg
 iOg
-iOg
+kLu
 jVJ
 ajD
 hbW
@@ -60248,7 +64953,7 @@ plq
 rkr
 fFG
 ojS
-dhC
+azv
 dhC
 usx
 tpM
@@ -60507,7 +65212,7 @@ grf
 wTA
 jHg
 dhC
-uqe
+ljG
 iOg
 iOg
 iOg
@@ -61023,8 +65728,8 @@ trW
 hAC
 usx
 iOg
-pao
-jwS
+vNR
+wfz
 nYH
 usx
 ofX
@@ -83435,8 +88140,8 @@ gcK
 gcK
 gcK
 gcK
-gcK
-uaf
+vaA
+mcN
 ajD
 aoJ
 erY
@@ -83693,7 +88398,7 @@ gcK
 gcK
 gcK
 gcK
-uaf
+mcN
 jIB
 ucz
 erY
@@ -83948,9 +88653,9 @@ gcK
 gcK
 gcK
 gcK
-ktB
 gcK
-gdY
+gcK
+mcN
 uyM
 hbW
 erY
@@ -84205,9 +88910,9 @@ gcK
 gcK
 gcK
 gcK
+ktB
 gcK
-gcK
-uaf
+mcN
 bMe
 qnS
 cdc
@@ -84464,7 +89169,7 @@ gcK
 gcK
 gcK
 gcK
-uaf
+mcN
 jIB
 hbW
 hYv
@@ -84721,7 +89426,7 @@ gcK
 gcK
 gcK
 gcK
-cam
+mcN
 unI
 hbW
 dFQ
@@ -84978,7 +89683,7 @@ gcK
 gcK
 gcK
 gcK
-bFJ
+mcN
 unI
 hbW
 toS
@@ -85234,8 +89939,8 @@ gcK
 gcK
 gcK
 gcK
-gcK
-qji
+vaA
+mcN
 unI
 agH
 cdc
@@ -85491,9 +90196,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-bFJ
-unI
+vaA
+goM
+fsl
 hbW
 cdc
 cdc
@@ -85747,8 +90452,8 @@ gcK
 gcK
 gcK
 gcK
-ktB
-gcK
+vaA
+vaA
 gdY
 unI
 hbW
@@ -86005,7 +90710,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ggK
 uaf
 pBv
 box
@@ -86262,7 +90967,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ggK
 bFJ
 unI
 hbW
@@ -86519,7 +91224,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ggK
 uaf
 unI
 hbW
@@ -86776,8 +91481,8 @@ gcK
 gcK
 gcK
 gcK
-vaA
-mcN
+ggK
+bFJ
 unI
 hbW
 erY
@@ -87033,8 +91738,8 @@ gcK
 gcK
 gcK
 gcK
-gcK
-mcN
+cok
+cpK
 pBv
 box
 erY
@@ -87290,8 +91995,8 @@ gcK
 gcK
 gcK
 gcK
-gcK
-mcN
+ggK
+cpK
 ajD
 lSD
 cdc
@@ -87546,9 +92251,9 @@ gcK
 gcK
 gcK
 gcK
-ktB
 gcK
-mcN
+mMB
+cpK
 mTL
 hbW
 apk
@@ -87804,8 +92509,8 @@ gcK
 gcK
 gcK
 gcK
-gcK
-mcN
+jvr
+cpK
 kzB
 ucz
 erY
@@ -88061,8 +92766,8 @@ gcK
 gcK
 gcK
 gcK
-gcK
-mcN
+jvr
+cpK
 ajD
 qnS
 ubg
@@ -88274,52 +92979,52 @@ dXy
 cdc
 snB
 koD
-mcN
+dMW
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-mcN
+vaA
+vaA
+bFJ
 jIB
 hbW
 uVo
@@ -88531,53 +93236,53 @@ rQh
 cdc
 snB
 koD
-mcN
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+dMW
+dit
+anq
+cFq
+agW
+otv
+gOU
+otv
+heS
+otv
+otv
+otv
+ibJ
+uhl
+heS
+heS
+heS
+heS
+ibJ
+cGS
+cGS
+cGS
+otv
+otv
+ibJ
+uhl
+eDV
+fDc
+mzL
+nmm
+vsn
+otv
+nYW
+otv
+nFT
+nsk
+mbm
+ioH
+ktB
+ktB
+ktB
+ktB
+ktB
 gcK
 vaA
-mcN
-ofX
+cpK
+unI
 hbW
 apk
 snB
@@ -88788,53 +93493,53 @@ hbW
 bJB
 gmX
 koD
-mcN
-gcK
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-vaA
+dMW
+dit
+lqQ
+otv
+exC
+otv
+tOW
+wOj
+jxp
+maa
+qsh
+hKL
+otv
+otv
+xOD
+gLK
+nZD
+otv
+tjO
+jwK
+srf
+qZd
+rZS
+amD
+dSB
+otv
+fxh
+xBx
+crb
+eYy
+otv
+otv
+cHw
+otv
+cGS
+otv
+otv
+hzF
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+pnA
 woT
-fsl
+mWI
 tbG
 erY
 apk
@@ -89045,53 +93750,53 @@ hbW
 erY
 gmX
 koD
-mcN
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-vaA
-vaA
+dMW
+dit
+lAD
+otv
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dKs
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+jVs
+jVs
+qfu
+jVs
+jVs
+dit
+dit
+dit
+uaj
+dit
+otv
+cGS
+otv
+kfj
+ioH
+gvT
+idu
+nDx
+idu
+idu
+nFL
+pnA
 heB
-mbm
+unI
 hbW
 erY
 gmX
@@ -89302,52 +94007,52 @@ hbW
 erY
 gmX
 koD
-mcN
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ggK
-keW
+dMW
+dit
+mbm
+otv
+dit
+ryA
+vTz
+uDt
+dit
+hdF
+ihF
+xoN
+xoN
+nnf
+dit
+hpb
+gqI
+jsZ
+vFE
+feK
+aGc
+spR
+dit
+fxD
+eqC
+cXe
+mWE
+qyS
+dit
+gtM
+xKq
+vdu
+dit
+ycI
+wuO
+jOz
+pNl
+ioH
+hbW
+ehN
+ehN
+ehN
+ehN
+gmX
+pnA
+cpK
 unI
 hbW
 erY
@@ -89559,53 +94264,53 @@ qnS
 erY
 gmX
 koD
-mcN
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ggK
-bFJ
-unI
+dMW
+dit
+ooh
+heS
+dit
+dit
+dit
+qzK
+dit
+dit
+dit
+vic
+gLS
+dBP
+dit
+pIM
+bQX
+uEj
+bQX
+ept
+bQX
+bBZ
+dit
+ngU
+lFh
+xbx
+vof
+kIf
+dit
+eSZ
+wGC
+dSn
+dit
+otv
+nxZ
+uOD
+uOD
+jPU
+hbW
+ehN
+uFk
+wES
+ehN
+gmX
+uFw
+ybI
+onk
 hbW
 erY
 gmX
@@ -89816,54 +94521,54 @@ dXy
 dFQ
 dFQ
 dJF
-mcN
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ggK
-cpK
-pBv
-box
+dMW
+dit
+otv
+heS
+dit
+kvG
+vTz
+gut
+dit
+nCo
+pOS
+vxX
+eTA
+vVa
+dit
+quv
+ept
+lGq
+qKw
+aOg
+qwf
+stF
+dit
+yci
+xGR
+uQN
+tUo
+rza
+dit
+qnt
+tQK
+xPD
+dit
+otv
+gtD
+otv
+izb
+wPL
+hbW
+ehN
+aLc
+dzS
+ehN
+jRh
+idu
+idu
+idu
+erY
 erY
 gmX
 qIn
@@ -90073,54 +94778,54 @@ dXy
 cdc
 snB
 koD
-mcN
-vaA
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ggK
-cpK
-ajD
-lSD
+dMW
+dit
+otv
+heS
+dit
+dit
+dit
+qzK
+dit
+dit
+dit
+dsS
+xoN
+naI
+dit
+eof
+bQX
+lGq
+ept
+uUE
+ept
+eIN
+ioH
+ioH
+eKT
+jVs
+dit
+dit
+dit
+bKn
+hpa
+apm
+dit
+otv
+nNo
+hqw
+hqw
+wcq
+hbW
+ehN
+nDG
+uFk
+jRh
+ehN
+ehN
+ehN
+ehN
+cdc
 cdc
 gmX
 sBk
@@ -90331,53 +95036,53 @@ cdc
 eSh
 bdN
 kOz
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fMO
-gcK
-sIM
-cpK
-jIB
+dit
+otv
+heS
+dit
+bka
+soD
+qzK
+dit
+kbz
+dwy
+kZQ
+kZQ
+jgF
+dit
+jto
+bQX
+ept
+eqC
+koe
+ept
+eIN
+pXC
+nxU
+ept
+rYl
+dit
+tNz
+sjA
+wGC
+wGC
+atT
+dit
+dmF
+uPH
+tZC
+tKa
+ioH
 hbW
+ehN
+ehN
+ehN
+fMO
+ehN
+kaM
+kaM
+ehN
+apk
 apk
 apk
 wwM
@@ -90588,52 +95293,52 @@ cdc
 gmX
 koD
 dMW
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ggK
-cpK
-lqQ
+dit
+sIM
+otv
+dit
+dit
+dit
+qzK
+dit
+tBA
+kZQ
+qKu
+dpE
+yet
+dit
+ubW
+jkn
+iBJ
+ept
+tPz
+ept
+eIN
+hkm
+enF
+oKW
+pUR
+dit
+kbD
+wcj
+jUl
+aIy
+rKC
+dit
+otv
+nxZ
+uOD
+uOD
+dCb
+hbW
+ehN
+ehN
+ehN
+ehN
+gmX
+rcj
+ees
+muk
 lSD
 erY
 ubg
@@ -90845,52 +95550,52 @@ erY
 gmX
 koD
 dMW
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+dit
 otv
-cpK
-unI
+otv
+dit
+xpo
+oTY
+iRx
+dit
+iKc
+kZQ
+qKu
+kZQ
+iUX
+dit
+sPr
+khu
+oXR
+ept
+ept
+ept
+ilf
+uRH
+uRH
+lUs
+lUs
+dit
+wzN
+aMb
+nmN
+wGC
+wQk
+dit
+otv
+qnb
+otv
+kYQ
+ugM
+kfu
+kLy
+ehN
+iWm
+ehN
+atI
+pnA
+cFe
+ofX
 urg
 ubg
 snB
@@ -91102,51 +95807,51 @@ erY
 gmX
 koD
 dMW
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-xgX
-bFJ
+dit
+otv
+heS
+dit
+suC
+kLg
+kle
+dit
+slJ
+xoN
+aJN
+xoN
+iWn
+dit
+cXp
+bbj
+lgB
+lgB
+lgB
+lgB
+kJC
+jSx
+jAb
+mle
+hZx
+dit
+qQx
+aMb
+cTy
+aqB
+diH
+dit
+bvV
+qVC
+ksX
+hqw
+hLC
+rmd
+qNB
+kaM
+kaM
+kaM
+huu
+pnA
+cpK
 unI
 hbW
 uVo
@@ -91359,51 +96064,51 @@ lZP
 gmX
 koD
 dMW
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+dit
+cnJ
+oBf
+dit
+dit
+dit
+oLm
+dit
+omq
+hbj
+omq
+jHO
+bOj
+dit
+dit
+swk
+ohY
+npI
+npI
+tZs
+tZs
+tZs
+ohY
+tZs
+dit
+dit
+dit
+wRq
+xFI
+hHV
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+ghg
+ghg
+ghg
+ghg
+ghg
+ghg
 xgX
-gdY
+cpK
 pBv
 lSD
 apk
@@ -91616,52 +96321,52 @@ tPy
 snB
 koD
 dMW
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-vaA
-vaA
+hkv
+pJU
+giZ
+dit
+dDM
+pDO
+qEZ
+qEZ
+qEZ
+mvC
+mvC
+mvC
+qqa
+uSl
+mEE
+qEZ
+mMk
+qEZ
+qEZ
+qEZ
+qEZ
+qEZ
+qEZ
+qEZ
+kUj
+aWV
+qEZ
+qEZ
+mEE
+kUf
+tFo
+jXb
+pdR
+bFJ
+bFJ
+bFJ
+bFJ
+bFJ
+bFJ
+bFJ
+bFJ
+bFJ
+bFJ
+bFJ
 uaf
-ajD
+dum
 hbW
 fuU
 apk
@@ -91873,52 +96578,52 @@ apk
 apk
 koD
 dMW
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-vaA
+stG
+spA
+pJU
+giZ
+vcx
+qEZ
+mvC
+gxo
+srj
+mvC
+rKd
+avP
+ryE
+qEZ
+mvC
+gBB
+srj
+gTU
+qEZ
+usb
+vCh
+hEN
+dZZ
+kqF
+ycP
+rzE
+qEZ
+dlY
+hAk
+tFo
+mEE
+dZs
+bFJ
+qfA
+xrd
+lHo
+bFJ
+qfA
+tkv
+lHo
+bFJ
+iGM
+piA
+rIq
 cam
-jIB
+unI
 hbW
 erY
 gmX
@@ -92130,50 +96835,50 @@ erY
 ubg
 koD
 dMW
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+fyf
+hkv
+faW
+aWV
+uqe
+mMk
+mMk
+any
+ccE
+mMk
+ebI
+vFC
+vHa
+qEZ
+any
+pUQ
+wiW
+ccE
+gTU
+fqv
+qKI
+bbp
+qEZ
+ccE
+any
+aWV
+gTJ
+hAk
+vTj
+hAk
+qEZ
+iiF
+sSc
+ybI
+ybI
+ybI
+oqe
+ybI
+ybI
+ybI
+oqe
+ybI
+ybI
+ybI
 dbH
 avh
 tbG
@@ -92387,51 +97092,51 @@ ubg
 snB
 koD
 dMW
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-uaf
+fyf
+nFV
+faW
+aWV
+uqe
+mMk
+mVp
+ccE
+gSm
+qdB
+lDM
+qKI
+bdp
+qEZ
+ccE
+aZQ
+qYr
+gSm
+lPR
+uEc
+qEZ
+afB
+qEZ
+gSm
+ccE
+qEZ
+rRP
+moz
+wEX
+hAk
+mvC
+iiF
+unI
+rfy
+idu
+idu
+idu
+idu
+idu
+idu
+idu
+mBc
+qev
+hzV
+koD
 unI
 hbW
 erY
@@ -92644,51 +97349,51 @@ tPy
 uVo
 koD
 dMW
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gdY
+fyf
+stG
+faW
+aWV
+aWV
+qdB
+mvC
+oHn
+iVh
+mvC
+sOi
+gdc
+ufD
+mEE
+mvC
+uhQ
+osD
+mvC
+iJq
+ans
+mzW
+bJC
+qZF
+uhQ
+osD
+pQp
+oPl
+hAk
+hAk
+qEZ
+tFo
+qGF
+unI
+hbW
+jni
+ehN
+sQX
+ubg
+sQX
+sQX
+ehN
+xKI
+arE
+bDM
+koD
 jnK
 hbW
 erY
@@ -92902,50 +97607,50 @@ snB
 koD
 dMW
 fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-uaf
+stG
+lrQ
+aWV
+pjc
+qEZ
+qEZ
+qEZ
+tFo
+tFo
+qEZ
+qEZ
+qEZ
+mEE
+oFD
+mEE
+mEE
+mEE
+xKE
+qEZ
+qEZ
+qEZ
+qEZ
+mEE
+mEE
+dNv
+aWV
+mEE
+mEE
+mEE
+pDO
+pLz
+unI
+eeh
+iaL
+iaL
+djt
+vcD
+sQX
+sQX
+ehN
+iaL
+iaL
+tlE
+koD
 unI
 hbW
 erY
@@ -93159,50 +97864,50 @@ gmX
 koD
 dMW
 fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-bFJ
+stG
+rtl
+dit
+dit
+dit
+oLm
+dit
+dit
+uXN
+aqy
+fHE
+fHE
+eJs
+fHE
+fHE
+fHE
+aqy
+dit
+dit
+dit
+bIF
+bIF
+umF
+yio
+dit
+dit
+dit
+gBa
+cHL
+tkc
+dit
+unI
+hbW
+ehN
+ehN
+fMI
+sQX
+blM
+sQX
+ehN
+pDa
+ehN
+sWr
+koD
 unI
 hbW
 erY
@@ -93416,50 +98121,50 @@ gmX
 koD
 dMW
 fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gdY
+weW
+pJU
+dit
+suC
+sgs
+kle
+dit
+lBT
+mMu
+aWj
+xBR
+gSS
+gSS
+gSS
+pal
+qQB
+kVV
+cBq
+dit
+pGH
+jMB
+jMB
+khI
+rnd
+eue
+dit
+dhQ
+xoN
+xzr
+dqr
+dit
+unI
+hbW
+ehN
+ehN
+sQX
+sQX
+wfo
+hOl
+ehN
+jni
+ehN
+gmX
+koD
 pBv
 lSD
 erY
@@ -93672,51 +98377,51 @@ erY
 gmX
 koD
 dMW
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-uaf
+gPW
+iII
+pJU
+dit
+suC
+kle
+kle
+dit
+oOi
+xBR
+hSz
+mMu
+gCM
+mMu
+wnh
+iYo
+mMu
+xBR
+mMu
+dit
+cTl
+moz
+dgp
+eGG
+moz
+iRk
+dit
+nnH
+xoN
+xoN
+nnH
+dit
+unI
+eeh
+iaL
+iaL
+sQX
+sQX
+ubg
+cdc
+ubg
+iIW
+qIF
+vNA
+koD
 ajD
 hbW
 erY
@@ -93929,51 +98634,51 @@ erY
 ubg
 koD
 dMW
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-cam
+dit
+dLY
+giZ
+dit
+rIu
+kle
+xgu
+dit
+uvj
+mMu
+cYX
+eQN
+eQN
+eQN
+tLS
+nTa
+gLW
+hcw
+pBj
+dit
+sWg
+moz
+nJq
+iZJ
+moz
+gak
+dit
+cAg
+giR
+vkY
+qjl
+dit
+unI
+hbW
+jyC
+ehN
+sQX
+ubg
+cdc
+cdc
+ehN
+jJq
+fPH
+hLn
+koD
 jIB
 hbW
 erY
@@ -94186,51 +98891,51 @@ erY
 uVo
 koD
 dMW
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gdY
+dit
+tjR
+pQM
+dit
+dnt
+sVw
+jUb
+dit
+xBR
+mMu
+sSr
+bNA
+tAZ
+rSW
+ybC
+qku
+dGL
+xBR
+cQH
+dit
+sdK
+eGG
+sEf
+vle
+fTN
+cSL
+dit
+nnH
+xoN
+ahI
+xoN
+dit
+unI
+hbW
+ehN
+ehN
+sQX
+cdc
+cdc
+bJB
+ehN
+eUJ
+uql
+hLn
+koD
 ofX
 hbW
 erY
@@ -94443,51 +99148,51 @@ erY
 gmX
 koD
 dMW
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-uaf
+dit
+kYG
+wrV
+dit
+dit
+dit
+qzK
+dit
+wcw
+mMu
+sSr
+svR
+xBx
+eSy
+mKk
+wLX
+hiq
+rCA
+gSS
+dit
+jod
+moz
+moz
+eGG
+moz
+jZB
+dit
+qDr
+bDt
+eai
+nnH
+dit
+unI
+eeh
+iaL
+iaL
+sQX
+apk
+bJB
+kLy
+ehN
+veI
+dDe
+rHz
+koD
 unI
 hbW
 erY
@@ -94700,51 +99405,51 @@ erY
 gmX
 koD
 dMW
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gdY
-bFJ
+dit
+kYG
+kYG
+dit
+orw
+vTz
+qzK
+dit
+etU
+cQH
+bNL
+bUL
+vMs
+xBx
+dit
+dit
+dit
+dit
+rlO
+dit
+pmW
+eGG
+aJd
+wNn
+mHB
+uCX
+dit
+dit
+dit
+dit
+xKg
+dit
+unI
+hbW
+dte
+bhC
+ehN
+ehN
+qJW
+adz
+ehN
+ehN
+nzV
+gmX
+koD
 unI
 hbW
 erY
@@ -94957,51 +99662,51 @@ erY
 gmX
 koD
 dMW
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-uaf
-bFJ
+dit
+ujl
+wrV
+dit
+dit
+dit
+tFL
+dit
+tiz
+dea
+pDv
+bUL
+bRi
+ioH
+nwC
+lcV
+mEE
+lcV
+mEE
+dit
+dXp
+eGG
+eGG
+enG
+jeW
+mBZ
+ayD
+yfi
+ikg
+mof
+mXy
+dit
+unI
+hbW
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+gmX
+koD
 unI
 hbW
 gln
@@ -95214,51 +99919,51 @@ erY
 gmX
 koD
 dMW
-fyf
-trW
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-trd
-bFJ
+dit
+wSx
+wrV
+dit
+kvG
+vTz
+qzK
+dit
+jBy
+mMu
+mHk
+xBx
+xBx
+dit
+rPI
+mEE
+uAL
+xsh
+fKD
+dit
+jsz
+nvq
+mHB
+lSw
+iMQ
+kDp
+dit
+brK
+wPG
+mXy
+bbq
+dit
+unI
+eeh
+iaL
+iaL
+ehN
+kLy
+ehN
+ehN
+ehN
+iaL
+iaL
+wFh
+koD
 unI
 hbW
 erY
@@ -95471,51 +100176,51 @@ erY
 gmX
 koD
 dMW
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-kdJ
-gdY
+dit
+msf
+wmx
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+pMR
+dit
+dit
+dit
+dit
+dit
+dit
+pMR
+dit
+dit
+dit
+dit
+pMR
+dit
+unI
+hbW
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+xUF
+gmX
+koD
 pBv
 hiS
 erY
@@ -95728,51 +100433,51 @@ erY
 gmX
 koD
 dMW
-fyf
-fyf
-upX
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-fyf
-fyf
-fyf
-trW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-kdJ
-fJl
+dit
+klh
+kYG
+gLK
+nZD
+uUT
+nHI
+tCL
+rcm
+uPY
+pQM
+grx
+bZN
+wiC
+rTr
+kYG
+kYG
+kYG
+wrV
+kYG
+bcX
+eDV
+fDc
+mzL
+nmm
+vYv
+aGS
+fUm
+heS
+vYv
+vYv
+dit
+unI
+fTZ
+akU
+kaM
+kaM
+ehN
+ehN
+ehN
+kaM
+kaM
+kaM
+huu
+qEb
 ajD
 hbW
 erY
@@ -95985,51 +100690,51 @@ erY
 gmX
 koD
 dMW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-trW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-upX
-fyf
-fyf
-fyf
-kdJ
-bbz
+dit
+gwp
+wrV
+wrV
+wrV
+oIi
+tVB
+kYG
+kYG
+fyh
+kYG
+oIi
+kYG
+mOq
+wrV
+wrV
+kYG
+bDl
+kYG
+kYG
+urq
+fxh
+xBx
+crb
+otH
+otv
+wUR
+grx
+bZN
+qOx
+jGU
+dit
+sIf
+ees
+ees
+ees
+wRr
+hbW
+erY
+erY
+ree
+ees
+ees
+ees
+oZf
 xFQ
 hbW
 mmK
@@ -96242,51 +100947,51 @@ erY
 gmX
 koD
 jkJ
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-bEw
-gSt
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-bEw
-tVV
-noK
-fGc
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
+dit
 bFJ
+uwG
+trW
+qfA
+unI
+hbW
+erY
+erY
+koD
+rIq
+gSB
+fGc
+cpK
 rpS
 hbW
 erY
@@ -96502,27 +101207,9 @@ ybI
 ybI
 ybI
 ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
 rRR
 wIK
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
+sTa
 ybI
 ybI
 ybI
@@ -96541,6 +101228,24 @@ ybI
 ybI
 rRR
 wIK
+sTa
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+onk
+nDg
+uDG
+uDG
+fLc
+ybI
 ybI
 ybI
 ybI
@@ -96793,9 +101498,9 @@ idu
 idu
 idu
 idu
-idu
-idu
-idu
+erY
+erY
+erY
 idu
 idu
 idu
@@ -98951,7 +103656,7 @@ hbO
 ntJ
 qCO
 xXm
-lAD
+jmv
 hom
 mEy
 mvv
@@ -99208,7 +103913,7 @@ hom
 hom
 vKl
 xNm
-ooh
+jmv
 kRD
 ggK
 ggK

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -24902,6 +24902,15 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"oqH" = (
+/obj/machinery/button/door{
+	id = "loading1";
+	name = "Loading Bay 1";
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "orm" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -91475,7 +91484,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+oqH
 gcK
 gcK
 gcK


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Yuma Mall - a hub for shopping for the locals of Yuma before the bombs fell, now a ghoul-ridden coffin for any raider foolish enough to stumble in.

![yumamall](https://user-images.githubusercontent.com/58221064/122574413-eb15cb80-d04f-11eb-93f1-549165c350d9.png)

The mall has the following stores: 
The Friendly Pharm (pharmacy)
Prestige Jewellers (jewellery store)
Barbarian's Dungeon Comics (comics and hobby store)
Rick's Outdoor Goods (hunting/camping goods store)
Sullivan's Suits (formal clothing store)
General Atomics Outlet (electronics/appliances store)
and a small Slocum's Joe and Tobacconist kiosk

(also fixes a minor issue with my previous fast-food restaurant PR - adds a mountain tile where I had accidentally removed one)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because of the removal of the raider town, the mountain to the east of the map has been left bare. Not only is having a large chunk of the map relegated to a solid mountain boring, but its a waste of space. Thus the Yuma Mall serves as an interesting place for players to explore - it acts as a relatively easy dungeon for players to conquer. Naturally, players could also clean up the mall and use it as a base.

## Changelog
:cl:
add: Added the Yuma Mall
tweak: A minor change to the prewar drive-through restaurant
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
