### PR TITLE
Halves the effect of gun tinkering (both good and bad)

### DIFF
--- a/code/modules/crafting/items.dm
+++ b/code/modules/crafting/items.dm
@@ -1115,9 +1115,9 @@
 		if(30 to 100)
 			prefix = "Legendary "
 	
-	E.extra_damage += (dmgmod/2)
-	E.extra_penetration += (penmod/120)
-	E.fire_delay += (spdmod/10)
+	E.extra_damage += (dmgmod/4)
+	E.extra_penetration += (penmod/240)
+	E.fire_delay += (spdmod/20)
 	//E.ammo_type[1].delay += spdmod
 	E.name = prefix + E.name
 	E.tinkered += 1


### PR DESCRIPTION
## About The Pull Request

Can't claim to understand the finer points of tinkering code, but I do feel it is too strong by a fair bit. This attempts to reduce the effect of tinkering guns without removing it. In effect halving the resulting bonus/malus from tinkering guns.

Its a bit of a test merge since I don't know the tricks to tinkering so I can't properly test it, if it doesn't work as intended just revert it, its a tiny amount of change in the code. Should give a good idea if the issues can be solved by scaling the effects.

## Changelog
:cl:
balance: tinkering effect on guns halved.
/:cl:
