### PR TITLE
The Breacher/Riot gun conspiracy

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
@@ -330,9 +330,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/ammo_casing/shotgun/dart,
 /obj/item/ammo_casing/shotgun/dart,
-/obj/item/gun/ballistic/revolver/doublebarrel{
-	desc = "For putting critters out to pasture."
-	},
 /obj/item/ammo_casing/shotgun/buckshot,
 /obj/item/storage/box/bodybags,
 /obj/machinery/light/small{

--- a/_maps/RandomZLevels/away_mission/SnowCabin.dmm
+++ b/_maps/RandomZLevels/away_mission/SnowCabin.dmm
@@ -355,7 +355,7 @@
 /area/awaymission/cabin)
 "aZ" = (
 /obj/structure/guncase/shotgun,
-/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/police,
 /turf/open/floor/carpet,
 /area/awaymission/cabin)
 "ba" = (

--- a/_maps/RandomZLevels/away_mission/challenge.dmm
+++ b/_maps/RandomZLevels/away_mission/challenge.dmm
@@ -531,7 +531,6 @@
 	},
 /area/awaymission/challenge/end)
 "bQ" = (
-/obj/item/gun/ballistic/revolver/russian,
 /turf/open/floor/plasteel/white/side,
 /area/awaymission/challenge/main)
 "bR" = (
@@ -658,7 +657,6 @@
 /area/awaymission/challenge/end)
 "ck" = (
 /obj/structure/rack,
-/obj/item/gun/ballistic/revolver/doublebarrel/improvised,
 /turf/open/floor/wood,
 /area/awaymission/challenge/end)
 "cl" = (
@@ -730,7 +728,6 @@
 /area/awaymission/challenge/end)
 "cw" = (
 /obj/structure/rack,
-/obj/item/gun/ballistic/revolver/doublebarrel,
 /turf/open/floor/wood,
 /area/awaymission/challenge/end)
 "cx" = (

--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -8372,7 +8372,7 @@
 /obj/structure/closet,
 /obj/item/clothing/neck/cloak/hos,
 /obj/item/clothing/under/hosparademale,
-/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/police,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
 "kDk" = (
@@ -17111,9 +17111,9 @@
 "vwT" = (
 /obj/structure/guncase/shotgun,
 /obj/effect/turf_decal/bot,
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/police,
+/obj/item/gun/ballistic/shotgun/police,
+/obj/item/gun/ballistic/shotgun/police,
 /turf/open/floor/plasteel/darkred/side{
 	dir = 9
 	},

--- a/_maps/map_files/Pahrump/old/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/old/Dungeons.dmm
@@ -5008,7 +5008,7 @@
 	},
 /area/f13/bunker)
 "mV" = (
-/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/police,
 /obj/structure/guncase/shotgun,
 /obj/effect/turf_decal/stripes/red/full,
 /obj/structure/window/reinforced/spawner,
@@ -12091,7 +12091,7 @@
 /obj/structure/closet,
 /obj/item/clothing/neck/cloak/hos,
 /obj/item/clothing/under/hosparademale,
-/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/police,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
 "HD" = (
@@ -17481,9 +17481,9 @@
 "Vh" = (
 /obj/structure/guncase/shotgun,
 /obj/effect/turf_decal/bot,
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/police,
+/obj/item/gun/ballistic/shotgun/police,
+/obj/item/gun/ballistic/shotgun/police,
 /turf/open/floor/plasteel/darkred/side{
 	dir = 9
 	},

--- a/_maps/map_files/StJeromes/StJeromesValley.dmm
+++ b/_maps/map_files/StJeromes/StJeromesValley.dmm
@@ -28817,7 +28817,7 @@
 /area/f13/underground/cave/vault/fourfivefour)
 "bHY" = (
 /obj/structure/rack,
-/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/police,
 /obj/item/storage/box/teargas,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"

--- a/_maps/map_files/Sunnyvale/Dungeons.dmm
+++ b/_maps/map_files/Sunnyvale/Dungeons.dmm
@@ -3632,13 +3632,13 @@
 	},
 /area/f13/bunker)
 "iP" = (
-/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/police,
 /obj/structure/guncase/shotgun,
 /obj/effect/turf_decal/stripes/red/full,
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/east,
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/police,
+/obj/item/gun/ballistic/shotgun/police,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -591,7 +591,7 @@
 //lever action
 /datum/crafting_recipe/lever_action
 	name = "Lever Action Shotgun"
-	result = /obj/item/gun/ballistic/shotgun/trench
+	result = /obj/item/gun/ballistic/shotgun/automatic/hunting/shotgunlever
 	reqs = list(/obj/item/stack/sheet/metal = 5,
 				/obj/item/advanced_crafting_components/receiver = 1,
 				/obj/item/stack/crafting/metalparts = 3,
@@ -746,7 +746,7 @@
 
 //breacher
 /datum/crafting_recipe/breacher
-	name = "Breacher Shotgun"
+	name = "Riot Shotgun"
 	result = /obj/item/gun/ballistic/automatic/shotgun/riot
 	reqs = list(/obj/item/stack/sheet/metal = 5,
 				/obj/item/advanced_crafting_components/alloys = 1,

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -702,10 +702,10 @@
 				)
 
 /obj/effect/spawner/bundle/f13/single_shotgun
-	name = "single single-shot single shotgun and ammo spawner"
+	name = "single slam-fire shotgun and ammo spawner"
 	items = list(
 				/obj/item/gun/ballistic/revolver/single_shotgun,
-				/obj/item/ammo_box/shotgun/bean
+				/obj/item/ammo_box/shotgun/buck
 				)
 
 /obj/effect/spawner/bundle/f13/caravan_shotgun

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -109,7 +109,6 @@
 	new /obj/item/flashlight/seclite(src)
 	new /obj/item/clothing/gloves/krav_maga/sec(src)
 	new /obj/item/door_remote/head_of_security(src)
-	new /obj/item/gun/ballistic/shotgun/riot(src)
 	new /obj/item/clothing/head/beret/sec/corporatewarden(src)
 /obj/structure/closet/secure_closet/security
 	name = "security officer's locker"
@@ -234,8 +233,6 @@
 	new /obj/item/storage/box/firingpins(src)
 	for(var/i in 1 to 3)
 		new /obj/item/storage/fancy/ammobox(src)
-	for(var/i in 1 to 3)
-		new /obj/item/gun/ballistic/shotgun/riot(src)
 /obj/structure/closet/secure_closet/armory3
 	name = "armory energy gun locker"
 	req_access = list(ACCESS_ARMORY)

--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -1,10 +1,3 @@
-/datum/bounty/item/security/riotshotgun
-	name = "Riot Shotguns"
-	description = "Hooligans have boarded CentCom! Ship riot shotguns quick, or things are going to get dirty."
-	reward = 2500
-	required_count = 2
-	wanted_types = list(/obj/item/gun/ballistic/shotgun/riot)
-
 /datum/bounty/item/security/recharger
 	name = "Rechargers"
 	description = "Nanotrasen military academy is conducting marksmanship exercises. They request that rechargers be shipped."
@@ -38,13 +31,6 @@
 	reward = 3500
 	required_count = 15
 	wanted_types = list(/obj/item/ammo_casing/shotgun/techshell)
-
-/datum/bounty/item/security/wt550
-	name = "Spare WT-550 clips"
-	description = "Nanotrasen Military Academy's ammunition is running low, please send in spare ammo for practice."
-	reward = 1500
-	required_count = 5
-	wanted_types = list(/obj/item/ammo_box/magazine/wt550m9)
 
 /datum/bounty/item/security/pins
 	name = "Test range firing pins"

--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -170,12 +170,12 @@
 	crate_name = "kitchen cutlery deluxe set"
 
 /datum/supply_pack/service/replacementdb
-	name = "Replacement Defensive Bar Shotgun"
+	name = "Replacement Defensive Bar"
 	desc = "Someone stole the Bartender's twin-barreled possession? Give them another one at a significant markup. Comes with one unused double-barrel shotgun, shells not included. Requires bartender access to open."
 	cost = 2200
 	access = ACCESS_BAR
 	contraband = TRUE
-	contains = list(/obj/item/gun/ballistic/revolver/doublebarrel)
+	contains = list(/obj/item/kitchen/knife/butcher)
 	crate_name = "replacement double-barrel crate"
 	crate_type = /obj/structure/closet/crate/secure
 

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -319,7 +319,7 @@ Head Knight
 /datum/outfit/loadout/capalt
 	name = "Warden-Defender"
 	backpack_contents = list(
-		/obj/item/gun/ballistic/shotgun/riot=1,
+		/obj/item/gun/ballistic/shotgun/police=1,
 		/obj/item/storage/fancy/ammobox/lethalshot=2,
 		/obj/item/stock_parts/cell/ammo/ec=2,
 		/obj/item/gun/energy/laser/pistol=1
@@ -669,7 +669,7 @@ datum/job/bos/f13seniorknight
 /datum/outfit/loadout/sknightb
 	name = "Knight-Defender"
 	backpack_contents = list(
-		/obj/item/gun/ballistic/shotgun/riot=1,
+		/obj/item/gun/ballistic/shotgun/police=1,
 		/obj/item/storage/fancy/ammobox/lethalshot=2,
 		/obj/item/stock_parts/cell/ammo/ec=2,
 		/obj/item/gun/energy/laser/pistol=1

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -797,7 +797,7 @@ Raider
 
 /datum/outfit/loadout/bodyguard
 	name = "Bodyguard"
-	r_hand = /obj/item/gun/ballistic/shotgun/police,
+	r_hand = /obj/item/gun/ballistic/shotgun/police
 	suit = /obj/item/clothing/suit/armor/vest
 	backpack_contents = list(
 						/obj/item/ammo_box/shotgun/buck=2, \

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -797,7 +797,7 @@ Raider
 
 /datum/outfit/loadout/bodyguard
 	name = "Bodyguard"
-	r_hand = /obj/item/gun/ballistic/shotgun/riot
+	r_hand = /obj/item/gun/ballistic/shotgun/police,
 	suit = /obj/item/clothing/suit/armor/vest
 	backpack_contents = list(
 						/obj/item/ammo_box/shotgun/buck=2, \

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1105,7 +1105,7 @@
 		if(1)
 			new /obj/item/mayhem(src)
 		if(2)
-			new /obj/item/gun/ballistic/revolver/doublebarrel/super(src)
+			new /obj/item/guardiancreator(src)
 		if(3)
 			new /obj/item/guardiancreator(src)
 
@@ -1175,17 +1175,6 @@
 
 	log_combat(user, L, "took out a blood contract on", src)
 	qdel(src)
-
-/obj/item/gun/ballistic/revolver/doublebarrel/super
-	name = "super combat shotgun"
-	desc = "From the belly of the beast - or rather, demon. Twice as lethal as a less-than-super shotgun, but a tad bulkier."
-	icon_state = "heckgun"
-	slot_flags = null
-	mag_type = /obj/item/ammo_box/magazine/internal/shot/dual/heck
-	burst_size = 2
-	burst_shot_delay = 0
-	unique_reskin = null
-	sawn_off = TRUE
 
 //Colossus
 /obj/structure/closet/crate/necropolis/colossus

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -186,9 +186,9 @@
 		icon_state = "[initial(icon_state)]"
 
 
-//Riot Shotgun. 6 round pump action, folding stock
-/obj/item/gun/ballistic/shotgun/riot
-	name = "riot shotgun"
+//Police Shotgun. 6 round pump action, folding stock
+/obj/item/gun/ballistic/shotgun/police
+	name = "police shotgun"
 	desc = "A old-world shotgun with large magazine and folding stock, made from steel and polymers."
 	icon_state = "shotgunriot"
 	item_state = "shotgunriot"
@@ -199,18 +199,18 @@
 	recoil = 2
 	spread = 2
 
-/obj/item/gun/ballistic/shotgun/riot/AltClick(mob/living/user)
+/obj/item/gun/ballistic/shotgun/police/AltClick(mob/living/user)
 	. = ..()
 	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
 	toggle_stock(user)
 	return TRUE
 
-/obj/item/gun/ballistic/shotgun/riot/examine(mob/user)
+/obj/item/gun/ballistic/shotgun/police/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>Alt-click to toggle the stock.</span>"
 
-/obj/item/gun/ballistic/shotgun/riot/proc/toggle_stock(mob/living/user)
+/obj/item/gun/ballistic/shotgun/police/proc/toggle_stock(mob/living/user)
 	stock = !stock
 	if(stock)
 		w_class = WEIGHT_CLASS_BULKY
@@ -224,7 +224,7 @@
 		spread = 3
 	update_icon()
 
-/obj/item/gun/ballistic/shotgun/riot/update_icon_state()
+/obj/item/gun/ballistic/shotgun/police/update_icon_state()
 	icon_state = "[current_skin ? unique_reskin[current_skin] : "shotgunriot"][stock ? "" : "fold"]"
 
 
@@ -334,10 +334,10 @@
 	var/semi_auto = TRUE
 
 
-//Breacher. 12 round drum, semiauto, pistol grip
+//Riot shotgun. 12 round drum, semiauto, pistol grip
 /obj/item/gun/ballistic/automatic/shotgun/riot
-	name = "Breacher shotgun"
-	desc = "A compact riot shotgun designed to fight in close quarters."
+	name = "Riot shotgun"
+	desc = "A compact riot shotgun with a large ammo drum and semi-automatic fire, designed to fight in close quarters."
 	icon = 'icons/fallout/objects/guns/ballistic.dmi'
 	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
@@ -346,8 +346,8 @@
 	mag_type = /obj/item/ammo_box/magazine/d12g
 	fire_delay = 7
 	burst_size = 1
-	recoil = 1 //Standard malus for sawn off stock
-	spread = 2 //Standard malus for sawn off stock
+	recoil = 1 //Standard malus for pistol grip
+	spread = 2 //Standard malus for pistol grip
 	automatic_burst_overlay = FALSE
 	semi_auto = TRUE
 	fire_sound = 'sound/f13weapons/riot_shotgun.ogg'
@@ -413,8 +413,8 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 	extra_damage = 0 //Normal barrel length for ammo
-	recoil = 1 //Standard malus for sawn off stock
-	spread = 2 //Standard malus for sawn off stock
+	recoil = 1 //Standard malus for pistol grip
+	spread = 2 //Standard malus for pistol grip
 	can_scope = FALSE
 	fire_sound = 'sound/f13weapons/shotgun.ogg'
 
@@ -544,7 +544,7 @@
 //Plasma musket.
 /obj/item/gun/ballistic/shotgun/plasmacaster
 	name = "Plasma Musket"
-	desc = "The cooling looks dubious and is that a empty can of beans used as a safty valve? Pray the plasma goes towards the enemy and not your face when you pull the trigger."
+	desc = "The cooling looks dubious and is that a empty can of beans used as a safety valve? Pray the plasma goes towards the enemy and not your face when you pull the trigger."
 	icon = 'icons/fallout/objects/guns/energy.dmi'
 	icon_state = "plasmamusket"
 	item_state = "plasmamusket"
@@ -552,10 +552,6 @@
 	fire_delay = 20
 	var/bolt_open = FALSE
 	isenergy = TRUE
-	can_bayonet = TRUE
-	bayonet_state = "lasmusket"
-	knife_x_offset = 23
-	knife_y_offset = 21
 	can_scope = TRUE
 	scope_state = "lasmusket_scope"
 	scope_x_offset = 9

--- a/modular_citadel/code/game/objects/cit_screenshake.dm
+++ b/modular_citadel/code/game/objects/cit_screenshake.dm
@@ -35,9 +35,6 @@
 /obj/item/gun/ballistic/revolver
 	recoil = 0.5
 
-/obj/item/gun/ballistic/revolver/doublebarrel
-	recoil = 1
-
 /obj/item/gun/syringe
 	recoil = 0.1
 


### PR DESCRIPTION
## About The Pull Request

Breacher was always a lazy rename to avoid repathing guns. Since its now done, no point keeping the bandaid, the gun was named Riot shotgun in NV and so it shall be. Repathing with all instances edited done.
The folding stock shotgun renamed police shotgun.
Standard cleaning of mostly shotgun related legacy stuff in affected files.
Couple spelling and comment errors fixed in the shotgun file.

## Changelog
:cl:
fix: The so called Breacher renamed to its proper name, Riot shotgun, and the folding stock shotty named police shotgun.
/:cl:
