### PR TITLE
tweaks tribe pop numbers

### DIFF
--- a/code/modules/jobs/job_types/tribals.dm
+++ b/code/modules/jobs/job_types/tribals.dm
@@ -185,6 +185,7 @@ Tribal Head Hunter
 		/obj/item/restraints/legcuffs/bola=1,
 		/obj/item/reagent_containers/pill/patch/healingpowder=2,
 		/obj/item/stack/medical/gauze=1,
+		/obj/item/restraints/legcuffs/bola/tactical=2,
 		/obj/item/flashlight/flare/torch=1)
 
 /*
@@ -239,10 +240,10 @@ Villager
 	flag = F13VILLAGER
 	department_flag = TRIBAL
 	faction = "Village"
-	total_positions = 6
-	spawn_positions = 6
+	total_positions = 4
+	spawn_positions = 4
 	supervisors = "Tribal Chief, Shaman and Headhunter"
-	description = "A proud member of the Wayfarer tribe, you do what needs to be done to ensure the survival of yourself and your people while following the laws of the tribe."
+	description = "A proud member of the Wayfarer tribe, you do what needs to be done to ensure the survival of yourself and your people while following the laws of the tribe. While it is common to venture out into the wasteland, do not thread far or without informing your kin."
 	selection_color = "#006666"
 	exp_requirements = 300
 
@@ -364,7 +365,7 @@ Hunter
 		/obj/item/clothing/suit/armor/f13/lightcloak=1,
 		/obj/item/storage/belt/tribe_quiver=1,
 		/obj/item/kitchen/knife/combat/bone=1,
-		/obj/item/restraints/legcuffs/bola/tactical=2,
+		/obj/item/restraints/legcuffs/bola=2,
 		/obj/item/binoculars=1,
 		/obj/item/reagent_containers/pill/patch/healingpowder=1
 	)
@@ -375,6 +376,7 @@ Hunter
 		/obj/item/twohanded/spear/bonespear/deathclaw=1,
 		/obj/item/kitchen/knife/combat/bone=1,
 		/obj/item/binoculars=1,
+		/obj/item/restraints/legcuffs/bola/tactical=2,
 		/obj/item/reagent_containers/pill/patch/healingpowder=1
 	)
 
@@ -386,10 +388,10 @@ Spirit-Pledged
 	flag = F13SPIRITPLEDGED
 	department_flag = TRIBAL
 	faction = "Village"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 4
+	spawn_positions = 4
 	supervisors = "All other tribals."
-	description = "An outsider to the tribe, you have been welcomed to learn their ways and grow closer to their culture and lifestyle."
+	description = "An outsider to the tribe, you have been welcomed to learn their ways and grow closer to their culture and lifestyle, do NOT run off alone into the wasteland without the supervision of another higher ranking tribal."
 	selection_color = "#006666"
 
 	outfit = /datum/outfit/job/tribal/f13spiritpledged


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tweaks loadout for tribals and also increases the pledge slot for more new players.

## Why It's Good For The Game

Tribal loadouts are pretty lacking, they have very barebones items like a bow and the dclaw spear. This gives more variety to their weapon pool as well as utilizing every tool for every job. Also, more pledge slots for more learning players and the reduction of regular villager slots. 6 > 4 Villager and 2 > 4 Pledge

## Changelog
:cl:
tweak: tribe faction numbers
balance: tribe loadouts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
