### PR TITLE
Added permeability coefficient to lots of things.

### DIFF
--- a/code/modules/clothing/glasses/f13.dm
+++ b/code/modules/clothing/glasses/f13.dm
@@ -8,24 +8,28 @@
 	desc = "Simple goggles to protect against wind and dirt."
 	icon_state = "biker"
 	item_state = "biker"
+	permeability_coefficient = 0.05 // for chemicals/diseases. 1 is no protection, 0.01 is effective immunity.
 
 /obj/item/clothing/glasses/legiongoggles
 	name = "sandstorm goggles"
 	desc = "Post-war makeshift protective goggles made by legion artisans."
 	icon_state = "legion"
 	item_state = "legion"
+	permeability_coefficient = 0.05
 
 /obj/item/clothing/glasses/legionpolarizing
 	name = "polarizing goggles"
 	desc = "Fancy goggles with rare polarizing glass, usually reserved for commanders due to rarity."
 	icon_state = "legpolarizing"
 	item_state = "legpolarizing"
+	permeability_coefficient = 0.05
 
 //Fallout 13 sunglasses
 
 /obj/item/clothing/glasses/sunglasses/f13
 	icon = 'icons/fallout/clothing/glasses.dmi'
 	armor = list(melee = 10, bullet = 10, laser = 10, energy = 10, bomb = 10, bio = 10, rad = 10, fire = 10, acid = 10)
+	permeability_coefficient = 0.9 // 10% protection. Not great, but not nothing!
 
 
 //Fallout 13 thermals
@@ -33,6 +37,7 @@
 /obj/item/clothing/glasses/thermal/f13
 	icon = 'icons/fallout/clothing/glasses.dmi'
 	armor = list(melee = 10, bullet = 10, laser = 10, energy = 10, bomb = 10, bio = 10, rad = 10, fire = 10, acid = 10)
+	permeability_coefficient = 0.9
 
 /obj/item/clothing/glasses/thermal/f13/doctorwho
 	name = "3D glasses"
@@ -46,12 +51,14 @@
 	desc = "Heat-sensitive goggles commonly worn by Enclave vertibird pilots."
 	icon_state = "enclavegoggles"
 	item_state = "enclavegoggles"
+	permeability_coefficient = 0.01
 
 //Fallout 13 science goggles
 
 /obj/item/clothing/glasses/science/f13
 	icon = 'icons/fallout/clothing/glasses.dmi'
 	armor = list(melee = 10, bullet = 10, laser = 10, energy = 10, bomb = 10, bio = 10, rad = 10, fire = 10, acid = 10)
+	permeability_coefficient = 0.01
 
 /obj/item/clothing/glasses/science/f13/steampunk
 	name = "\improper goggles"

--- a/code/modules/clothing/gloves/f13gloves.dm
+++ b/code/modules/clothing/gloves/f13gloves.dm
@@ -1,5 +1,6 @@
 /obj/item/clothing/gloves/f13
 	armor = list(melee = 10, bullet = 10, laser = 10, energy = 10, bomb = 10, bio = 10, rad = 10, fire = 10, acid = 10)
+	permeability_coefficient = 0.9 // for chemicals/diseases. 1 is no protection, 0.01 is effective immunity. Defaulting to 10% protection.
 
 /obj/item/clothing/gloves/f13/baseball
 	name = "baseball glove"
@@ -31,6 +32,7 @@
 	icon_state = "ncr_gloves"
 	item_state = "ncr_gloves"
 	transfer_prints = TRUE
+	permeability_coefficient = 0.95
 
 /obj/item/clothing/gloves/f13/military
 	name = "military gloves"
@@ -44,6 +46,7 @@
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
+	permeability_coefficient = 0.05
 
 /obj/item/clothing/gloves/f13/doom
 	name = "strange gloves"
@@ -58,6 +61,7 @@
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	armor = list(melee = 10, bullet = 10, laser = 10, energy = 10, bomb = 10, bio = 80, rad = 80, fire = 80, acid = 50)
+	permeability_coefficient = 0.01
 
 /obj/item/clothing/gloves/f13/handwraps
 	name = "handwraps"
@@ -71,6 +75,7 @@
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
+	permeability_coefficient = 0.95 // Only 5% defense for you.
 
 /obj/item/clothing/gloves/f13/lace
 	name = "lace gloves"
@@ -97,6 +102,7 @@
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
+	permeability_coefficient = 0.05
 
 /obj/item/clothing/gloves/f13/crudemedical
 	name = "crude medical gloves"
@@ -112,6 +118,7 @@
 	icon_state = "mutie_bracer"
 	item_state = "mutie_bracer"
 	armor = list("tier" = 4, "energy" = 40, "bomb" = 50, "bio" = 60, "rad" = 10, "fire" = 60, "acid" = 20)
+	permeability_coefficient = 1 // This isn't stopping any chemical splash at all
 
 /obj/item/clothing/gloves/f13/mutant/mk2
 	name = "mutant bracers"

--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -56,6 +56,7 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	armor = list("tier" = 4, "energy" = 25, "bomb" = 30, "bio" = 20, "rad" = 0, "fire" = 50, "acid" = 0)
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+	permeability_coefficient = 0.7 // for chemicals/diseases. 1 is no protection, 0.01 is effective immunity. Doing 30% for this, only covers the top of the head. Better wear a gas mask!
 
 /obj/item/clothing/head/helmet/f13/raider/supafly
 	name = "supa-fly raider helmet"
@@ -187,6 +188,7 @@
 	flags_inv = HIDEEARS|HIDEFACE
 	flags_cover = null
 	armor = list("tier" = 1)
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/helmet/f13/helmet/enclave/intel
 	name = "intel beret"
@@ -223,6 +225,7 @@
 	item_state = "legslaveservant"
 	flags_inv = HIDEEARS|HIDEFACE
 	flags_cover = null
+	permeability_coefficient = 0.7 // Not as good as true medical gear, but better than nothing!
 
 /obj/item/clothing/head/f13/legion/auxilia
 	name = "auxilia headwear"
@@ -231,6 +234,7 @@
 	item_state = "legaux"
 	flags_inv = HIDEEARS|HIDEFACE
 	flags_cover = null
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/helmet/f13/legion
 	name = "legion helmet"
