### PR TITLE
Ancient Beds + Minimart

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -1210,8 +1210,8 @@
 /turf/open/floor/plasteel/yellow/side,
 /area/f13/vault)
 "bzb" = (
-/obj/structure/bed,
 /obj/item/bedsheet/captain,
+/obj/structure/bed/old,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
 "bzd" = (
@@ -1284,8 +1284,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
 "bCd" = (
-/obj/structure/bed,
 /obj/item/bedsheet/black,
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
@@ -1734,8 +1734,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "chr" = (
-/obj/structure/bed,
 /obj/item/bedsheet/orange,
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
@@ -1834,8 +1834,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "cmM" = (
-/obj/structure/bed,
 /obj/item/bedsheet/orange,
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
@@ -1861,8 +1861,8 @@
 	},
 /area/f13/vault)
 "cnL" = (
-/obj/structure/bed,
 /obj/item/bedsheet/yellow,
+/obj/structure/bed/old,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -2768,8 +2768,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "dDB" = (
-/obj/structure/bed,
 /obj/item/bedsheet/red,
+/obj/structure/bed/old,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -3196,13 +3196,13 @@
 /turf/open/floor/wood,
 /area/f13/vault)
 "dZI" = (
-/obj/structure/bed,
 /obj/item/bedsheet/hop{
 	name = "overseer's bedsheet"
 	},
 /obj/machinery/light/broken{
 	dir = 1
 	},
+/obj/structure/bed/old,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -4733,9 +4733,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "fZB" = (
-/obj/structure/bed,
 /obj/item/trash/f13/bubblegum,
 /obj/machinery/light/broken,
+/obj/structure/bed/old,
 /turf/open/floor/carpet/black,
 /area/f13/bunker)
 "fZC" = (
@@ -6260,8 +6260,8 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "hJD" = (
-/obj/structure/bed,
 /obj/item/bedsheet/hos,
+/obj/structure/bed/old,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
 "hJW" = (
@@ -6701,9 +6701,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "itA" = (
-/obj/structure/bed,
 /obj/item/bedsheet/black,
 /obj/effect/landmark/start/f13/vaultsecurityofficer,
+/obj/structure/bed/old,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
 "itU" = (
@@ -8603,8 +8603,8 @@
 /turf/open/floor/carpet/black,
 /area/f13/bunker)
 "kPN" = (
-/obj/structure/bed,
 /obj/item/bedsheet/black,
+/obj/structure/bed/old,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "kQV" = (
@@ -12157,8 +12157,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "plk" = (
-/obj/structure/bed,
 /obj/item/bedsheet/blue,
+/obj/structure/bed/old,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -12339,9 +12339,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
 "pvN" = (
-/obj/structure/bed,
 /obj/item/bedsheet/random,
 /obj/effect/landmark/start/f13/vaultdweller,
+/obj/structure/bed/old,
 /turf/open/floor/wood,
 /area/f13/vault)
 "pvR" = (
@@ -12449,7 +12449,7 @@
 /area/f13/bunker)
 "pBf" = (
 /obj/item/bedsheet/qm,
-/obj/structure/bed,
+/obj/structure/bed/old,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 9
 	},
@@ -12670,10 +12670,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
 "pVH" = (
-/obj/structure/bed,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/bed/old,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
 "pVK" = (
@@ -13975,7 +13975,7 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "ruW" = (
-/obj/structure/bed,
+/obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
 "rvm" = (

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -235,6 +235,13 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
+"agY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/bubblegum,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "ahh" = (
 /obj/item/kirbyplants,
 /turf/open/indestructible/ground/outside/dirt{
@@ -2008,6 +2015,13 @@
 	icon_state = "horizontalbottomborderbottom2left"
 	},
 /area/f13/wasteland)
+"bfX" = (
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "bgd" = (
 /obj/structure/barricade/wooden/strong{
 	obj_integrity = 500
@@ -2679,6 +2693,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"byI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/storage/fancy/cigarettes/cigpack_bigboss,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "byT" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/f13/wood{
@@ -2996,6 +3018,14 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/building)
+"bHI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/borscht,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "bIh" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/clinic)
@@ -3147,6 +3177,14 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"bNu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/storage/fancy/cigarettes/cigpack_greytort,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/building)
 "bNA" = (
 /obj/item/stack/sheet/mineral/wood,
@@ -3533,6 +3571,13 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"caj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/yumyum,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "cam" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2right"
@@ -3576,12 +3621,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "ccF" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetgrey"
+/mob/living/simple_animal/hostile/cazador,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 7;
+	icon_state = "outerpavement"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "cdc" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
@@ -3648,8 +3693,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "chA" = (
-/obj/structure/bed,
 /obj/item/bedsheet/brown,
+/obj/structure/bed/old,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "chM" = (
@@ -6164,12 +6209,14 @@
 	},
 /area/f13/building)
 "dEB" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetbrown"
+/obj/machinery/door/poddoor/shutters{
+	id = "minimart";
+	name = "Minimart Shutters"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/village)
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/building)
 "dER" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/inside/dirt,
@@ -7092,6 +7139,10 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ejQ" = (
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "ekB" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
@@ -8492,9 +8543,9 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "eUk" = (
-/obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bedsheet/black,
+/obj/structure/bed/old,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "eUs" = (
@@ -9841,8 +9892,8 @@
 	},
 /area/f13/building)
 "fFO" = (
-/obj/structure/bed,
 /obj/item/bedsheet/black,
+/obj/structure/bed/old,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "fGc" = (
@@ -11382,11 +11433,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
 /area/f13/building)
 "guw" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright2bottom"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "minimart";
+	name = "Minimart Button"
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "guA" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
@@ -11735,9 +11791,11 @@
 	},
 /area/f13/wasteland)
 "gFi" = (
-/obj/structure/table/wood/settler,
-/obj/structure/table/wood/settler,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/building)
 "gFR" = (
 /turf/open/indestructible/ground/inside/subway,
@@ -12050,6 +12108,11 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/f13,
 /area/f13/building)
+"gQJ" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/bar)
 "gQL" = (
 /obj/structure/decoration/vent,
 /turf/open/floor/f13{
@@ -13384,7 +13447,6 @@
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "hzt" = (
-/obj/structure/bed/pod,
 /obj/structure/lattice/catwalk,
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /obj/structure/railing{
@@ -13961,6 +14023,16 @@
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"hOM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	termtag = "Business"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "hPd" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/f13/leatherarmor,
@@ -14015,6 +14087,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"hRb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "hRl" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
@@ -15123,10 +15203,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "iyR" = (
-/obj/structure/bed,
 /obj/item/bedsheet{
 	icon_state = "sheethos"
 	},
+/obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "izb" = (
@@ -15167,8 +15247,13 @@
 	},
 /area/f13/building)
 "iAz" = (
-/obj/structure/bed,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/building)
 "iAB" = (
 /obj/structure/table/wood,
@@ -16462,10 +16547,10 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/building)
 "jfx" = (
-/obj/structure/bed,
 /obj/item/bedsheet{
 	icon_state = "sheetbrown"
 	},
+/obj/structure/bed/old,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "jfD" = (
@@ -16474,9 +16559,11 @@
 /turf/closed/wall/f13/wood,
 /area/f13/village)
 "jfF" = (
-/obj/structure/simple_door/house,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/building)
 "jfG" = (
 /obj/machinery/iv_drip,
@@ -16715,10 +16802,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jmr" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/building)
 "jmt" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18081,6 +18168,12 @@
 /obj/machinery/trading_machine/medical,
 /turf/closed/wall/f13/supermart,
 /area/f13/building)
+"kar" = (
+/obj/structure/window/fulltile/store,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/building)
 "kas" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -18949,6 +19042,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/brotherhood)
+"kAB" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "kAJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
@@ -19043,6 +19143,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"kEx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "kEE" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/desert,
@@ -19797,6 +19904,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/ncr)
+"ldk" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/f13/crisps,
+/obj/item/trash/f13/crisps,
+/obj/item/trash/f13/crisps,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "ldy" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19834,6 +19948,14 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"lep" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/bubblegum/large,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "les" = (
 /obj/machinery/light,
 /turf/open/floor/f13{
@@ -20265,6 +20387,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"lqG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/dog,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "lqO" = (
 /obj/structure/bookcase,
 /turf/open/floor/f13/wood,
@@ -20512,6 +20641,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
+"lxL" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/instamash,
+/obj/item/reagent_containers/food/snacks/f13/instamash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "lxW" = (
 /obj/machinery/button/door{
 	id = "bosgarage";
@@ -20830,9 +20968,24 @@
 /obj/machinery/light/small,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"lHD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/trash/f13/rotten,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "lHG" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"lHH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/building)
 "lHK" = (
 /obj/machinery/light,
@@ -20928,12 +21081,12 @@
 	},
 /area/f13/wasteland)
 "lLz" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowbroken"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/crafting/abraxo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "lLB" = (
 /obj/structure/window/fulltile/house{
@@ -21726,6 +21879,15 @@
 	icon_state = "rubble"
 	},
 /area/f13/village)
+"mjx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/building)
 "mjJ" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/dice,
@@ -21996,11 +22158,10 @@
 	},
 /area/f13/building)
 "msy" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetbrown"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "msG" = (
 /obj/structure/barricade/wooden,
@@ -22352,8 +22513,8 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	icon_state = "floor5-old"
 	},
-/obj/structure/bed,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/structure/bed/old,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "mHy" = (
@@ -22489,6 +22650,13 @@
 	icon_state = "horizontaloutermainright"
 	},
 /area/f13/wasteland)
+"mKA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/instamash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "mLc" = (
 /obj/item/claymore/machete/training,
 /turf/open/indestructible/ground/outside/dirt,
@@ -23336,9 +23504,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/building)
 "nmS" = (
-/obj/structure/bed,
 /obj/item/bedsheet/brown,
 /mob/living/simple_animal/hostile/ghoul,
+/obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nmZ" = (
@@ -23597,6 +23765,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"nwV" = (
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/plate,
+/turf/open/floor/wood/f13/oak,
+/area/f13/bar)
 "nwZ" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -23673,6 +23847,15 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/building)
+"nyA" = (
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "nyM" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -24699,10 +24882,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ohA" = (
-/obj/structure/simple_door/house,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/crafting/duct_tape,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
 	},
 /area/f13/building)
 "ohU" = (
@@ -25082,6 +25266,14 @@
 	icon_state = "horizontaloutermainleft"
 	},
 /area/f13/wasteland)
+"osw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/dog,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "osB" = (
 /obj/effect/landmark/observer_start,
 /turf/open/indestructible/ground/outside/road{
@@ -25422,7 +25614,6 @@
 	},
 /area/f13/wasteland)
 "oCA" = (
-/obj/structure/bed,
 /obj/item/bedsheet,
 /turf/open/floor/f13/wood,
 /area/f13/village)
@@ -25979,6 +26170,16 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"oUr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/sugarbombs,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "oUy" = (
 /obj/structure/rack,
 /obj/structure/lattice/catwalk,
@@ -26453,6 +26654,12 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland)
+"pht" = (
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland)
 "phu" = (
@@ -27619,12 +27826,14 @@
 	},
 /area/f13/caves)
 "pOb" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
+/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
 	},
-/area/f13/village)
+/area/f13/building)
 "pOg" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road{
@@ -27719,6 +27928,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"pQA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "pQL" = (
 /obj/machinery/shower{
 	dir = 4
@@ -27886,6 +28104,13 @@
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"pUG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/porknbeans,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "pUP" = (
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
@@ -27931,8 +28156,8 @@
 	},
 /area/f13/wasteland)
 "pWe" = (
-/obj/structure/bed,
 /obj/item/bedsheet/orange,
+/obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "pWt" = (
@@ -28921,6 +29146,16 @@
 /obj/structure/sign/poster/official/twelve_gauge,
 /turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood)
+"qAf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/f13/raiderharness,
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "qAx" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -30208,11 +30443,11 @@
 	},
 /area/f13/wasteland)
 "rkt" = (
-/obj/structure/bed,
 /obj/item/bedsheet/random,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/bed/old,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "rkZ" = (
@@ -30640,6 +30875,14 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
+"rzH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/clothing/head/soft/f13/baseball,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "rzR" = (
 /obj/machinery/light{
 	dir = 8
@@ -31054,10 +31297,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "rOm" = (
-/obj/structure/bed,
 /obj/item/bedsheet{
 	icon_state = "sheetbrown"
 	},
+/obj/structure/bed/old,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "rOo" = (
@@ -31186,8 +31429,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "rRX" = (
-/obj/structure/bed,
 /obj/item/bedsheet/random,
+/obj/structure/bed/old,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "rSy" = (
@@ -31392,6 +31635,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/radiation)
+"rZn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/crisps,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "rZK" = (
 /obj/structure/table,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -31715,6 +31968,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
+"shk" = (
+/obj/structure/window/fulltile/store,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/building)
 "shp" = (
 /obj/machinery/light/broken,
 /turf/open/floor/f13{
@@ -31835,6 +32096,14 @@
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"skS" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/yumyum,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "skZ" = (
 /obj/structure/simple_door/metal/fence{
 	dir = 8
@@ -32375,6 +32644,14 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/building)
+"sAs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/crafting/lunchbox,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "sAH" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -32429,12 +32706,12 @@
 	},
 /area/f13/wasteland)
 "sCz" = (
-/obj/structure/bed,
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#c1caff"
 	},
 /obj/item/bedsheet/brown,
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
@@ -32482,6 +32759,13 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"sEE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
 	},
 /area/f13/building)
 "sGg" = (
@@ -32595,11 +32879,11 @@
 /turf/open/water,
 /area/f13/caves)
 "sJh" = (
-/obj/structure/bed,
 /obj/item/bedsheet,
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
+/obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "sJl" = (
@@ -33873,6 +34157,15 @@
 "tsT" = (
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
+"tta" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/building)
 "tte" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -34163,12 +34456,12 @@
 	},
 /area/f13/wasteland)
 "tBP" = (
-/obj/structure/bed,
 /obj/item/bedsheet/cmo,
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#c1caff"
 	},
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
@@ -34899,7 +35192,6 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "tXt" = (
-/obj/structure/bed,
 /obj/item/bedsheet/brown,
 /obj/machinery/light{
 	dir = 4
@@ -34907,6 +35199,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
+/obj/structure/bed/old,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -35866,6 +36159,13 @@
 	icon_state = "horizontaltopbordertop2left"
 	},
 /area/f13/wasteland)
+"uzg" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "uzs" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	icon_state = "floor2-old"
@@ -35936,6 +36236,14 @@
 /obj/item/locked_box/weapon/range/tier1,
 /obj/item/locked_box/weapon/range/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
+"uBm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/building)
 "uBx" = (
 /obj/structure/table/wood/settler,
@@ -37291,10 +37599,7 @@
 	},
 /area/f13/wasteland)
 "vkR" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "ruinswindow"
-	},
+/obj/structure/window/fulltile/store,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -37566,6 +37871,14 @@
 	icon_state = "platingdmg2"
 	},
 /area/f13/bar)
+"vvH" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/crisps,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "vvU" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -37659,8 +37972,8 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
 "vya" = (
-/obj/structure/bed,
 /obj/effect/decal/cleanable/cobweb,
+/obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vye" = (
@@ -38445,10 +38758,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vWC" = (
-/obj/structure/bed,
-/obj/item/bedsheet/hos,
-/turf/open/floor/carpet/black,
-/area/f13/legion)
+/obj/structure/bed/old,
+/obj/item/bedsheet/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "vWK" = (
 /obj/structure/table,
 /obj/item/storage/box/gloves,
@@ -40051,15 +40367,14 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "wSn" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/fence{
+	dir = 8
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavementcorner"
 	},
-/area/f13/ncr)
+/area/f13/wasteland)
 "wSw" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -40562,6 +40877,13 @@
 /obj/structure/table/wood,
 /obj/item/papercutter,
 /turf/open/floor/wood,
+/area/f13/building)
+"xfx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/borscht,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/building)
 "xfy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41130,8 +41452,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "xtL" = (
-/obj/structure/bed,
 /obj/item/bedsheet/blue,
+/obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xtV" = (
@@ -41374,6 +41696,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"xBZ" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/f13/steak,
+/obj/item/trash/f13/steak,
+/obj/item/trash/f13/rotten,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "xCo" = (
 /obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/dirt{
@@ -41469,6 +41799,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
 /area/f13/bar)
+"xGe" = (
+/obj/structure/window/fulltile/store,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/building)
 "xGg" = (
 /obj/structure/table/wood,
 /obj/item/storage/toolbox/mechanical/old,
@@ -41709,7 +42046,6 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "xLd" = (
-/obj/structure/bed,
 /obj/item/bedsheet/patriot,
 /obj/machinery/light{
 	dir = 4
@@ -41717,6 +42053,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
+/obj/structure/bed/old,
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "xLK" = (
@@ -41853,10 +42190,10 @@
 	},
 /area/f13/building)
 "xRf" = (
-/obj/structure/bed,
 /obj/item/bedsheet{
 	icon_state = "sheetcmo"
 	},
+/obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xRg" = (
@@ -42035,10 +42372,23 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"xWs" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
 "xWu" = (
 /obj/structure/chair,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"xWz" = (
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/bar)
 "xXa" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -45689,7 +46039,7 @@ rUp
 kzs
 xGv
 dsn
-wSn
+aik
 sed
 tXt
 kzs
@@ -52429,7 +52779,7 @@ gcK
 gcK
 ktB
 qFk
-dEB
+jwl
 cPZ
 sqx
 qFk
@@ -57372,7 +57722,7 @@ bmO
 xbv
 gWn
 yhw
-vrz
+gQJ
 fyf
 fyf
 dRo
@@ -57883,7 +58233,7 @@ xuy
 hUK
 qiO
 rCO
-yhw
+xWz
 yhw
 aRp
 kBU
@@ -58142,7 +58492,7 @@ hLc
 dre
 yhw
 yhw
-yhw
+xWz
 vrz
 kGc
 nPg
@@ -58660,7 +59010,7 @@ gWn
 kBU
 kGc
 unI
-hbW
+box
 sQX
 rbe
 sQX
@@ -58917,7 +59267,7 @@ lhc
 tkd
 kGc
 unI
-eeh
+pht
 qci
 sQX
 sQX
@@ -59177,9 +59527,9 @@ unI
 hbW
 xJz
 sQX
-sQX
-sQX
-sQX
+hOl
+sgz
+kjQ
 koD
 dMW
 fyf
@@ -59433,9 +59783,9 @@ kGc
 unI
 hbW
 sQX
-sQX
-sQX
-sQX
+hOl
+sgz
+kjQ
 sQX
 koD
 dMW
@@ -59683,7 +60033,7 @@ iqx
 hUK
 xuy
 xuy
-uBx
+nwV
 nsg
 whO
 kGc
@@ -59946,10 +60296,10 @@ kBU
 kGc
 unI
 hbW
+rbe
 sQX
 sQX
-sQX
-sQX
+ubg
 jYQ
 koD
 dMW
@@ -60206,7 +60556,7 @@ hbW
 sQX
 sQX
 sQX
-sQX
+apk
 sQX
 koD
 dMW
@@ -60461,7 +60811,7 @@ kGc
 unI
 eeh
 qci
-sQX
+ubg
 sQX
 qci
 qci
@@ -60718,9 +61068,9 @@ kGc
 unI
 hbW
 ybw
+apk
 sQX
-sQX
-sQX
+rbe
 sQX
 koD
 dMW
@@ -61413,7 +61763,7 @@ fyf
 fyf
 fyf
 aYK
-pOb
+gPy
 pJd
 qgl
 pJd
@@ -61745,9 +62095,9 @@ aJb
 tUb
 idu
 idu
-hBN
-aJb
-tUb
+ehN
+ehN
+ehN
 idu
 idu
 idu
@@ -61982,7 +62332,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+lWZ
 kGc
 ajD
 hbW
@@ -61991,7 +62341,7 @@ ehN
 ehN
 sgz
 kjQ
-jyC
+ehN
 rbe
 ehN
 rbe
@@ -62240,12 +62590,12 @@ fyf
 fyf
 fyf
 fyf
-kGc
+ccF
 ajD
 qnS
 kaM
 kaM
-akU
+kaM
 fvz
 kaM
 kaM
@@ -62495,9 +62845,9 @@ fyf
 sqA
 fyf
 fyf
-fyf
-fyf
-kGc
+gSt
+igz
+hgX
 sIf
 ees
 ees
@@ -62507,7 +62857,7 @@ gQv
 fsm
 fsm
 gQv
-guw
+jZE
 gQv
 jZE
 ees
@@ -62752,9 +63102,8 @@ fyf
 fyf
 fyf
 fyf
-nPu
-fyf
-nJW
+kGc
+sUX
 ptf
 ptf
 ptf
@@ -62767,7 +63116,8 @@ ptf
 ptf
 ptf
 ptf
-ptf
+gNA
+sUX
 ptf
 ptf
 ptf
@@ -63009,22 +63359,22 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kGc
+dMW
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+kGc
+dMW
 fyf
 fyf
 sVO
@@ -63266,22 +63616,22 @@ fyf
 fyf
 fyf
 fyf
-fyf
-lWZ
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kGc
+dMW
+gts
+guw
+skS
+agY
+tta
+kAB
+jmr
+mKA
+kAB
+jmr
+jmr
+kar
+kGc
+dMW
 fyf
 fyf
 thG
@@ -63523,22 +63873,22 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uqa
-uqa
-uqa
-uqa
-uqa
-uqa
-fyf
-fyf
-fyf
+kGc
+dMW
+dEB
+iAz
+lxL
+caj
+gts
+rzH
+sAs
+jmr
+gFi
+jmr
+byI
+shk
+kGc
+dMW
 fyf
 fyf
 thG
@@ -63780,22 +64130,22 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uqa
-rpu
-rpu
-taN
-rpu
-uqa
-fyf
-fyf
-fyf
+kGc
+dMW
+dEB
+msy
+msy
+lHH
+gts
+oUr
+kAB
+jmr
+hOM
+jmr
+bNu
+kar
+kGc
+obr
 fyf
 fyf
 thG
@@ -63817,7 +64167,7 @@ fyf
 fyf
 fyf
 sYX
-ccF
+ovS
 sew
 rpu
 sYX
@@ -64037,22 +64387,22 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kGc
+dMW
+dEB
+pOb
+lqG
+vvH
+gts
 lLz
-rpu
-klA
+lLz
+xfx
 gFi
-gvW
-uqa
-fyf
-fyf
-fyf
+lHD
+hRb
+gts
+kGc
+bfX
 fyf
 fyf
 sYX
@@ -64294,22 +64644,22 @@ fyf
 trW
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-lLz
-neZ
-uCO
-uCO
-uCO
-uqa
-fyf
-fyf
-fyf
+kGc
+dMW
+gts
+vWC
+qAf
+lep
+gts
+pQA
+jmr
+kAB
+jmr
+mKA
+jmr
+mjx
+kGc
+dMW
 fyf
 fyf
 sYX
@@ -64551,22 +64901,22 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uqa
-rpu
+kGc
+dMW
+gts
+gts
+gts
+gts
+gts
 jfF
-rpu
-ovS
-uqa
-fyf
-fyf
-fyf
+uBm
+jmr
+osw
+osw
+kEx
+gts
+kGc
+dMW
 fyf
 fyf
 sYX
@@ -64808,22 +65158,22 @@ fyf
 fyf
 fyf
 fyf
+kGc
+jkJ
+igz
+wSn
+xBZ
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uqa
-rpu
-uCO
+gts
+rZn
+kAB
 jmr
-rpu
-uqa
-fyf
-fyf
-fyf
+jmr
+kAB
+jmr
+xGe
+kGc
+dMW
 fyf
 fyf
 sYX
@@ -65065,22 +65415,22 @@ fyf
 fyf
 fyf
 fyf
+nJW
+ptf
+gNA
+dMW
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uqa
+gts
+bHI
 jfF
-uqa
-uCO
+jmr
+jfF
 ohA
-uqa
-fyf
-fyf
-fyf
+jmr
+kar
+kGc
+dMW
 fyf
 fyf
 tKZ
@@ -65323,21 +65673,21 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
 sND
+nJW
+xWs
+ldk
 fyf
-fyf
-fyf
-fyf
-uqa
-xiy
-dhC
-uqa
-fyf
-fyf
-fyf
+gts
+kAB
+pUG
+jmr
+jmr
+jmr
+sEE
+xGe
+kGc
+dMW
 fyf
 fyf
 tKZ
@@ -65389,7 +65739,7 @@ dDF
 uCO
 tWu
 jhl
-iAz
+lkg
 sYX
 fyf
 fyf
@@ -65582,19 +65932,19 @@ qOV
 cWG
 cWG
 cWG
-cWG
-cWG
-wDc
-fyf
-fyf
-fyf
-uqa
-gCU
-jbw
-uqa
-fyf
-fyf
-fyf
+nyA
+vpx
+uzg
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+kGc
+dMW
 fyf
 fyf
 sYX
@@ -65844,14 +66194,14 @@ mvv
 tmA
 wDc
 fyf
-fyf
-uqa
-uqa
-uqa
-uqa
+ejQ
 fyf
 fyf
 fyf
+fyf
+fyf
+nJW
+edA
 fyf
 fyf
 sYX
@@ -66356,7 +66706,7 @@ imR
 mRD
 oZg
 mvv
-mvv
+wsC
 doX
 cWG
 cWG
@@ -66672,7 +67022,7 @@ rpu
 rpu
 rpu
 uCO
-msy
+jOH
 rpu
 uiL
 sYX
@@ -68375,7 +68725,7 @@ gjP
 cpH
 hRl
 gvh
-oCA
+jdE
 cbk
 pIV
 gvh
@@ -70793,7 +71143,7 @@ fyf
 sDp
 rpu
 rpu
-msy
+jOH
 uqa
 vhP
 sYK
@@ -74797,7 +75147,7 @@ ijg
 jMC
 fyf
 gjP
-oCA
+jdE
 sJh
 bMg
 iFb
@@ -78143,7 +78493,7 @@ iFb
 uRJ
 uRJ
 cbk
-oCA
+jdE
 wyI
 uRJ
 gjP
@@ -102158,7 +102508,7 @@ aBH
 lGd
 hom
 moX
-vWC
+cXS
 hom
 xXm
 xox

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -113,6 +113,10 @@
 /obj/item/stack/f13Cash/random/aureus/med,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"adV" = (
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/bar)
 "aeb" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/dirt{
@@ -235,13 +239,6 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
-"agY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/bubblegum,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "ahh" = (
 /obj/item/kirbyplants,
 /turf/open/indestructible/ground/outside/dirt{
@@ -2015,13 +2012,6 @@
 	icon_state = "horizontalbottomborderbottom2left"
 	},
 /area/f13/wasteland)
-"bfX" = (
-/obj/item/trash/f13/tin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
 "bgd" = (
 /obj/structure/barricade/wooden/strong{
 	obj_integrity = 500
@@ -2693,14 +2683,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"byI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/fancy/cigarettes/cigpack_bigboss,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "byT" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/f13/wood{
@@ -3018,14 +3000,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/building)
-"bHI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/borscht,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "bIh" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/clinic)
@@ -3066,6 +3040,11 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
+"bIY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "bJi" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -3177,14 +3156,6 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"bNu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/fancy/cigarettes/cigpack_greytort,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
 /area/f13/building)
 "bNA" = (
 /obj/item/stack/sheet/mineral/wood,
@@ -3571,13 +3542,6 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
-"caj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/yumyum,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "cam" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2right"
@@ -3679,6 +3643,13 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/water,
 /area/f13/caves)
+"chr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/yumyum,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "cht" = (
 /obj/structure/fence{
 	dir = 1
@@ -4300,6 +4271,14 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"cBd" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/f13/steak,
+/obj/item/trash/f13/steak,
+/obj/item/trash/f13/rotten,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "cBq" = (
 /obj/structure/rack,
 /obj/item/storage/backpack,
@@ -4368,6 +4347,14 @@
 	light_color = "#d8b1b1"
 	},
 /turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"cDE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/crafting/lunchbox,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/building)
 "cEc" = (
 /obj/structure/campfire,
@@ -6574,6 +6561,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"dRQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/borscht,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "dRT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/slot_machine,
@@ -7139,10 +7134,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ejQ" = (
-/mob/living/simple_animal/hostile/raider/ranged,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "ekB" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
@@ -9376,6 +9367,11 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/building)
+"fqE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood/f13/oak,
+/area/f13/bar)
 "fqL" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
@@ -10792,11 +10788,15 @@
 /area/f13/village)
 "gip" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "minimart";
+	name = "Minimart Button"
 	},
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "giq" = (
 /obj/structure/closet/crate/wicker,
 /turf/open/indestructible/ground/outside/dirt,
@@ -11434,10 +11434,8 @@
 /area/f13/building)
 "guw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "minimart";
-	name = "Minimart Button"
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
 	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
@@ -11525,6 +11523,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"gwr" = (
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "gwJ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -11790,6 +11792,13 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"gFh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "gFi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -12108,11 +12117,6 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/f13,
 /area/f13/building)
-"gQJ" = (
-/obj/effect/decal/cleanable/glass,
-/obj/item/trash/f13/tin,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/bar)
 "gQL" = (
 /obj/structure/decoration/vent,
 /turf/open/floor/f13{
@@ -13297,6 +13301,15 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
+"hvn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "hvp" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -14023,16 +14036,6 @@
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"hOM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	termtag = "Business"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "hPd" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/f13/leatherarmor,
@@ -14087,14 +14090,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"hRb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/light/small/broken,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "hRl" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
@@ -14401,6 +14396,16 @@
 	layer = 2.1
 	},
 /turf/open/floor/wood,
+/area/f13/building)
+"ian" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/crisps,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/building)
 "iap" = (
 /obj/structure/simple_door/metal/store{
@@ -15072,6 +15077,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/ncr)
+"iuO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/porknbeans,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "iuS" = (
 /obj/structure/chair/wood/modern{
 	dir = 4;
@@ -15248,9 +15260,6 @@
 /area/f13/building)
 "iAz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
@@ -15880,6 +15889,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"iPX" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "iQs" = (
 /obj/structure/table/wood,
 /obj/structure/reagent_dispensers/beerkeg,
@@ -16291,6 +16307,13 @@
 /obj/machinery/vending/cola/space_up,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"iYL" = (
+/obj/structure/window/fulltile/store,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/building)
 "iYO" = (
 /obj/item/reagent_containers/food/snacks/grown/broc,
 /obj/item/reagent_containers/food/snacks/grown/broc,
@@ -16527,6 +16550,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"jes" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/building)
 "jeO" = (
 /obj/structure/barricade/wooden/planks,
@@ -17404,6 +17435,16 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/ncr)
+"jFC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	termtag = "Business"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "jFE" = (
 /obj/structure/table/wood,
 /obj/item/trash/sosjerky{
@@ -18167,12 +18208,6 @@
 "kai" = (
 /obj/machinery/trading_machine/medical,
 /turf/closed/wall/f13/supermart,
-/area/f13/building)
-"kar" = (
-/obj/structure/window/fulltile/store,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
 /area/f13/building)
 "kas" = (
 /obj/structure/window/fulltile/house,
@@ -19042,13 +19077,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/brotherhood)
-"kAB" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "kAJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
@@ -19143,13 +19171,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"kEx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "kEE" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/desert,
@@ -19828,12 +19849,14 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
 "kZH" = (
+/obj/structure/closet/cardboard,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/clock{
-	pixel_y = 30
+/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
+/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
 	},
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
+/area/f13/building)
 "kZQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -19904,13 +19927,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/ncr)
-"ldk" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/trash/f13/crisps,
-/obj/item/trash/f13/crisps,
-/obj/item/trash/f13/crisps,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "ldy" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19948,14 +19964,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
-"lep" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/bubblegum/large,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "les" = (
 /obj/machinery/light,
 /turf/open/floor/f13{
@@ -20387,13 +20395,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"lqG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/dog,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "lqO" = (
 /obj/structure/bookcase,
 /turf/open/floor/f13/wood,
@@ -20641,15 +20642,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
-"lxL" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/instamash,
-/obj/item/reagent_containers/food/snacks/f13/instamash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "lxW" = (
 /obj/machinery/button/door{
 	id = "bosgarage";
@@ -20826,8 +20818,8 @@
 	},
 /area/f13/wasteland)
 "lDy" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/black,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "lDz" = (
@@ -20936,7 +20928,9 @@
 /area/f13/building)
 "lGH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/comfy/black,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "lGV" = (
@@ -20968,24 +20962,9 @@
 /obj/machinery/light/small,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"lHD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/trash/f13/rotten,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "lHG" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"lHH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
 /area/f13/building)
 "lHK" = (
 /obj/machinery/light,
@@ -21879,15 +21858,6 @@
 	icon_state = "rubble"
 	},
 /area/f13/village)
-"mjx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/building)
 "mjJ" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/dice,
@@ -21998,6 +21968,14 @@
 "mnG" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 1
+	},
+/area/f13/building)
+"mnP" = (
+/obj/structure/window/fulltile/store,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
 	},
 /area/f13/building)
 "mof" = (
@@ -22158,6 +22136,8 @@
 	},
 /area/f13/building)
 "msy" = (
+/obj/structure/bed/old,
+/obj/item/bedsheet/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
@@ -22650,13 +22630,6 @@
 	icon_state = "horizontaloutermainright"
 	},
 /area/f13/wasteland)
-"mKA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/instamash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "mLc" = (
 /obj/item/claymore/machete/training,
 /turf/open/indestructible/ground/outside/dirt,
@@ -22816,6 +22789,15 @@
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"mQT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
 "mQZ" = (
@@ -23765,12 +23747,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"nwV" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/plate,
-/turf/open/floor/wood/f13/oak,
-/area/f13/bar)
 "nwZ" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -23815,6 +23791,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building)
+"nxV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/dog,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "nxY" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -23847,15 +23830,6 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/building)
-"nyA" = (
-/obj/structure/fence/corner{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "nyM" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -24023,6 +23997,13 @@
 	icon_state = "plating"
 	},
 /area/f13/bar)
+"nEH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/instamash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "nFb" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -24437,6 +24418,14 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"nRW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/dog,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "nSc" = (
 /obj/structure/rack,
 /obj/item/flashlight/seclite,
@@ -24487,6 +24476,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/legion)
+"nTo" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/crisps,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "nTO" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/dirt,
@@ -25266,14 +25263,6 @@
 	icon_state = "horizontaloutermainleft"
 	},
 /area/f13/wasteland)
-"osw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/dog,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "osB" = (
 /obj/effect/landmark/observer_start,
 /turf/open/indestructible/ground/outside/road{
@@ -25352,11 +25341,14 @@
 	},
 /area/f13/ncr)
 "otQ" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/flashlight/lamp/green,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
 "otV" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood{
@@ -26170,16 +26162,6 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"oUr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/sugarbombs,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "oUy" = (
 /obj/structure/rack,
 /obj/structure/lattice/catwalk,
@@ -26326,6 +26308,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/ncr)
+"oZE" = (
+/obj/structure/window/fulltile/store,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/building)
 "oZK" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -26515,7 +26503,7 @@
 "pes" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/pen,
+/obj/item/flashlight/lamp/green,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "peu" = (
@@ -26656,12 +26644,6 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
-"pht" = (
-/obj/effect/decal/marking,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2right"
-	},
-/area/f13/wasteland)
 "phu" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -26772,6 +26754,13 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
+"pkx" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/f13/crisps,
+/obj/item/trash/f13/crisps,
+/obj/item/trash/f13/crisps,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "pkL" = (
 /obj/machinery/workbench,
 /turf/open/floor/wood/f13/oak,
@@ -26820,6 +26809,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"pmq" = (
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/plate,
+/turf/open/floor/wood/f13/oak,
+/area/f13/bar)
 "pmt" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -27826,12 +27821,19 @@
 	},
 /area/f13/caves)
 "pOb" = (
-/obj/structure/closet/cardboard,
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
+"pOe" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
-/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
+/obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
+	icon_state = "floorgrime"
 	},
 /area/f13/building)
 "pOg" = (
@@ -27928,15 +27930,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"pQA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "pQL" = (
 /obj/machinery/shower{
 	dir = 4
@@ -27955,6 +27948,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"pQQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/paper_bin,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "pQX" = (
 /obj/structure/fence/post{
 	desc = "A wooden post.";
@@ -27986,7 +27985,7 @@
 "pRo" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/paper_bin,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey/empty,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "pRv" = (
@@ -28104,13 +28103,6 @@
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
-"pUG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/porknbeans,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "pUP" = (
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
@@ -29146,16 +29138,6 @@
 /obj/structure/sign/poster/official/twelve_gauge,
 /turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood)
-"qAf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/under/f13/raiderharness,
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "qAx" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -29542,6 +29524,12 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"qLJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/pen,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "qLO" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt{
@@ -30332,6 +30320,11 @@
 	icon_state = "housebase"
 	},
 /area/f13/legion)
+"rgU" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/bar)
 "rhf" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/f13/diesel/alt,
@@ -30392,6 +30385,13 @@
 	},
 /turf/open/floor/wood/f13/stage_r,
 /area/f13/building)
+"riH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "riP" = (
 /obj/effect/landmark/start/f13/hunter,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -30525,6 +30525,14 @@
 /obj/item/trash/candy,
 /obj/item/trash/cheesie,
 /turf/open/floor/carpet,
+/area/f13/building)
+"rnk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/storage/fancy/cigarettes/cigpack_bigboss,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/building)
 "rns" = (
 /obj/effect/decal/cleanable/oil{
@@ -30874,14 +30882,6 @@
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/building)
-"rzH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/clothing/head/soft/f13/baseball,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
 /area/f13/building)
 "rzR" = (
 /obj/machinery/light{
@@ -31268,6 +31268,14 @@
 	icon_state = "crossborder"
 	},
 /area/f13/wasteland)
+"rNs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/storage/fancy/cigarettes/cigpack_greytort,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "rNv" = (
 /obj/structure/sink{
 	dir = 8;
@@ -31635,16 +31643,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/radiation)
-"rZn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/crisps,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "rZK" = (
 /obj/structure/table,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -31968,14 +31966,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
-"shk" = (
-/obj/structure/window/fulltile/store,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/building)
 "shp" = (
 /obj/machinery/light/broken,
 /turf/open/floor/f13{
@@ -32096,14 +32086,6 @@
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"skS" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/yumyum,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "skZ" = (
 /obj/structure/simple_door/metal/fence{
 	dir = 8
@@ -32385,6 +32367,15 @@
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"srF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/building)
 "ssm" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -32644,14 +32635,6 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/building)
-"sAs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/crafting/lunchbox,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "sAH" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -32759,13 +32742,6 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
-"sEE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
 	},
 /area/f13/building)
 "sGg" = (
@@ -32970,6 +32946,13 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
+"sLF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/bubblegum,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "sLV" = (
 /obj/machinery/photocopier,
 /turf/open/floor/f13/wood,
@@ -33061,6 +33044,14 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/building)
+"sPm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/trash/f13/rotten,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/building)
 "sPr" = (
 /obj/structure/chair/office/dark,
@@ -33915,6 +33906,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"tmP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/clothing/head/soft/f13/baseball,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "tnd" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/wood/f13/oak,
@@ -34157,15 +34156,6 @@
 "tsT" = (
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
-"tta" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/building)
 "tte" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -34273,6 +34263,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/city)
+"twy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/borscht,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "twI" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
@@ -34332,6 +34329,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/brotherhood)
+"txZ" = (
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2right"
+	},
+/area/f13/wasteland)
 "tyd" = (
 /obj/docking_port/stationary{
 	area_type = /area/f13;
@@ -34558,6 +34561,14 @@
 "tFo" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"tFF" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/bubblegum/large,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/building)
 "tFL" = (
@@ -35409,6 +35420,16 @@
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"udJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/f13/raiderharness,
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "udT" = (
 /obj/structure/table/wood,
 /obj/item/stack/medical/suture,
@@ -36085,6 +36106,12 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
+"uwE" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/old/ruinedcornertr,
+/area/f13/bar)
 "uwG" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -36159,13 +36186,6 @@
 	icon_state = "horizontaltopbordertop2left"
 	},
 /area/f13/wasteland)
-"uzg" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
 "uzs" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	icon_state = "floor2-old"
@@ -36236,14 +36256,6 @@
 /obj/item/locked_box/weapon/range/tier1,
 /obj/item/locked_box/weapon/range/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/building)
-"uBm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
 /area/f13/building)
 "uBx" = (
 /obj/structure/table/wood/settler,
@@ -36393,6 +36405,13 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"uEL" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "uEX" = (
 /obj/structure/decoration/clock{
 	pixel_y = 27
@@ -37711,6 +37730,13 @@
 	icon_state = "verticaloutermain2"
 	},
 /area/f13/wasteland)
+"vpo" = (
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "vpx" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
@@ -37792,6 +37818,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"vsS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "vsU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -37871,14 +37904,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/f13/bar)
-"vvH" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/crisps,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "vvU" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -38744,6 +38769,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"vVX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "vWo" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6"
@@ -38758,13 +38791,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vWC" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/yellow,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
+/obj/structure/fence/corner{
+	dir = 4
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "vWK" = (
 /obj/structure/table,
 /obj/item/storage/box/gloves,
@@ -39374,6 +39408,16 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"wrY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/sugarbombs,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
 	},
 /area/f13/building)
 "wso" = (
@@ -40367,14 +40411,13 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "wSn" = (
-/obj/structure/fence{
-	dir = 8
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/yumyum,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavementcorner"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "wSw" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -40877,13 +40920,6 @@
 /obj/structure/table/wood,
 /obj/item/papercutter,
 /turf/open/floor/wood,
-/area/f13/building)
-"xfx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/borscht,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
 /area/f13/building)
 "xfy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41584,11 +41620,14 @@
 	},
 /area/f13/wasteland)
 "xxg" = (
-/obj/structure/table,
+/obj/structure/closet/cardboard,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey/empty,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
+/obj/item/reagent_containers/food/snacks/f13/instamash,
+/obj/item/reagent_containers/food/snacks/f13/instamash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "xxL" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -41696,14 +41735,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"xBZ" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/trash/f13/steak,
-/obj/item/trash/f13/steak,
-/obj/item/trash/f13/rotten,
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "xCo" = (
 /obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/dirt{
@@ -41799,13 +41830,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
 /area/f13/bar)
-"xGe" = (
-/obj/structure/window/fulltile/store,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/building)
 "xGg" = (
 /obj/structure/table/wood,
 /obj/item/storage/toolbox/mechanical/old,
@@ -42372,23 +42396,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xWs" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavementcorner"
-	},
-/area/f13/wasteland)
 "xWu" = (
 /obj/structure/chair,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
-"xWz" = (
-/obj/item/trash/f13/tin,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/bar)
 "xXa" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -57193,7 +57204,7 @@ gcK
 gcK
 gcK
 gcK
-kBU
+gcK
 kBU
 kBU
 kBU
@@ -57450,11 +57461,11 @@ gcK
 gcK
 gcK
 gcK
+gcK
 kBU
 suS
 suS
-suS
-suS
+riH
 suS
 kBU
 xuy
@@ -57707,11 +57718,11 @@ gcK
 gcK
 gcK
 gcK
+gcK
 kBU
-kZH
-otQ
-pes
 suS
+pes
+qLJ
 suS
 kBU
 cqe
@@ -57722,7 +57733,7 @@ bmO
 xbv
 gWn
 yhw
-gQJ
+rgU
 fyf
 fyf
 dRo
@@ -57964,11 +57975,11 @@ gcK
 gcK
 gcK
 gcK
+gcK
 kBU
-gip
 lGH
 lDy
-suS
+bIY
 suS
 igs
 xuy
@@ -58221,11 +58232,11 @@ gcK
 gcK
 gcK
 gcK
+gcK
 kBU
 suS
-xxg
 pRo
-suS
+pQQ
 suS
 kBU
 elF
@@ -58233,7 +58244,7 @@ xuy
 hUK
 qiO
 rCO
-xWz
+adV
 yhw
 aRp
 kBU
@@ -58478,8 +58489,8 @@ gcK
 gcK
 gcK
 gcK
+gcK
 kBU
-suS
 suS
 suS
 suS
@@ -58488,11 +58499,11 @@ kBU
 lnc
 xuy
 xuy
-hLc
+uwE
 dre
 yhw
 yhw
-xWz
+adV
 vrz
 kGc
 nPg
@@ -58745,7 +58756,7 @@ tAg
 xuy
 anl
 uBx
-nsg
+fqE
 hLc
 lhc
 dre
@@ -59267,7 +59278,7 @@ lhc
 tkd
 kGc
 unI
-pht
+txZ
 qci
 sQX
 sQX
@@ -60032,8 +60043,8 @@ xuy
 iqx
 hUK
 xuy
-xuy
-nwV
+fqE
+pmq
 nsg
 whO
 kGc
@@ -63619,17 +63630,17 @@ fyf
 kGc
 dMW
 gts
-guw
-skS
-agY
-tta
-kAB
+gip
+wSn
+sLF
+mQT
+uEL
 jmr
-mKA
-kAB
+nEH
+uEL
 jmr
 jmr
-kar
+oZE
 kGc
 dMW
 fyf
@@ -63876,17 +63887,17 @@ fyf
 kGc
 dMW
 dEB
-iAz
-lxL
-caj
+guw
+xxg
+chr
 gts
-rzH
-sAs
+tmP
+cDE
 jmr
 gFi
 jmr
-byI
-shk
+rnk
+mnP
 kGc
 dMW
 fyf
@@ -64133,17 +64144,17 @@ fyf
 kGc
 dMW
 dEB
-msy
-msy
-lHH
+iAz
+iAz
+vsS
 gts
-oUr
-kAB
+wrY
+uEL
 jmr
-hOM
+jFC
 jmr
-bNu
-kar
+rNs
+oZE
 kGc
 obr
 fyf
@@ -64390,19 +64401,19 @@ fyf
 kGc
 dMW
 dEB
-pOb
-lqG
-vvH
+kZH
+nxV
+nTo
 gts
 lLz
 lLz
-xfx
+twy
 gFi
-lHD
-hRb
+sPm
+jes
 gts
 kGc
-bfX
+vpo
 fyf
 fyf
 sYX
@@ -64647,17 +64658,17 @@ fyf
 kGc
 dMW
 gts
-vWC
-qAf
-lep
+msy
+udJ
+tFF
 gts
-pQA
+hvn
 jmr
-kAB
+uEL
 jmr
-mKA
+nEH
 jmr
-mjx
+srF
 kGc
 dMW
 fyf
@@ -64909,11 +64920,11 @@ gts
 gts
 gts
 jfF
-uBm
+vVX
 jmr
-osw
-osw
-kEx
+nRW
+nRW
+gFh
 gts
 kGc
 dMW
@@ -65161,17 +65172,17 @@ fyf
 kGc
 jkJ
 igz
-wSn
-xBZ
+otQ
+cBd
 fyf
 gts
-rZn
-kAB
+ian
+uEL
 jmr
 jmr
-kAB
+uEL
 jmr
-xGe
+iYL
 kGc
 dMW
 fyf
@@ -65422,13 +65433,13 @@ dMW
 fyf
 fyf
 gts
-bHI
+dRQ
 jfF
 jmr
 jfF
 ohA
 jmr
-kar
+oZE
 kGc
 dMW
 fyf
@@ -65675,17 +65686,17 @@ fyf
 fyf
 sND
 nJW
-xWs
-ldk
+pOb
+pkx
 fyf
 gts
-kAB
-pUG
+uEL
+iuO
 jmr
 jmr
 jmr
-sEE
-xGe
+pOe
+iYL
 kGc
 dMW
 fyf
@@ -65932,9 +65943,9 @@ qOV
 cWG
 cWG
 cWG
-nyA
+vWC
 vpx
-uzg
+iPX
 gts
 gts
 gts
@@ -66194,7 +66205,7 @@ mvv
 tmA
 wDc
 fyf
-ejQ
+gwr
 fyf
 fyf
 fyf

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -289,10 +289,10 @@
 	},
 /area/f13/bunker)
 "aky" = (
-/obj/structure/bed,
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old"
 	},
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -556,9 +556,9 @@
 /area/f13/caves)
 "aAL" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/landmark/start/f13/usprivate,
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -1277,11 +1277,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "bns" = (
-/obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
@@ -1299,8 +1299,8 @@
 	},
 /area/f13/followers)
 "bof" = (
-/obj/structure/bed,
 /obj/item/bedsheet,
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -2912,9 +2912,9 @@
 	},
 /area/f13/den)
 "cOS" = (
-/obj/structure/bed/pod,
 /obj/item/bedsheet/brown,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/old,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/leisure)
 "cPA" = (
@@ -3877,8 +3877,8 @@
 /area/f13/caves)
 "dFh" = (
 /obj/item/bedsheet/red,
-/obj/structure/bed/pod,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/old,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "dFz" = (
@@ -3931,12 +3931,12 @@
 /area/f13/bunker)
 "dHz" = (
 /obj/item/bedsheet/red,
-/obj/structure/bed/pod,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_x = 16
 	},
+/obj/structure/bed/old,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "dHQ" = (
@@ -4331,9 +4331,9 @@
 	},
 /area/f13/tunnel)
 "dYM" = (
-/obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/landmark/start/f13/usspy,
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -4414,8 +4414,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "edB" = (
-/obj/structure/bed,
 /obj/item/bedsheet,
+/obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "edM" = (
@@ -4716,11 +4716,11 @@
 	},
 /area/f13/brotherhood/operations)
 "eqz" = (
-/obj/structure/bed,
 /obj/item/bedsheet{
 	icon_state = "sheetblue"
 	},
 /obj/effect/landmark/start/f13/followersdoctor,
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -5545,10 +5545,10 @@
 	},
 /area/f13/bunker)
 "fbD" = (
-/obj/structure/bed,
 /obj/item/bedsheet/random,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "fcy" = (
@@ -5609,11 +5609,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "ffJ" = (
-/obj/structure/bed,
 /obj/item/bedsheet{
 	icon_state = "sheetblue"
 	},
 /obj/effect/landmark/start/f13/followersvolunteer,
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -5709,9 +5709,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "fji" = (
-/obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/landmark/start/f13/usprivate,
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -6727,9 +6727,9 @@
 /area/f13/followers)
 "gcD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/pod,
 /obj/item/bedsheet/brown,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -7232,8 +7232,8 @@
 	},
 /area/f13/bunker)
 "guo" = (
-/obj/structure/bed,
 /obj/item/bedsheet/brown,
+/obj/structure/bed/old,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "guw" = (
@@ -7734,10 +7734,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "gSD" = (
-/obj/structure/bed,
 /obj/item/bedsheet{
 	icon_state = "sheetUSA"
 	},
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
@@ -8077,8 +8077,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "hfb" = (
-/obj/structure/bed,
 /obj/item/bedsheet/random,
+/obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "hfr" = (
@@ -8556,7 +8556,7 @@
 /area/f13/den)
 "huw" = (
 /obj/structure/light_construct,
-/obj/structure/bed,
+/obj/structure/bed/old,
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
@@ -10360,11 +10360,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "iSf" = (
-/obj/structure/bed,
 /obj/item/reagent_containers/pill/patch/jet,
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
 	},
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -10636,10 +10636,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jcn" = (
-/obj/structure/bed,
 /obj/machinery/camera/autoname{
 	dir = 9
 	},
+/obj/structure/bed/old,
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
@@ -11176,8 +11176,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jwN" = (
-/obj/structure/bed,
 /obj/item/bedsheet/medical,
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "bluedirtyfull"
 	},
@@ -11992,13 +11992,13 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "kbH" = (
-/obj/structure/bed,
 /obj/item/bedsheet/hos,
 /obj/item/toy/figure/warden{
 	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
 	name = "Head Knight Action Figure";
 	toysay = "Victory is our tradition!"
 	},
+/obj/structure/bed/old,
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
 "kcD" = (
@@ -12586,9 +12586,9 @@
 /area/f13/tunnel)
 "kBs" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/landmark/start/f13/usspy,
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -13295,8 +13295,8 @@
 /area/f13/brotherhood/operations)
 "leT" = (
 /obj/machinery/light,
-/obj/structure/bed,
 /obj/item/bedsheet/medical,
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "bluerustyfull"
 	},
@@ -13513,8 +13513,8 @@
 /turf/open/floor/plasteel/f13/vault_floor,
 /area/f13/den)
 "lnO" = (
-/obj/structure/bed,
 /obj/item/bedsheet/cult,
+/obj/structure/bed/old,
 /turf/open/floor/carpet,
 /area/f13/den)
 "lof" = (
@@ -14154,9 +14154,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "lTX" = (
-/obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/landmark/start/f13/ussgt,
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -14216,11 +14216,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "lXy" = (
-/obj/structure/bed,
 /obj/item/bedsheet/brown,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
+/obj/structure/bed/old,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "lXF" = (
@@ -14527,11 +14527,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/den)
 "mkY" = (
-/obj/structure/bed,
 /obj/item/bedsheet/random,
 /obj/structure/sign/poster/contraband/pinup_bed{
 	pixel_x = 32
 	},
+/obj/structure/bed/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "mln" = (
@@ -15606,7 +15606,6 @@
 	},
 /area/f13/brotherhood/operations)
 "ncA" = (
-/obj/structure/bed/pod,
 /obj/machinery/button/door{
 	id = "sentdorm";
 	normaldoorcontrol = 1;
@@ -15614,6 +15613,7 @@
 	specialfunctions = 4
 	},
 /obj/item/bedsheet/hos,
+/obj/structure/bed/old,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "ncX" = (
@@ -15621,8 +15621,8 @@
 /turf/open/floor/plasteel/f13/vault_floor,
 /area/f13/den)
 "ncY" = (
-/obj/structure/bed/pod,
 /obj/item/bedsheet/rd,
+/obj/structure/bed/old,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "ndi" = (
@@ -17721,7 +17721,7 @@
 	},
 /area/f13/bunker)
 "oKN" = (
-/obj/structure/bed,
+/obj/structure/bed/old,
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
 	},
@@ -19693,10 +19693,10 @@
 	pixel_y = 2
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed,
 /obj/item/bedsheet{
 	icon_state = "sheetcmo"
 	},
+/obj/structure/bed/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -20920,11 +20920,11 @@
 	},
 /area/f13/den)
 "rdF" = (
-/obj/structure/bed/pod,
 /obj/item/bedsheet/blue,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/bed/old,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "rex" = (
@@ -21059,9 +21059,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rjQ" = (
-/obj/structure/bed/pod,
 /obj/item/bedsheet/black,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/old,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "rjY" = (
@@ -21185,9 +21185,9 @@
 /area/f13/tunnel)
 "rnw" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/landmark/start/f13/ussgt,
+/obj/structure/bed/old,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -23682,9 +23682,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/bed,
 /obj/item/bedsheet/black,
 /obj/effect/landmark/start/f13/uslt,
+/obj/structure/bed/old,
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
 "tqH" = (
@@ -24856,8 +24856,8 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "urc" = (
-/obj/structure/bed/pod,
 /obj/item/bedsheet/hos,
+/obj/structure/bed/old,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "urg" = (
@@ -27798,11 +27798,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "wXr" = (
-/obj/structure/bed,
 /obj/item/bedsheet/rd,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
+/obj/structure/bed/old,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "wXG" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://user-images.githubusercontent.com/38540951/123841166-3ac08680-d8dd-11eb-9d92-1734b531d3fc.png)
I've placed a new minor ruin and made all of the beds in Yuma Valley into ancient ones, seeing as its been 200+ years since these mattresses were last changed out. Enjoy the Minimart! Just a little old convenience store full of bugs, with some tasty snacks.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The ancient bed sprites look better than the regular bed sprites and make the environment feel more post-apocalyptic. The convenience store replaces another space-filler cabin home and I intend to replace most if not all of those eventually.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added the Minimart!
balance: Replaced all the beds in Yuma so players have the Back Ache status effect after resting on an ancient bed. (Joke)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
