### PR TITLE
Adds medical items to Legion and Tribals

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -26,6 +26,7 @@
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/stack/medical/poultice/ten,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
@@ -2244,6 +2245,11 @@
 /obj/machinery/light/small,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"bog" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/pill/patch/bitterdrink,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "bol" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -4852,6 +4858,7 @@
 /obj/structure/closet/crate/freezer/blood{
 	pixel_y = -5
 	},
+/obj/item/defibrillator/primitive,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "cWy" = (
@@ -5880,10 +5887,7 @@
 /area/f13/wasteland)
 "dzE" = (
 /obj/structure/table/wood/settler,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/smelling_salts/wayfarer,
-/obj/item/smelling_salts/wayfarer,
+/obj/item/defibrillator/primitive,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "dzK" = (
@@ -6890,6 +6894,7 @@
 /area/f13/building)
 "efO" = (
 /obj/machinery/chem_master/primitive,
+/obj/item/stack/medical/poultice/ten,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "egn" = (
@@ -32319,6 +32324,11 @@
 /obj/effect/spawner/lootdrop/crafts,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"szb" = (
+/obj/structure/table/wood,
+/obj/item/paper/bitterdrink,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "szi" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
@@ -56847,7 +56857,7 @@ jxq
 uRJ
 uRJ
 ntv
-iWc
+szb
 tBN
 mvv
 mvv
@@ -57104,7 +57114,7 @@ uRJ
 wsq
 uRJ
 mqp
-iWc
+bog
 tBN
 mvv
 mvv


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds both factions a primitive defibrillator since salts are fucking borked and tbh kinda shit. While also adding morning poultice, essentially a healing item like synth flesh for your dead buddies.

## Why It's Good For The Game

Cant heal anyone as either faction without an ahelp currently, this fixes that problem.

## Changelog
:cl:
add: prim defibs and morning poultice to tribe and legion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
