### PR TITLE
Strange Reagent removal

### DIFF
--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -135,7 +135,6 @@ datum/bounty/reagent/chemical/New()
 		/datum/reagent/medicine/ephedrine,\
 		/datum/reagent/medicine/diphenhydramine,\
 		/datum/reagent/medicine/atropine,\
-		/datum/reagent/medicine/strange_reagent,\
 		/datum/reagent/medicine/regen_jelly,\
 		/datum/reagent/drug/space_drugs,\
 		/datum/reagent/drug/crank,\

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -54,7 +54,6 @@
 		/datum/reagent/carpet,
 		/datum/reagent/firefighting_foam,
 		/datum/reagent/consumable/tearjuice,
-		/datum/reagent/medicine/strange_reagent
 
 	)
 	//needs to be chemid unit checked at some point

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -223,7 +223,6 @@ Head Scribe
 		/obj/item/shield/energy=1, \
 		/obj/item/kitchen/knife/combat=1, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak/super=2, \
-		/obj/item/reagent_containers/dropper/SR/NotVault = 1
 		)
 
 /datum/outfit/loadout/hsstand

--- a/code/modules/jobs/job_types/followers.dm
+++ b/code/modules/jobs/job_types/followers.dm
@@ -84,7 +84,6 @@ Administrator
 		/obj/item/reagent_containers/medspray/synthflesh=2,
 		/obj/item/reagent_containers/hypospray/combat=1,
 		/obj/item/clothing/glasses/hud/health=1,
-		/obj/item/reagent_containers/dropper/SR/NotVault=1,
 		/obj/item/book/granter/trait/chemistry=1,
 		/obj/item/book/granter/trait/techno=1)
 

--- a/code/modules/jobs/job_types/vault.dm
+++ b/code/modules/jobs/job_types/vault.dm
@@ -168,7 +168,6 @@ Medical Doctor
 	satchel = 		/obj/item/storage/backpack/satchel/med
 	duffelbag = 	/obj/item/storage/backpack/duffelbag/med
 	backpack_contents = list(
-		/obj/item/reagent_containers/dropper/SR/Vault =1,
 		/obj/item/crowbar = 1)
 
 /datum/outfit/job/vault/f13doctor/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -926,7 +926,7 @@
 		M.losebreath++
 		. = 1
 	..()
-/* no. just no.
+/* no. just no. the revive timer is 30 minutes(hopefully lowered soon); that is plenty of time. we do not need this.
 /datum/reagent/medicine/strange_reagent
 	name = "Strange Reagent"
 	description = "A miracle drug capable of bringing the dead back to life. Only functions when applied by patch or spray, if the target has less than 100 brute and burn damage (independent of one another) and hasn't been husked. Causes slight damage to the living."
@@ -936,7 +936,7 @@
 	taste_description = "magnets"
 	pH = 0
 	value = REAGENT_VALUE_RARE
-*/
+
 /datum/reagent/medicine/strange_reagent/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(M.stat == DEAD)
 		if(M.suiciding || M.hellbound) //they are never coming back
@@ -986,7 +986,7 @@
 	M.adjustFireLoss(0.5*REM, 0)
 	..()
 	. = 1
-
+*/
 /datum/reagent/medicine/mannitol
 	name = "Mannitol"
 	description = "Efficiently restores brain damage."

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -926,7 +926,7 @@
 		M.losebreath++
 		. = 1
 	..()
-
+/* no. just no.
 /datum/reagent/medicine/strange_reagent
 	name = "Strange Reagent"
 	description = "A miracle drug capable of bringing the dead back to life. Only functions when applied by patch or spray, if the target has less than 100 brute and burn damage (independent of one another) and hasn't been husked. Causes slight damage to the living."
@@ -936,7 +936,7 @@
 	taste_description = "magnets"
 	pH = 0
 	value = REAGENT_VALUE_RARE
-
+*/
 /datum/reagent/medicine/strange_reagent/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(M.stat == DEAD)
 		if(M.suiciding || M.hellbound) //they are never coming back
@@ -1325,7 +1325,7 @@
 	pH = 11
 	value = REAGENT_VALUE_COMMON //not any higher. Ambrosia is a milestone for hydroponics already.
 
-	
+
 //Earthsblood is still a wonderdrug. Just... don't expect to be able to mutate something that makes plants so healthy.
 /datum/reagent/medicine/earthsblood/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray, mob/user)
 	. = ..()
@@ -1339,7 +1339,7 @@
 			myseed.adjust_yield(round(chems.get_reagent_amount(src.type) * 1))
 			myseed.adjust_endurance(round(chems.get_reagent_amount(src.type) * 0.5))
 			myseed.adjust_production(-round(chems.get_reagent_amount(src.type) * 0.5))
-	
+
 /datum/reagent/medicine/earthsblood/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(-3 * REM, FALSE)
 	M.adjustFireLoss(-3 * REM, FALSE)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -212,7 +212,7 @@
 	id = /datum/reagent/medicine/epinephrine
 	results = list(/datum/reagent/medicine/epinephrine = 6)
 	required_reagents = list(/datum/reagent/phenol = 1, /datum/reagent/acetone = 1, /datum/reagent/diethylamine = 1, /datum/reagent/oxygen = 1, /datum/reagent/chlorine = 1, /datum/reagent/hydrogen = 1)
