### PR TITLE
Buffing .308 Damage

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -463,7 +463,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 5
-	extra_damage = 10
+	extra_damage = 5
 	extra_penetration = 0.2
 	can_scope = TRUE
 	scope_state = "kar_scope"
@@ -507,7 +507,7 @@
 	item_state = "paciencia"
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/remington/paciencia
 	fire_delay = 5
-	extra_damage = 20 //60 damage- hits as hard as an AMR!
+	extra_damage = 15 //60 damage- hits as hard as an AMR!
 	extra_penetration = 0.2
 
 /obj/item/gun/ballistic/shotgun/remington/paciencia/attackby(obj/item/A, mob/user, params) //no sawing off this one

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -22,10 +22,10 @@
 
 /obj/item/projectile/bullet/a762/sport //.308 Winchester
 	name = ".308 bullet"
-	damage = 35
-	armour_penetration = 0.08
-	wound_bonus = 10
-	bare_wound_bonus = -10
+	damage = 45 //35
+	armour_penetration = 0.25 //0.08
+	wound_bonus = 20 //10
+	bare_wound_bonus = -20 //-10
 
 /obj/item/projectile/bullet/a762/match
 	name = "7.62 match bullet"


### PR DESCRIPTION
## About The Pull Request

Buffs .308 projectile damage to 45 with stats equivalent to 7.62.  Niche guns chambered in .308 (Paciencia and kar98k) are balanced to have less of a bonus to compensate.

## Why It's Good For The Game

Currently the .308 hunting rifle (the only common gun that uses .308) is an inferior analogue to the Mosin Nagant due to lower damage while still being bolt-action.  This doesn't make sense given they're roughly equivalent cartridges.  This change gives .308 the same stats as 7.62 with one extra damage.  However .308 does not have other ammo types like 7.62.  This makes the hunting rifle a viable low-tier weapon and ghetto sniper rifle.

## Changelog
:cl:
balance: .308 cartridge buffed from 35 to 45 damage, armor pen from 0.08 to 0.25, wound bonus from 10 to 20, bare wound bonus from -10 to -20
balance: kar98k extra damage adjusted from 10 to 5, paciencia extra damage from 20 to 15
/:cl:
