### PR TITLE
Random spawn hard counters are a dumb mechanic (nerfs the pulse rifle and its effect against PA)

### DIFF
--- a/code/modules/clothing/head/f13head.dm
+++ b/code/modules/clothing/head/f13head.dm
@@ -333,19 +333,11 @@
 	if(emped == 0)
 		if(ismob(loc))
 			to_chat(loc, "<span class='warning'>Warning: electromagnetic surge detected in helmet. Rerouting power to emergency systems.</span>")
-			tint += 2
-			if(istype(loc, /mob/living/carbon))
-				var/mob/living/carbon/M = loc
-				M.update_tint()
-			armor = armor.modifyRating(linemelee = -50, linebullet = -50, linelaser = -50)
+			armor = armor.modifyRating(linemelee = -100, linebullet = -100, linelaser = -100)
 			emped = 1
 			spawn(50) //5 seconds of being blind and weak
 				to_chat(loc, "<span class='warning'>Helmet power reroute successful. All systems operational.</span>")
-				tint -= 2
-				if(istype(loc, /mob/living/carbon))
-					var/mob/living/carbon/M = loc
-					M.update_tint()
-				armor = armor.modifyRating(linemelee = 50, linebullet = 50, linelaser = 50)
+				armor = armor.modifyRating(linemelee = 100, linebullet = 100, linelaser = 100)
 				emped = 0
 
 /obj/item/clothing/head/helmet/f13/power_armor/run_block(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)

--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -317,13 +317,13 @@
 	if(emped == 0)
 		if(ismob(loc))
 			to_chat(loc, "<span class='warning'>Warning: electromagnetic surge detected in armor. Rerouting power to emergency systems.</span>")
-			slowdown += 30
-			armor = armor.modifyRating(linemelee = -75, linebullet = -75, linelaser = -75)
+			slowdown += 1.2
+			armor = armor.modifyRating(linemelee = -100, linebullet = -100, linelaser = -100)
 			emped = 1
 			spawn(50) //5 seconds of being slow and weak
 				to_chat(loc, "<span class='warning'>Armor power reroute successful. All systems operational.</span>")
-				slowdown -= 30
-				armor = armor.modifyRating(linemelee = 75, linebullet = 75, linelaser = 75)
+				slowdown -= 1.2
+				armor = armor.modifyRating(linemelee = 100, linebullet = 100, linelaser = 100)
 				emped = 0
 
 /obj/item/clothing/suit/armor/f13/power_armor/run_block(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -1,5 +1,5 @@
 /obj/item/ammo_casing/energy/ion
-	projectile_type = /obj/item/projectile/ion
+	projectile_type = /obj/item/projectile/ion/weak
 	select_name = "ion"
 	fire_sound = 'sound/weapons/ionrifle.ogg'
 

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -4,7 +4,7 @@
 	fire_sound = 'sound/weapons/ionrifle.ogg'
 
 /obj/item/ammo_casing/energy/ion/hos
-	projectile_type = /obj/item/projectile/ion
+	projectile_type = /obj/item/projectile/ion/weak
 	e_cost = 200
 
 /obj/item/ammo_casing/energy/declone

--- a/code/modules/projectiles/projectile/special/ion.dm
+++ b/code/modules/projectiles/projectile/special/ion.dm
@@ -15,5 +15,5 @@
 
 /obj/item/projectile/ion/weak
 	emp_radius = 1
-	damage = 12
+	damage = 20
 	armour_penetration = 0.5

--- a/code/modules/projectiles/projectile/special/ion.dm
+++ b/code/modules/projectiles/projectile/special/ion.dm
@@ -15,5 +15,5 @@
 
 /obj/item/projectile/ion/weak
 	emp_radius = 1
-	damage = 25
+	damage = 12
 	armour_penetration = 0.5


### PR DESCRIPTION
This gives the pulse rifle the weak EMP, nerfs the weak EMP's damage by 5 points and makes it so that you're as slow as wearing salvaged PA when ioned in PA instead of being completely immobilized and reduces your protection when ioned by 2 tiers instead of 1. Also removes the blinding effect because it makes no sense.

Basically, the nerfed ion gun range means you need to aim with it and won't accidentally hit yourself. The nerfed effect against PA is deserved considering the ion effect drains all your energy weapons and fries your implants as well, which is more than good enough to make it worth.