@@ -244,6 +248,7 @@
 	strip_delay = 50
 	dynamic_hair_suffix = ""
 	dynamic_fhair_suffix = ""
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/helmet/f13/legion/recruit
 	name = "legion recruit helmet"
@@ -263,6 +268,7 @@
 	item_state = "legprime"
 	icon_state = "legprime"
 	armor = list("tier" = 4, "energy" = 15, "bomb" = 25, "bio" = 40, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.6
 
 /obj/item/clothing/head/helmet/f13/legion/prime/slavemaster
 	name = "slave master helmet"
@@ -279,6 +285,7 @@
 	icon_state = "legvet"
 	item_state = "legvet"
 	armor = list("tier" = 5, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 20, "fire" = 70, "acid" = 0)
+	permeability_coefficient = 0.5
 
 /obj/item/clothing/head/helmet/f13/legion/heavy
 	name = "legion veteran decan helmet"
@@ -287,12 +294,14 @@
 	item_state = "legheavy"
 	armor = list("tier" = 6, "energy" = 15, "bomb" = 25, "bio" = 60, "rad" = 20, "fire" = 75, "acid" = 10)
 	actions_types = list(/datum/action/item_action/toggle)
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/head/helmet/f13/legion/heavy/attack_self(mob/user)
 	weldingvisortoggle(user)
 	icon_state = "legheavyup"
 	item_state = "legheavyup"
 	armor = list("tier" = 6, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 20, "fire" = 70, "acid" = 0)
+	permeability_coefficient = 0.5
 
 /obj/item/clothing/head/helmet/f13/legion/vet/explorer
 	name = "legion explorer hood"
@@ -318,6 +327,7 @@
 	icon_state = "legvenator"
 	item_state = "legvenator"
 	armor = list("tier" = 6, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 20, "fire" = 70, "acid" = 0)
+	permeability_coefficient = 0.5
 
 /obj/item/clothing/head/helmet/f13/legion/libritor
 	name = "legion libritor helmet"
@@ -325,6 +335,7 @@
 	icon_state = "legheavy"
 	item_state = "legheavy"
 	armor = list("tier" = 7, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 20, "fire" = 70, "acid" = 0)
+	permeability_coefficient = 0.5
 
 /obj/item/clothing/head/helmet/f13/legion/recruit/decan
 	name = "legion recruit decanus helmet"
@@ -332,6 +343,7 @@
 	icon_state = "legdecan"
 	item_state = "legdecan"
 	armor = list("tier" = 5, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 20, "fire" = 70, "acid" = 0)
+	permeability_coefficient = 0.5
 
 /obj/item/clothing/head/helmet/f13/legion/prime/decan
 	name = "legion prime decanus helmet"
@@ -339,6 +351,7 @@
 	item_state = "legdecanprim"
 	icon_state = "legdecanprim"
 	armor = list("tier" = 5, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 20, "fire" = 70, "acid" = 0)
+	permeability_coefficient = 0.5
 
 /obj/item/clothing/head/helmet/f13/legion/vet/decan
 	name = "legion veteran decanus helmet"
@@ -346,7 +359,7 @@
 	icon_state = "legdecanvet"
 	item_state = "legdecanvet"
 	armor = list("tier" = 6, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 20, "fire" = 70, "acid" = 0)
-
+	permeability_coefficient = 0.5
 
 /obj/item/clothing/head/helmet/f13/legion/centurion
 	name = "legion centurion helmet"
@@ -355,6 +368,7 @@
 	item_state = "legcenturion"
 	armor = list("tier" = 6, "energy" = 35, "bomb" = 39, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0)
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/head/helmet/f13/legion/rangercent
 	name = "ranger-hunter centurion helmet"
@@ -363,6 +377,7 @@
 	item_state = "rangercent"
 	armor = list("tier" = 5, "energy" = 35, "bomb" = 39, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0)
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/head/helmet/f13/legion/palacent
 	name = "paladin-slayer centurion helmet"
@@ -371,12 +386,14 @@
 	item_state = "palacent"
 	armor = list("tier" = 6, "energy" = 35, "bomb" = 39, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0)
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/head/helmet/f13/legion/palacent/custom_excess
 	name = "Champion of Kanab's Helm"
 	desc = "(VII) A custom forged steel full helmet made for the Conqueror and Champion of Kanab. It has a large plume of red horse hair across the top of it going horizontally, symbolizing the position of a Centurion."
 	icon_state = "palacent_excess"
 	item_state = "palacent_excess"
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/head/helmet/f13/legion/legate
 	name = "legion legate helmet"
@@ -387,6 +404,7 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	flags_inv = HIDEEARS|HIDEEYES|HIDEHAIR
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/head/helmet/f13/legion/marsheaddress
 	name = "priestess' headdress"
@@ -394,6 +412,7 @@
 	icon_state = "mars_headdress"
 	item_state = "mars_headdress"
 	dynamic_hair_suffix = "+generic"
+	permeability_coefficient = 0.01 // Blessed by Mars... And the admemes.
 
 /obj/item/clothing/head/helmet/f13/combat/legion
 	name = "Legion combat helmet"
@@ -418,6 +437,7 @@
 	strip_delay = 50
 	obj_flags = UNIQUE_RENAME
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets
+	permeability_coefficient = 0.7 // The goggles do nothing!
 
 /obj/item/clothing/head/f13/ncr/Initialize()
 	. = ..()
@@ -496,6 +516,7 @@
 	armor = list("tier" = 5, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 	icon_state = "ncr_flapcap"
 	item_state = "ncr_flapcap"
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/f13/ncr_slouch
 	name = "NCR slouch hat"
@@ -503,6 +524,7 @@
 	icon_state = "ncr_slouch"
 	item_state = "ncr_slouch"
 	armor = list("tier" = 5, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/beret/ncr
 	name = "NCR officer beret"
@@ -510,6 +532,7 @@
 	icon_state = "ncr_officer_beret"
 	item_state = "ncr_officer_beret"
 	armor = list("tier" = 6, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/beret/ncr_recon
 	name = "NCR First Recon beret"
@@ -517,6 +540,7 @@
 	icon_state = "ncr_recon_beret"
 	item_state = "ncr_recon_beret"
 	armor = list("tier" = 6, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/beret/ncr_scout
 	name = "NCR Third Scout beret"
@@ -524,6 +548,7 @@
 	icon_state = "scoutberet"
 	item_state = "scoutberet"
 	armor = list("tier" = 6, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/beret/ncr_scout_lt
 	name = "NCR Third Scout officer beret"
@@ -531,6 +556,7 @@
 	icon_state = "scoutberet"
 	item_state = "scoutberet"
 	armor = list("tier" = 6, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/beret/ncr_sapper
 	name = "NCR Sapper beret"
@@ -538,6 +564,7 @@
 	icon_state = "ncr_sapper_beret"
 	item_state = "ncr_sapper_beret"
 	armor = list("tier" = 7, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/beret/ncr_sof
 	name = "NCR SOF beret"
@@ -545,6 +572,7 @@
 	icon_state = "ncr_sof_beret"
 	item_state = "ncr_sof_beret"
 	armor = list("tier" = 7, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/f13/ncr_stetson
 	name = "NCR air cavalry stetson"
@@ -552,6 +580,7 @@
 	icon_state = "ncr_stetson"
 	item_state = "ncr_stetson"
 	armor = list("tier" = 7, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/f13/ncr_cap
 	name = "NCR garrison cap"
@@ -566,6 +595,7 @@
 	icon_state = "ncr_campaign"
 	item_state = "ncr_campaign"
 	armor = list("tier" = 7, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/beret/ncr_dresscap
 	name = "NCR peaked cap"
@@ -573,6 +603,7 @@
 	icon_state = "ncr_dresscap"
 	item_state = "ncr_dresscap"
 	armor = list("tier" = 2, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/beret/ncr_codresscap
 	name = "NCR peaked cap"
@@ -580,6 +611,7 @@
 	icon_state = "ncr_codresscap"
 	item_state = "ncr_codresscap"
 	armor = list("tier" = 2, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.7
 
 //NCR Ranger
 
@@ -589,6 +621,7 @@
 	icon_state = "scoutberet"
 	item_state = "scoutberet"
 	armor = list("tier" = 4, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/f13/trailranger
 	name = "NCR trail ranger hat"
@@ -596,6 +629,7 @@
 	icon_state = "cowboyrang"
 	item_state = "cowboyrang"
 	armor = list("tier" = 4, "energy" = 30, "bomb" = 25, "bio" = 40, "rad" = 40, "fire" = 80, "acid" = 0)
+	permeability_coefficient = 0.6
 
 /obj/item/clothing/head/f13/ranger
 	name = "NCR ranger campaign hat"
@@ -603,6 +637,7 @@
 	icon_state = "drillhat"
 	item_state = "drill_hat"
 	armor = list("tier" = 5, "energy" = 40, "bomb" = 25, "bio" = 40, "rad" = 40, "fire" = 80, "acid" = 0)
+	permeability_coefficient = 0.6
 
 /obj/item/clothing/head/helmet/f13/combat/ncr_patrol
 	name = "NCR patrol helmet"
@@ -639,6 +674,7 @@
 	glass_colour_type = /datum/client_colour/glass_colour/red
 	lighting_alpha = LIGHTING_PLANE_ALPHA_NV_TRAIT
 	darkness_view = 24
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/head/helmet/f13/ncr/rangercombat/eliteriot
 	name = "elite riot gear helmet"
@@ -646,6 +682,7 @@
 	icon_state = "elite_riot"
 	item_state = "elite_riot"
 	armor = list("tier" = 8, "energy" = 60, "bomb" = 55, "bio" = 60, "rad" = 60, "fire" = 40, "acid" = 0)
+	permeability_coefficient = 0.4
 
 
 /obj/item/clothing/head/helmet/f13/ncr/rangercombat/desert
@@ -662,6 +699,7 @@
 	icon_state = "desert_ranger"
 	item_state = "desert_ranger"
 	armor = list("tier" = 4, "energy" = 30, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 30, "acid" = 0)
+	permeability_coefficient = 0.7
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDEFACE
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 
@@ -673,6 +711,7 @@
 	icon_state = "brotherhood_helmet_knight"
 	item_state = "brotherhood_helmet_knight"
 	armor = list("tier" = 7, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/head/helmet/f13/combat/brotherhood/senior
 	name = "brotherhood star knight helmet"
@@ -730,6 +769,7 @@
 	item_state = "dethat"
 	flags_inv = HIDEHAIR
 	armor = list("tier" = 3, "energy" = 40, "bomb" = 25, "bio" = 40, "rad" = 30, "fire" = 80, "acid" = 0)
+	permeability_coefficient = 0.6
 
 /obj/item/clothing/head/f13/town/mayor
 	name = "mayoral tricorn"
@@ -783,6 +823,7 @@
 	icon_state = "shamskull"
 	item_state = "shamskull"
 	armor = list("tier" = 2, "energy" = 20, "bomb" = 30, "bio" = 20, "rad" = 10, "fire" = 10, "acid" = 0)
+	permeability_coefficient = 0.8
 
 /obj/item/clothing/head/f13/helmet/wayfarer
 
@@ -792,6 +833,7 @@
 	icon_state = "hunterhelm"
 	item_state = "hunterhelm"
 	armor = list("tier" = 5, "energy" = 20, "bomb" = 30, "bio" = 20, "rad" = 10, "fire" = 10, "acid" = 0)
+	permeability_coefficient = 0.8
 
 /obj/item/clothing/head/helmet/f13/wayfarer/antler
 	name = "antler skullcap"
@@ -799,6 +841,7 @@
 	icon_state = "antlerhelm"
 	item_state = "antlerhelm"
 	armor = list("tier" = 3, "energy" = 0, "bomb" = 20, "bio" = 70, "rad" = 10, "fire" = 20, "acid" = 0)
+	permeability_coefficient = 0.3
 
 /obj/item/clothing/head/helmet/f13/wayfarer/shamanblue
 	name = "ritual headdress"
@@ -806,6 +849,7 @@
 	icon_state = "shamanblue"
 	item_state = "shamanblue"
 	armor = list("tier" = 4, "energy" = 20, "bomb" = 20, "bio" = 70, "rad" = 10, "fire" = 20, "acid" = 0)
+	permeability_coefficient = 0.3
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 
 /obj/item/clothing/head/helmet/f13/wayfarer/shamanred
@@ -814,6 +858,7 @@
 	icon_state = "shamanred"
 	item_state = "shamanred"
 	armor = list("tier" = 4, "energy" = 20, "bomb" = 20, "bio" = 70, "rad" = 10, "fire" = 20, "acid" = 0)
+	permeability_coefficient = 0.3
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 
 /obj/item/clothing/head/helmet/f13/wayfarer/chief
@@ -822,6 +867,7 @@
 	icon_state = "chiefblue"
 	item_state = "chiefblue"
 	armor = list("tier" = 7, "energy" = 40, "bomb" = 39, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0)
+	permeability_coefficient = 0.4
 	actions_types = list(/datum/action/item_action/toggle)
 	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
@@ -836,6 +882,7 @@
 	icon_state = "chiefred"
 	item_state = "chiefred"
 	armor = list("tier" = 7, "energy" = 40, "bomb" = 39, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0)
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/head/helmet/f13/wayfarer/chief/green
 	name = "helm of the helping hand"
@@ -843,6 +890,7 @@
 	icon_state = "chiefgreen"
 	item_state = "chiefgreen"
 	armor = list("tier" = 7, "energy" = 40, "bomb" = 39, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0)
+	permeability_coefficient = 0.4
 
 //Followers
 
@@ -852,13 +900,15 @@
 	name = "security helmet"
 	desc = "(V) A standard issue vault security helmet, pretty robust."
 	armor = list("tier" = 5, "energy" = 5, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 50, "acid" = 50)
+	permeability_coefficient = 0.5
 
 /obj/item/clothing/head/helmet/riot/vaultsec/vc
 	name = "vtcc riot helmet"
 	desc = "(VII) A riot helmet adapted from the design of most pre-war riot helmets, painted blue."
 	icon_state = "vtcc_riot_helmet"
 	item_state = "vtcc_riot_helmet"
-	armor = list("tier" = 7, "energy" = 35, "bomb" = 35, "bio" = 40, "rad" = 10, "fire" = 60, "acid" = 10)
+	armor = list("tier" = 7, "energy" = 35, "bomb" = 35, "bio" = 40, "rad" = 10, "fire" = 60, "acid" = 60)
+	permeability_coefficient = 0.4
 
 
 

--- a/code/modules/clothing/head/f13head.dm
+++ b/code/modules/clothing/head/f13head.dm
@@ -1,5 +1,4 @@
 /*PARENT ITEMS FOR REFERENCE PURPOSES. DO NOT UNCOMMENT
-
 /obj/item/clothing/head
 	name = BODY_ZONE_HEAD
 	icon = 'icons/obj/clothing/hats.dmi'
@@ -12,6 +11,7 @@
 	dynamic_hair_suffix = "+generic"
 	var/datum/beepsky_fashion/beepsky_fashion //the associated datum for applying this to a secbot
 	var/list/speechspan = null
+	armor = list("tier" = 1)
 
 /obj/item/clothing/head/Initialize()
 	. = ..()
@@ -61,6 +61,7 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	dynamic_hair_suffix = ""
 	dynamic_fhair_suffix = ""
+	permeability_coefficient = 0.7 // for chemicals/diseases. 1 is no protection, 0.01 is effective immunity. Doing 30% for this, only covers the top of the head. Better wear a gas mask!
 
 /obj/item/clothing/head/helmet/f13/combat/dark
 	color = "#302E2E" // Dark Grey
@@ -102,6 +103,7 @@
 	dynamic_hair_suffix = ""
 	dynamic_fhair_suffix = ""
 	flash_protect = 1
+	permeability_coefficient = 0.85 // Broken!
 
 /obj/item/clothing/head/helmet/f13/combat/swat
 	name = "SWAT combat helmet"
@@ -118,6 +120,7 @@
 	strip_delay = 60
 	equip_delay_other = 60
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	permeability_coefficient = 0.01
 
 /obj/item/clothing/head/helmet/f13/combat/environmental/ComponentInitialize()
 	. = ..()
@@ -133,6 +136,7 @@
 	armor = list("tier" = 6, "energy" = 40, "bomb" = 50, "bio" = 60, "rad" = 10, "fire" = 60, "acid" = 20)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	permeability_coefficient = 0.4
 
 //Metal
 
@@ -173,6 +177,7 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	visor_flags_inv = HIDEMASK|HIDEEYES|HIDEFACE
+	permeability_coefficient = 0.7 // Crude
 
 /obj/item/clothing/head/helmet/f13/metalmask/Initialize()
 	. = ..()
@@ -200,6 +205,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	var/hit_reflect_chance = 20
 	protected_zones = list(BODY_ZONE_CHEST, BODY_ZONE_PRECISE_GROIN, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/helmet/f13/tesla/run_block(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
 	if(is_energy_reflectable_projectile(object) && (attack_type == ATTACK_TYPE_PROJECTILE) && (def_zone in protected_zones))
@@ -223,6 +229,7 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	clothing_flags = THICKMATERIAL
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	permeability_coefficient = 0.01
 	item_flags = SLOWS_WHILE_IN_HAND
 	flash_protect = 2
 	dynamic_hair_suffix = ""
@@ -603,6 +610,7 @@
 	strip_delay = 30
 	dynamic_hair_suffix = ""
 	dynamic_fhair_suffix = ""
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/f13
 	flags_inv = HIDEHAIR
@@ -626,6 +634,7 @@
 	desc = "White cloth headdress for nurses"
 	icon_state = "nursehat"
 	item_state = "nursehat"
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/f13/beaver
 	name = "beaverkin"
@@ -676,6 +685,7 @@
 	icon_state = "headscarf"
 	item_state = "dethat"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/head/f13/headscarf/Initialize()
 	. = ..()
@@ -690,6 +700,7 @@
 	hitsound = 'sound/items/trayhit1.ogg'
 	flags_inv = HIDEHAIR
 	armor = list("tier" = 3)
+	permeability_coefficient = 0.9
 
 /obj/item/clothing/head/f13/cowboy
 	name = "cowboy hat"
@@ -756,6 +767,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	dynamic_hair_suffix = ""
 	dynamic_fhair_suffix = ""
+	permeability_coefficient = 0.01
 
 /obj/item/clothing/head/helmet/f13/brahmincowboyhat
 	name = "brahmin leather cowboy hat"
@@ -873,6 +885,7 @@
 	icon_state = "jasonmask"
 	item_state = "jasonmask"
 	armor = list("tier" = 2, "energy" = 20, "bomb" = 70, "bio" = 70, "rad" = 70, "fire" = 65, "acid" = 30)
+	permeability_coefficient = 0.3
 
 /obj/item/clothing/head/welding/f13/fire
 	name = "cremator welding helmet"
@@ -890,6 +903,7 @@
 	armor = list("tier" = 2, "energy" = 45, "bomb" = 55, "bio" = 65, "rad" = 100, "fire" = 60, "acid" = 20)
 	dynamic_hair_suffix = ""
 	dynamic_fhair_suffix = ""
+	permeability_coefficient = 0.35
 
 /obj/item/clothing/head/f13/flatranger
 	name = "NCR gambler ranger hat"
@@ -897,6 +911,7 @@
 	icon_state = "gamblerrang"
 	item_state = "gamblerrang"
 	armor = list("tier" = 4, "energy" = 30, "bomb" = 25, "bio" = 40, "rad" = 40, "fire" = 80, "acid" = 0)
+	permeability_coefficient = 0.6
 
 /obj/item/clothing/head/helmet/f13/legion/venator/diohelmet
 	name = "galerum lacertarex"
@@ -904,6 +919,7 @@
 	icon_state = "diohelmet"
 	item_state = "diohelmet"
 	armor = list("tier" = 6, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 20, "fire" = 70, "acid" = 0)
+	permeability_coefficient = 0.5
 
 /obj/item/clothing/head/helmet/f13/herbertranger
 	name = "weathered desert ranger helmet"

--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -31,6 +31,7 @@
 	item_state = "combat_jacket"
 	desc = "(III) This heavily padded leather jacket is unusual in that it has two sleeves. You'll definitely make a fashion statement whenever, and wherever, you rumble."
 	armor = list("tier" = 3, "energy" = 20, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 25, "acid" = 25)
+	permeability_coefficient = 0.75
 
 /obj/item/clothing/suit/armor/f13/leather_jacket/combat/coat
 	name = "combat leather coat"
@@ -38,6 +39,7 @@
 	item_state = "combat_coat"
 	desc = "(IV) A combat leather jacket, outfitted with a special armored leather coat."
 	armor = list("tier" = 4, "energy" = 35, "bomb" = 45, "bio" = 30, "rad" = 5, "fire" = 50, "acid" = 35)
+	permeability_coefficient = 0.65
 
 /obj/item/clothing/suit/armor/f13/leather_jacket/combat/riotpolice
 	name = "combat body armor"
@@ -45,6 +47,7 @@
 	item_state = "combat_coat"
 	desc = "(VII) A heavy armor with ballistic inserts, sewn into a padded riot police coat."
 	armor = list("tier" = 7, "energy" = 25, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 5, "acid" = 35)
+	permeability_coefficient = 0.55
 
 /obj/item/clothing/suit/armor/f13/kit
 	name = "armor kit"
@@ -77,6 +80,7 @@
 	icon_state = "leather_armor"
 	item_state = "leather_armor"
 	armor = list("tier" = 3, "energy" = 25, "bomb" = 32, "bio" = 0, "rad" = 10, "fire" = 30, "acid" = 35)
+	permeability_coefficient = 0.8
 	strip_delay = 40
 
 /obj/item/clothing/suit/armor/f13/leatherarmor/reinforced
@@ -85,6 +89,7 @@
 	item_state = "leather_armor_2"
 	desc = "(IV) An enhanced version of the basic leather armor with extra layers of protection. Finely crafted from tanned brahmin hide."
 	armor = list("tier" = 4, "energy" = 30, "bomb" = 35, "bio" = 0, "rad" = 15, "fire" = 40, "acid" = 35)
+	permeability_coefficient = 0.8
 
 /obj/item/clothing/suit/armor/f13/metalarmor
 	name = "metal armor"
@@ -92,6 +97,7 @@
 	icon_state = "metal_chestplate"
 	item_state = "metal_chestplate"
 	armor = list("tier" = 4, "energy" = 40, "bomb" = 40, "bio" = 30, "rad" = 15, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.8
 	slowdown = 0.25
 	strip_delay = 10
 
@@ -110,6 +116,7 @@
 	icon_state = "metal_chestplate2"
 	item_state = "metal_chestplate2"
 	armor = list("tier" = 5, "energy" = 50, "bomb" = 40, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.8
 	slowdown = 0.05
 	strip_delay = 10
 
@@ -120,6 +127,7 @@
 	icon_state = "combat_armor"
 	item_state = "combat_armor"
 	armor = list("tier" = 5, "energy" = 40, "bomb" = 50, "bio" = 60, "rad" = 10, "fire" = 60, "acid" = 20)
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/suit/armor/f13/combat/dark
 	name = "combat armor"
@@ -179,6 +187,7 @@
 	permeability_coefficient = 0.5
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	armor = list("tier" = 5,"energy" = 45, "bomb" = 55, "bio" = 70, "rad" = 100, "fire" = 60, "acid" = 50)
+	permeability_coefficient = 0.01
 	strip_delay = 60
 	equip_delay_other = 60
 	flags_inv = HIDEJUMPSUIT
@@ -208,6 +217,7 @@
 	equip_delay_other = 60
 	strip_delay = 200
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	permeability_coefficient = 0.01
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -627,6 +637,7 @@
 	icon_state = "insect_armor"
 	item_state = "insect_armor"
 	armor = list("tier" = 4, "energy" = 25, "bomb" = 25, "bio" = 70, "rad" = 65, "fire" = 80, "acid" = 100)
+	permeability_coefficient = 0.3
 	flags_inv = HIDEJUMPSUIT
 	strip_delay = 40
 
@@ -656,6 +667,7 @@
 	icon_state = "sulphitearmor"
 	item_state = "sulphitearmor"
 	armor = list("tier" = 6, "energy" = 40, "bomb" = 50, "bio" = 60, "rad" = 10, "fire" = 60, "acid" = 20)
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/suit/toggle/armor
 	body_parts_covered = CHEST|GROIN
@@ -694,6 +706,7 @@
 	icon_state = "battlecoat"
 	item_state = "battlecoat"
 	armor = list("tier" = 3, "energy" = 30, "bomb" = 30, "bio" = 0, "rad" = 30, "fire" = 30, "acid" = 30)
+	permeability_coefficient = 0.7
 	strip_delay = 30
 	icon = 'icons/fallout/clothing/suits.dmi'
 
@@ -716,6 +729,7 @@
 	icon_state = "marshal_commandcoat"
 	item_state = "marshal_commandcoat"
 	armor = list("tier" = 7, "energy" = 35, "bomb" = 35, "bio" = 40, "rad" = 10, "fire" = 60, "acid" = 10)
+	permeability_coefficient = 0.6
 
 /obj/item/clothing/suit/armor/f13/battlecoat/vault/armoured
 	name = "armoured vault battlecoat"
@@ -723,6 +737,7 @@
 	icon_state = "armouredvault_commandcoat"
 	item_state = "armouredvault_commandcoat"
 	armor = list("tier" = 4, "energy" = 35, "bomb" = 35, "bio" = 40, "rad" = 10, "fire" = 60, "acid" = 10)
+	permeability_coefficient = 0.6
 
 /obj/item/clothing/suit/armor/f13/battlecoat/tan
 	name = "tan battlecoat"
@@ -736,6 +751,7 @@
 	icon_state = "brahmin_leather_duster"
 	item_state = "brahmin_leather_duster"
 	armor = list("tier" = 3, "energy" = 35, "bomb" = 35, "bio" = 40, "rad" = 10, "fire" = 60, "acid" = 10)
+	permeability_coefficient = 0.6
 
 /obj/item/clothing/suit/armor/f13/rustedcowboy
 	name = "rusted cowboy outfit"
@@ -743,6 +759,7 @@
 	icon_state = "rusted_cowboy"
 	item_state = "rusted_cowboy"
 	armor = list("tier" = 3, "energy" = 35, "bomb" = 35, "bio" = 40, "rad" = 10, "fire" = 60, "acid" = 10)
+	permeability_coefficient = 0.6
 
 //Inherited from SS13
 /obj/item/clothing/suit/armor/bulletproof
@@ -752,6 +769,7 @@
 	item_state = "armor"
 	blood_overlay_type = "armor"
 	armor = list("tier" = 4, "linebullet" = 50, "energy" = 35, "bomb" = 55, "bio" = 0, "rad" = 0, "fire" = 55, "acid" = 55)
+	permeability_coefficient = 0.4
 	strip_delay = 70
 	equip_delay_other = 50
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -114,6 +114,7 @@
 	armor = list("tier" = 2, "energy" = 20, "bomb" = 40, "bio" = 40, "rad" = 20, "fire" = 60, "acid" = 20)
 	strip_delay = 30
 	icon = 'icons/fallout/clothing/suits.dmi'
+	permeability_coefficient = 0.6
 
 /obj/item/clothing/suit/armor/f13/exile/ncrexile
 	name = "modified NCR armor"
@@ -151,6 +152,7 @@
 	icon_state = "raider_combat"
 	item_state = "raider_combat"
 	armor = list("tier" = 5, "energy" = 30, "bomb" = 50, "bio" = 50, "rad" = 10, "fire" = 60, "acid" = 10)
+	permeability_coefficient = 0.5
 
 /obj/item/clothing/suit/armor/f13/raider/raidermetal
 	name = "metal raider armor"
@@ -158,6 +160,7 @@
 	icon_state = "raider_metal"
 	item_state = "raider_metal"
 	armor = list("tier" = 5, "energy" = 35, "bomb" = 50, "bio" = 50, "rad" = 10, "fire" = 60, "acid" = 10)
+	permeability_coefficient = 0.5
 	resistance_flags = FIRE_PROOF
 
 //Legion
@@ -168,6 +171,7 @@
 	icon_state = "legmedicus"
 	armor = list("energy" = 0, "bomb" = 0, "bio" = 20, "rad" = 0, "fire" = 0, "acid" = 0)
 	allowed = list(/obj/item/scalpel, /obj/item/surgical_drapes, /obj/item/cautery, /obj/item/hemostat, /obj/item/retractor)
+	permeability_coefficient = 0.8
 
 /obj/item/clothing/suit/armor/f13/opifex
 	name = "opifex apron"
@@ -176,6 +180,7 @@
 	item_state = "opifex_apron"
 	blood_overlay_type = "armor"
 	armor = list("melee" = 5,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 5)
+	permeability_coefficient = 0.7
 	allowed = list(/obj/item/crowbar,
 		/obj/item/screwdriver,
 		/obj/item/weldingtool,
@@ -209,6 +214,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	allowed = list(/obj/item/gun, /obj/item/claymore, /obj/item/throwing_star/spear, /obj/item/restraints/legcuffs/bola, /obj/item/twohanded, /obj/item/melee/smith, /obj/item/melee/smith/twohand)
 	armor = list("tier" = 2, "energy" = 10, "bomb" = 16, "bio" = 30, "rad" = 20, "fire" = 50, "acid" = 0)
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/suit/armor/f13/legion/Initialize()
 	. = ..()
@@ -231,6 +237,7 @@
 	icon_state = "legprime"
 	slowdown = -0.13
 	armor = list("tier" = 3, "energy" = 15, "bomb" = 25, "bio" = 40, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.6
 
 /obj/item/clothing/suit/armor/f13/legion/prime/slavemaster
 	name = "slavemaster armor"
@@ -243,6 +250,7 @@
 	icon_state = "legvet"
 	slowdown = -0.1
 	armor = list("tier" = 4, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 20, "fire" = 70, "acid" = 0)
+	permeability_coefficient = 0.5
 
 /obj/item/clothing/suit/armor/f13/legion/heavy
 	name = "legion veteran decan armor"
@@ -251,6 +259,7 @@
 	item_state = "legmetal"
 	slowdown = -0.1
 	armor = list("tier" = 5, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 20, "fire" = 70, "acid" = 0)
+	permeability_coefficient = 0.5
 
 /obj/item/clothing/suit/armor/f13/legion/vet/explorer
 	name = "legion explorer armor"
@@ -268,12 +277,14 @@
 	desc = "(VI) The armor appears to be based off of a suit of Legion veteran armor, with the addition of bracers and a chainmail skirt."
 	icon_state = "legvenator"
 	armor = list("tier" = 6, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 20, "fire" = 70, "acid" = 0)
+	permeability_coefficient = 0.5
 
 /obj/item/clothing/suit/armor/f13/legion/vet/orator
 	name = "legion orator armor"
 	desc = "(VI) The armor appears to be based off of a suit of Legion veteran armor, with the addition of bracers, a chainmail skirt, and large pauldrons.  A tabard emblazoned with the bull is loosely draped over the torso."
 	icon_state = "legheavy"
 	armor = list("tier" = 6, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 20, "fire" = 70, "acid" = 0)
+	permeability_coefficient = 0.5
 
 /obj/item/clothing/suit/armor/f13/legion/centurion
 	name = "legion centurion armor"
@@ -281,6 +292,7 @@
 	icon_state = "legcenturion"
 	slowdown = -0.13
 	armor = list("tier" = 6, "energy" = 35, "bomb" = 39, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0)
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/suit/armor/f13/legion/palacent
 	name = "paladin-slayer centurion armor"
@@ -288,6 +300,7 @@
 	icon_state = "palacent"
 	slowdown = -0.13
 	armor = list("tier" = 6, "energy" = 35, "bomb" = 39, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0)
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/suit/armor/f13/legion/palacent/custom_excess
 	name = "Champion of Kanab's Armor"
@@ -302,6 +315,7 @@
 	item_state = "rangercent"
 	slowdown = -0.2
 	armor = list("tier" = 5, "energy" = 35, "bomb" = 39, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0)
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/suit/armor/f13/legion/legate
 	name = "legion legate armor"
@@ -309,6 +323,7 @@
 	icon_state = "leglegat"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
 	armor = list("tier" = 8, "energy" = 40, "bomb" = 45, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0)
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/suit/armor/f13/combat/legion
 	name = "Legion combat armor"
@@ -330,6 +345,7 @@
 	item_state = "ncr_infantry_vest"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	armor = list("tier" = 2, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.7
 
 /obj/item/clothing/suit/armor/f13/ncrarmor/Initialize()
 	. = ..()
@@ -362,6 +378,7 @@
 	icon_state = "ncr_labcoat"
 	item_state = "ncr_labcoat"
 	armor = list("tier" = 3, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.4
 	allowed = list(/obj/item/gun, /obj/item/analyzer, /obj/item/stack/medical, /obj/item/dnainjector, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray, /obj/item/healthanalyzer, /obj/item/flashlight/pen, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/pill, /obj/item/storage/pill_bottle, /obj/item/paper, /obj/item/melee/classic_baton/telescopic, /obj/item/soap, /obj/item/sensor_device, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 
 /obj/item/clothing/suit/armor/f13/ncrarmor/captain
@@ -442,6 +459,7 @@
 	icon_state = "duster_recon"
 	item_state = "duster_recon"
 	armor = list("tier" = 4, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.7
 	slowdown = -0.1
 
 /obj/item/clothing/suit/armor/f13/rangerrig
@@ -450,6 +468,7 @@
 	icon_state = "r_gear_rig"
 	item_state = "r_gear_rig"
 	armor = list("tier" = 4, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.7
 	slowdown = -0.1
 
 /obj/item/clothing/suit/armor/f13/trailranger
@@ -458,6 +477,7 @@
 	icon_state = "cowboyrang"
 	item_state = "cowboyrang"
 	armor = list("tier" = 4, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	permeability_coefficient = 0.7
 	slowdown = -0.14
 
 /obj/item/clothing/suit/armor/f13/modif_r_vest
@@ -466,6 +486,7 @@
 	icon_state = "modif_r_vest"
 	item_state = "modif_r_vest"
 	armor = list("tier" = 5, "energy" = 45, "bomb" = 55, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/suit/armor/f13/combat/ncr_patrol
 	name = "ranger patrol armor"
@@ -473,6 +494,7 @@
 	icon_state = "ncr_patrol"
 	item_state = "ncr_patrol"
 	armor = list("tier" = 5, "energy" = 45, "bomb" = 55, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/suit/armor/f13/combat/ncr_patrol/mutant
 	name = "mutant ranger armor"
@@ -492,6 +514,7 @@
 	icon_state = "refurb_scout"
 	item_state = "refurb_scout"
 	armor = list("tier" = 5, "energy" = 45, "bomb" = 55, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/suit/armor/f13/rangercombat
 	name = "veteran ranger combat armor"
@@ -500,6 +523,7 @@
 	item_state = "ranger"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
 	armor = list("tier" = 7, "energy" = 40, "bomb" = 55, "bio" = 60, "rad" = 60, "fire" = 90, "acid" = 20)
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/suit/armor/f13/ncrcfjacket
 	name = "NCRCF jacket"
@@ -549,6 +573,7 @@
 	icon_state = "brotherhood_armor_knight"
 	item_state = "brotherhood_armor_knight"
 	armor = list("tier" = 7, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/senior
 	name = "brotherhood senior knight armor"
@@ -568,6 +593,7 @@
 	icon_state = "brotherhood_armor"
 	item_state = "brotherhood_armor"
 	armor = list("tier" = 5, "energy" = 40, "bomb" = 50, "bio" = 60, "rad" = 10, "fire" = 60, "acid" = 20)
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate/mk2
 	name = "reinforced initiate armor"
@@ -575,6 +601,7 @@
 	icon_state = "brotherhood_armor_mk2"
 	item_state = "brotherhood_armor_mk2"
 	armor = list("tier" = 6, "energy" = 45, "bomb" = 55, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	permeability_coefficient = 0.4
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/outcast
 	name = "brotherhood armor"
@@ -582,6 +609,7 @@
 	icon_state = "brotherhood_armor_outcast"
 	item_state = "brotherhood_armor_outcast"
 	armor = list("tier" = 7, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	permeability_coefficient = 0.4
 
 //Oasis/Town
 /obj/item/clothing/suit/armor/f13/town
@@ -591,23 +619,27 @@
 	item_state = "hostrench"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("tier" = 3, "energy" = 40, "bomb" = 25, "bio" = 40, "rad" = 30, "fire" = 80, "acid" = 0)
+	permeability_coefficient = 0.6
 
 /obj/item/clothing/suit/armor/f13/town/mayor
 	name = "mayor trenchcoat"
 	desc = "(IV) A symbol of the mayor's authority (or lack thereof)."
 	armor = list("tier" = 4, "energy" = 40, "bomb" = 25, "bio" = 40, "rad" = 35, "fire" = 80, "acid" = 0)
+	permeability_coefficient = 0.6
 
 /obj/item/clothing/suit/armor/f13/town/sheriff
 	name = "sheriff trenchcoat"
 	desc = "(VI) A trenchcoat which does not attempt to hide the full-body combat armor beneath it."
 	icon_state = "towntrench_heavy"
 	armor = list("tier" = 6, "energy" = 40, "bomb" = 25, "bio" = 40, "rad" = 40, "fire" = 80, "acid" = 0)
+	permeability_coefficient = 0.6
 
 /obj/item/clothing/suit/armor/f13/town/deputy
 	name = "deputy trenchcoat"
 	desc = "(V) An armored trench coat with added shoulderpads, a chestplate, and legguards."
 	icon_state = "towntrench_medium"
 	armor = list("tier" = 5, "energy" = 40, "bomb" = 25, "bio" = 40, "rad" = 35, "fire" = 80, "acid" = 0)
+	permeability_coefficient = 0.6
 
 //Great Khan
 /obj/item/clothing/suit/armor/khan_jacket
@@ -625,6 +657,7 @@
 	item_state = "tribal_armor"
 	body_parts_covered = CHEST|GROIN|ARMS
 	armor = list("tier" = 4, "energy" = 25, "bomb" = 25, "bio" = 70, "rad" = 65, "fire" = 80, "acid" = 100)
+	permeability_coefficient = 0.01
 	allowed = list(/obj/item/gun, /obj/item/kitchen, /obj/item/twohanded, /obj/item/claymore, /obj/item/twohanded/spear, /obj/item/melee/smith, /obj/item/melee/smith/twohand
 )
 
@@ -634,6 +667,7 @@
 	icon_state = "heavy_tribal_armor"
 	item_state = "heavy_tribal_armor"
 	armor = list("tier" = 5, "energy" = 45, "bomb" = 55, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	permeability_coefficient = 0.4
 	flags_inv = HIDEJUMPSUIT
 	allowed = list(/obj/item/gun, /obj/item/kitchen, /obj/item/twohanded, /obj/item/claymore, /obj/item/twohanded/spear, /obj/item/melee/smith, /obj/item/melee/smith/twohand
 )
@@ -647,7 +681,8 @@
 	desc = "(VII) A suit of riot armour adapted from the design of the pre-war U.S.M.C. armour, painted blue and white."
 	icon_state = "vtcc_riot_gear"
 	item_state = "vtcc_riot_gear"
-	armor = list("tier" = 7, "energy" = 35, "bomb" = 35, "bio" = 40, "rad" = 10, "fire" = 60, "acid" = 10)
+	armor = list("tier" = 7, "energy" = 35, "bomb" = 35, "bio" = 40, "rad" = 10, "fire" = 60, "acid" = 60)
+	permeability_coefficient = 0.4
 
 
 //THE GRAVEYARD

--- a/code/modules/clothing/suits/f13suits.dm
+++ b/code/modules/clothing/suits/f13suits.dm
@@ -219,6 +219,7 @@
 	icon = 'icons/fallout/clothing/suits.dmi'
 	icon_state = "hazmat"
 	item_state = "hazmat_suit"
+	permeability_coefficient = 0.01
 
 /obj/item/clothing/head/bio_hood/f13/hazmat
 	name = "hazmat hood"
@@ -227,6 +228,7 @@
 	icon_state = "hazmat"
 	item_state = "hazmat_helmet"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+	permeability_coefficient = 0.01
 
 //Fallout 13 toggle apparel directory
 /obj/item/clothing/suit/toggle/labcoat/f13/emergency
@@ -234,6 +236,7 @@
 	desc = "(I) A high-visibility jacket worn by medical first responders."
 	icon_state = "fr_jacket"
 	item_state = "fr_jacket"
+	permeability_coefficient = 0.6
 
 /obj/item/clothing/suit/toggle/labcoat/f13/warriors
 	name = "warriors jacket"
@@ -276,6 +279,7 @@
 	icon_state = "followers"
 	item_state = "labcoat"
 	armor = list("tier" = 2, "energy" = 10, "bomb" = 0, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10)
+	permeability_coefficient = 0.6
 
 /obj/item/clothing/suit/armor/f13/generaluniform
 	name = "Yuma 1st Irregular General Uniform"
@@ -334,6 +338,7 @@
 	desc = "(III) A staunch, practical parka made out of a wind-breaking jacket, reinforced with metal plates."
 	armor = list("tier" = 3, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60)
 	hoodtype = /obj/item/clothing/head/hooded/parkahood/medical
+	permeability_coefficient = 0.6
 
 /obj/item/clothing/head/hooded/parkahood/medical
 	name = "armored medical parka hood"
@@ -341,6 +346,7 @@
 	desc = "(III) A protective & concealing parka hood."
 	armor = list("tier" = 3, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60)
 	flags_inv = HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR
+	permeability_coefficient = 0.6
 
 /obj/item/clothing/suit/hooded/parka/grey
 	name = "grey armored parka"


### PR DESCRIPTION
May have been a bit overzealous. Will require testing to see how it is handled.

Overall this should nerf the effectiveness of chemical warfare on properly covered individuals. Those in light armor may find themselves at the mercy of the local robust botanist/chemist still.

**To test:**
Does permeability_coefficient stack on the same slot? If so, how? Multiplicative? Additive?

Is permeability_coefficient an attribute for the mob as a whole? Will a pair of gloves that offer 99% chemical protection give that resistance across the full body?