-
+/* no. just no. the revive timer is 30 minutes(hopefully lowered soon); that is plenty of time. we do not need this.
 /datum/chemical_reaction/strange_reagent
 	name = "Strange Reagent"
 	id = /datum/reagent/medicine/strange_reagent
@@ -224,7 +224,7 @@
 	id = /datum/reagent/medicine/strange_reagent
 	results = list(/datum/reagent/medicine/strange_reagent = 2)
 	required_reagents = list(/datum/reagent/medicine/omnizine/protozine = 1, /datum/reagent/water/holywater = 1, /datum/reagent/toxin/mutagen = 1)
-
+*/
 /datum/chemical_reaction/mannitol
 	name = "Mannitol"
 	id = /datum/reagent/medicine/mannitol
@@ -388,4 +388,4 @@
 	name = "Bitter drink"
 	id = /datum/reagent/medicine/bitter_drink
 	results = list(/datum/reagent/medicine/bitter_drink = 30)
-	required_reagents = list(/datum/reagent/consumable/ethanol/salgam = 10 , /datum/reagent/consumable/ethanol/brocbrew = 10 , /datum/reagent/consumable/sunset = 10 , /datum/reagent/consumable/ethanol/yellowpulque = 10) 
+	required_reagents = list(/datum/reagent/consumable/ethanol/salgam = 10 , /datum/reagent/consumable/ethanol/brocbrew = 10 , /datum/reagent/consumable/sunset = 10 , /datum/reagent/consumable/ethanol/yellowpulque = 10)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -612,7 +612,7 @@
 	id = /datum/reagent/colorful_reagent
 	results = list(/datum/reagent/colorful_reagent = 5)
 	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/radium = 1, /datum/reagent/drug/space_drugs = 1, /datum/reagent/medicine/cryoxadone = 1, /datum/reagent/consumable/triple_citrus = 1)
-
+/* strange reagent removed
 /datum/chemical_reaction/life
 	name = "Life"
 	id = "life"
@@ -620,7 +620,7 @@
 	required_temp = 374
 
 /datum/chemical_reaction/life/on_reaction(datum/reagents/holder, multiplier)
-	chemical_mob_spawn(holder, rand(1, round(multiplier, 1)), "Life (friendly)", FRIENDLY_SPAWN) // a certain person keep abusing this to spawn like 20 mobs infront of ncr base 
+	chemical_mob_spawn(holder, rand(1, round(multiplier, 1)), "Life (friendly)", FRIENDLY_SPAWN) // a certain person keep abusing this to spawn like 20 mobs infront of ncr base
 
 //This is missing, I'm adding it back (see tgwiki). Not sure why we don't have it.
 /datum/chemical_reaction/life_friendly
@@ -643,7 +643,7 @@
 	for(var/i = rand(1, multiplier), i <= multiplier, i++) // More lulz.
 		new /mob/living/simple_animal/pet/dog/corgi(location)
 	..()
-
+*/
 /datum/chemical_reaction/hair_dye
 	name = "hair_dye"
 	id = /datum/reagent/hair_dye

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -118,7 +118,7 @@
 	var/location = get_turf(holder.my_atom)
 	empulse(location, multiplier)
 	holder.clear_reagents()
-
+/* strange reagent removed
 /datum/chemical_reaction/beesplosion
 	name = "Bee Explosion"
 	id = "beesplosion"
@@ -142,7 +142,7 @@
 			if(LAZYLEN(beeagents))
 				new_bee.assign_reagent(pick(beeagents))
 
-
+*/
 /datum/chemical_reaction/stabilizing_agent
 	name = "stabilizing_agent"
 	id = /datum/reagent/stabilizing_agent

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -95,16 +95,3 @@
 /obj/item/reagent_containers/dropper/get_belt_overlay()
 	return mutable_appearance('icons/obj/clothing/belt_overlays.dmi', "pouch")
 
-/obj/item/reagent_containers/dropper/SR/Vault
-	name = "Strange reagent dropper"
-	desc = "A dropper filled with a strange reagent,rumored to bring the dead back to life..."
-	icon = 'icons/obj/chemical.dmi'
-	icon_state = "dropper0"
-	list_reagents = list(/datum/reagent/medicine/strange_reagent = 2)
-
-/obj/item/reagent_containers/dropper/SR/NotVault
-	name = "Strange reagent dropper"
-	desc = "A dropper filled with a strange reagent,rumored to bring the dead back to life..."
-	icon = 'icons/obj/chemical.dmi'
-	icon_state = "dropper0"
-	list_reagents = list(/datum/reagent/medicine/strange_reagent = 3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Comments out strange reagent and it's recipe, life/life_friendly chems(not make-able anyways), and removes the SR dropper from all of the roles that spawn with it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The revive timer is 30 minutes. This is absolutely plenty of time to be revived, it is literally a fifth of the average round. In terms of revival, there are absolutely *no* limiting factors. Literally, none. Unless, of course, someone broke the rules. This adds an actual limiter to revival, that being the 30 minute revive timer. Before, with strange reagent, this timer was fluff and entirely pointless.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: strange reagent
del: life chem
del: life_friendly chem
del: sr dropper from all loadouts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
