### PR TITLE
Changes the sprites of T-45 T-51 T-60

### DIFF
--- a/code/modules/clothing/head/f13head.dm
+++ b/code/modules/clothing/head/f13head.dm
@@ -433,8 +433,8 @@
 /obj/item/clothing/head/helmet/f13/power_armor/t45d
 	name = "T-45d power helmet"
 	desc = "(IX) It's an old pre-War power armor helmet. It's pretty hot inside of it."
-	icon_state = "t45dhelmet0"
-	item_state = "t45dhelmet0"
+	icon_state = "t45dhelmet"
+	item_state = "t45dhelmet"
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	armor = list("tier" = 9, "energy" = 60, "bomb" = 62, "bio" = 100, "rad" = 90, "fire" = 90, "acid" = 0, "wound" = 60)
 	armor_block_chance = 60
@@ -472,8 +472,8 @@
 /obj/item/clothing/head/helmet/f13/power_armor/t51b
 	name = "T-51b power helmet"
 	desc = "(X) It's a T-51b power helmet, typically used by the Brotherhood. It looks somewhat charming."
-	icon_state = "t51bhelmet0"
-	item_state = "t51bhelmet0"
+	icon_state = "t51bhelmet"
+	item_state = "t51bhelmet"
 	armor = list("tier" = 10, "energy" = 65, "bomb" = 62, "bio" = 100, "rad" = 99, "fire" = 90, "acid" = 0, "wound" = 70)
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	armor_block_chance = 70
@@ -510,8 +510,8 @@
 /obj/item/clothing/head/helmet/f13/power_armor/t60
 	name = "T-60a power helmet"
 	desc = "(XI) The T-60 powered helmet, equipped with targetting software suite, Friend-or-Foe identifiers, dynamic HuD, and an internal music player."
-	icon_state = "t60helmet0"
-	item_state = "t60helmet0"
+	icon_state = "t60helmet"
+	item_state = "t60helmet"
 	armor = list("tier" = 11, "energy" = 70, "bomb" = 82, "bio" = 100, "rad" = 100, "fire" = 95, "acid" = 0, "wound" = 80)
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	armor_block_chance = 80


### PR DESCRIPTION
## About The Pull Request
I went to a old code source to add the old sprites back. It took about 10-15 minutes to do in total and look quite better in my opinion

## Why It's Good For The Game
Well the new T-45 T-51 T-60 doesn't even look like power armor more like a heap of scrap metal produced by cavemen

## Changelog
:cl:
add: Added the old T-45 T-51 T-60 sprites back
code: changed some code
/:cl:


