### PR TITLE
YuMail Express Ruin

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -7,6 +7,14 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/water,
 /area/f13/caves)
+"aaC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/storage/fancy/cigarettes/cigpack_greytort,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "aaN" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood/f13/oak,
@@ -1576,6 +1584,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"aTX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/trash/f13/rotten,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "aUl" = (
 /obj/structure/fence,
 /obj/structure/fence,
@@ -1825,6 +1841,13 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/f13/brotherhood)
+"baO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "bbf" = (
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/f13/wood,
@@ -1915,6 +1938,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"bcH" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/instamash,
+/obj/item/reagent_containers/food/snacks/f13/instamash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "bcK" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/indestructible/ground/outside/dirt{
@@ -1982,6 +2014,14 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/tunnel)
+"ber" = (
+/obj/structure/fluff/paper,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "bet" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/dirt,
@@ -2350,11 +2390,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"boW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/oak,
-/area/f13/bar)
 "bph" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
@@ -3095,10 +3130,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"bLK" = (
-/obj/effect/mine/explosive,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "bLL" = (
 /obj/structure/table/snooker{
 	dir = 9
@@ -3125,14 +3156,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"bMG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/fancy/cigarettes/cigpack_greytort,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "bMJ" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/f13/wood,
@@ -3596,6 +3619,7 @@
 /obj/structure/table,
 /obj/item/ammo_box/shotgun/rubber,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/packageWrap,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -3625,9 +3649,9 @@
 "ceP" = (
 /obj/structure/closet,
 /obj/item/storage/backpack/satchel/leather,
-/obj/item/gun/ballistic/automatic/smg10mm/worn,
-/obj/item/clothing/mask/rat/raven,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/gun/ballistic/automatic/smg10mm,
+/obj/item/clothing/mask/rat/raven,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -3871,10 +3895,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "clQ" = (
-/obj/structure/rack,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -4073,13 +4095,6 @@
 "csk" = (
 /turf/open/water,
 /area/f13/caves)
-"csG" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "csO" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
@@ -4191,14 +4206,6 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"cwk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/clothing/head/soft/f13/baseball,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "cwV" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -4360,13 +4367,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"cEn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/instamash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "cEv" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/outside/dirt,
@@ -5234,14 +5234,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/city)
-"ddR" = (
-/obj/structure/fluff/paper,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "dea" = (
 /obj/item/stack/sheet/mineral/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -5263,15 +5255,6 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
-"deP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
 /area/f13/building)
 "deT" = (
 /obj/machinery/light/small{
@@ -5296,15 +5279,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"deZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
 /area/f13/building)
 "dfo" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -5523,6 +5497,15 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"dlm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "dlp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -6876,7 +6859,9 @@
 	},
 /area/f13/tunnel)
 "ebV" = (
-/obj/structure/rack,
+/obj/structure/table,
+/obj/structure/fluff/paper/stack,
+/obj/item/stamp,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -6884,8 +6869,7 @@
 /area/f13/building)
 "ecg" = (
 /obj/structure/table,
-/obj/structure/fluff/paper/stack,
-/obj/item/stamp,
+/obj/item/storage/box/lights/bulbs,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -6935,13 +6919,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"edW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/bubblegum,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "eeh" = (
 /obj/effect/decal/marking,
 /turf/open/indestructible/ground/outside/road{
@@ -6959,7 +6936,7 @@
 /area/f13/wasteland)
 "eeN" = (
 /obj/structure/table,
-/obj/item/storage/box/lights/bulbs,
+/obj/item/stamp/denied,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -7021,15 +6998,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/building)
-"ehm" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavementcorner"
-	},
-/area/f13/wasteland)
 "ehx" = (
 /obj/effect/spawner/lootdrop/trash,
 /mob/living/simple_animal/hostile/ghoul/reaver,
@@ -7092,8 +7060,9 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "eig" = (
-/obj/structure/table,
-/obj/item/stamp/denied,
+/obj/effect/decal/remains/human,
+/obj/item/clothing/head/mailman,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -7188,11 +7157,6 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
-"elg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
 "ely" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice/catwalk,
@@ -7403,9 +7367,9 @@
 	},
 /area/f13/wasteland)
 "eqm" = (
-/obj/effect/decal/remains/human,
-/obj/item/clothing/head/mailman,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -7629,9 +7593,9 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "ewI" = (
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
-	},
+/obj/structure/table,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -7877,7 +7841,7 @@
 /area/f13/wasteland)
 "eDc" = (
 /obj/structure/table,
-/obj/item/stack/packageWrap,
+/obj/item/clothing/head/christmashat,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -8159,16 +8123,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"eKu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	termtag = "Business"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "eKB" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8251,8 +8205,9 @@
 	},
 /area/f13/wasteland)
 "eMU" = (
-/obj/structure/table,
-/obj/item/clothing/head/christmashat,
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -8275,6 +8230,16 @@
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
+	},
+/area/f13/building)
+"eMZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/f13/raiderharness,
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/building)
 "eNb" = (
@@ -9097,6 +9062,13 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"fgj" = (
+/mob/living/simple_animal/hostile/cazador,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 7;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "fgp" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -9212,15 +9184,6 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
-"fkB" = (
-/obj/structure/chair/f13chair1{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "fkD" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -9339,14 +9302,6 @@
 "foz" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"foA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
 /area/f13/building)
 "foM" = (
 /obj/structure/chair/wood,
@@ -10413,6 +10368,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"fUB" = (
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "fUZ" = (
 /obj/machinery/door/unpowered/wooddoor{
 	max_integrity = 300;
@@ -10766,6 +10728,12 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building)
+"gfl" = (
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/plate,
+/turf/open/floor/wood/f13/oak,
+/area/f13/bar)
 "gfB" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowright"
@@ -10780,6 +10748,12 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"gfX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/building)
 "gfY" = (
 /obj/structure/sink{
@@ -10850,9 +10824,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gip" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
+/mob/living/simple_animal/hostile/eyebot,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -11168,13 +11141,6 @@
 	icon_state = "cross3"
 	},
 /area/f13/wasteland)
-"goA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/dog,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "goC" = (
 /obj/structure/chair/comfy{
 	dir = 8
@@ -11292,7 +11258,7 @@
 /area/f13/building)
 "gqy" = (
 /mob/living/simple_animal/hostile/eyebot,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -11503,8 +11469,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
 /area/f13/building)
 "guw" = (
-/mob/living/simple_animal/hostile/eyebot,
 /obj/structure/fluff/paper,
+/obj/structure/table,
+/obj/item/trash/f13/rotten,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -11631,14 +11598,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"gxY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/crafting/lunchbox,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "gyd" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -11872,9 +11831,26 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building)
+"gFt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/building)
 "gFR" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland)
+"gFV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/borscht,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "gGp" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road,
@@ -11957,6 +11933,16 @@
 /obj/structure/curtain,
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
+	},
+/area/f13/building)
+"gJe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/crisps,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
 	},
 /area/f13/building)
 "gJp" = (
@@ -13271,14 +13257,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"hsP" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "htf" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -13407,14 +13385,6 @@
 "hwC" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/wasteland)
-"hwK" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/yumyum,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "hwO" = (
 /obj/structure/fence,
 /turf/closed/wall/f13/tunnel,
@@ -13519,6 +13489,15 @@
 	icon_state = "horizontalbottomborderbottomright"
 	},
 /area/f13/wasteland)
+"hzl" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
 "hzm" = (
 /obj/effect/landmark/start/f13/sheriff,
 /obj/effect/decal/cleanable/dirt,
@@ -13586,14 +13565,6 @@
 "hBr" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
-"hBG" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/yellow,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "hBN" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2top"
@@ -13623,6 +13594,10 @@
 	icon_state = "verticalinnermaintop"
 	},
 /area/f13/wasteland)
+"hCu" = (
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/bar)
 "hCC" = (
 /obj/structure/grille/indestructable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -13815,11 +13790,6 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
-"hHy" = (
-/obj/effect/decal/cleanable/glass,
-/obj/item/trash/f13/tin,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/bar)
 "hHz" = (
 /obj/structure/table,
 /obj/item/crafting/abraxo,
@@ -14074,6 +14044,15 @@
 	icon_state = "horizontalbottombordertop3"
 	},
 /area/f13/wasteland)
+"hNi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "hNo" = (
 /obj/structure/weightlifter,
 /turf/open/floor/f13,
@@ -14290,15 +14269,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
 /area/f13/bar)
-"hUL" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/instamash,
-/obj/item/reagent_containers/food/snacks/f13/instamash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "hUN" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
@@ -14706,6 +14676,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"igw" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
+/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "igz" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -15055,13 +15034,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
-"irz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "irF" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper,
 /turf/open/water,
@@ -15159,6 +15131,16 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/ncr)
+"iuw" = (
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "iuE" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/f13{
@@ -15312,15 +15294,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"izg" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
-/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "izr" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -15349,9 +15322,12 @@
 	},
 /area/f13/building)
 "iAz" = (
-/obj/structure/fluff/paper,
-/obj/structure/table,
-/obj/item/trash/f13/rotten,
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -15476,6 +15452,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"iEE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/dog,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "iEX" = (
 /obj/structure/rack,
 /obj/item/storage/fancy/cracker_pack,
@@ -15727,12 +15711,8 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
 "iKm" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/obj/structure/fluff/paper/corner{
-	dir = 8
-	},
+/obj/structure/fluff/paper/corner,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -17366,6 +17346,10 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"jxP" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "jxY" = (
 /obj/item/stack/sheet/mineral/wood/five,
 /turf/open/floor/f13/wood,
@@ -17385,14 +17369,6 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/ncr)
-"jzv" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/crisps,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "jzB" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 8
@@ -17425,14 +17401,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/brotherhood)
-"jAP" = (
-/obj/structure/window/fulltile/store,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/building)
 "jAZ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -17486,12 +17454,6 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"jCs" = (
-/obj/effect/decal/marking,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2right"
-	},
-/area/f13/wasteland)
 "jCC" = (
 /obj/structure/musician/piano,
 /turf/open/floor/f13{
@@ -17540,10 +17502,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/ncr)
-"jFx" = (
-/mob/living/simple_animal/hostile/raider/ranged,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "jFE" = (
 /obj/structure/table/wood,
 /obj/item/trash/sosjerky{
@@ -17728,17 +17686,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"jLu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "minimart";
-	name = "Minimart Button"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "jLK" = (
 /obj/structure/closet,
 /obj/item/clothing/gloves/combat,
@@ -17750,6 +17697,11 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"jLL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood/f13/oak,
+/area/f13/bar)
 "jMj" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/radiation)
@@ -17833,6 +17785,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"jOn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/yumyum,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "jOq" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -17982,6 +17941,12 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"jSb" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/old/ruinedcornertr,
+/area/f13/bar)
 "jSj" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18409,14 +18374,6 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/building)
-"kbI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/dog,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "kbQ" = (
 /obj/structure/table/wood/poker,
 /obj/effect/holodeck_effect/cards,
@@ -18674,6 +18631,13 @@
 	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/wasteland)
+"khC" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "khG" = (
 /obj/item/clothing/head/helmet/f13/motorcycle,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19076,13 +19040,6 @@
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"kwB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "kwK" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19250,14 +19207,6 @@
 /obj/structure/pondlily_small,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"kDa" = (
-/obj/structure/fluff/paper,
-/obj/item/storage/trash_stack,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "kDj" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -19386,6 +19335,13 @@
 	name = "gate shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"kGr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/instamash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/building)
 "kGy" = (
 /obj/structure/decoration/hatch{
@@ -19738,6 +19694,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"kTE" = (
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "kTP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -19801,13 +19761,6 @@
 /obj/item/binoculars,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"kUK" = (
-/mob/living/simple_animal/hostile/cazador,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 7;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
 "kUM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -19989,8 +19942,9 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
 "kZH" = (
-/obj/structure/fluff/paper/corner,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper,
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/bottle/instacoffee,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -20870,14 +20824,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"lBt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/borscht,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "lBD" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -20945,6 +20891,12 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
 	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"lCN" = (
+/mob/living/simple_animal/hostile/eyebot,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
 "lDv" = (
@@ -21225,9 +21177,9 @@
 	},
 /area/f13/building)
 "lLX" = (
-/obj/structure/fluff/paper,
 /obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/instacoffee,
+/obj/structure/fluff/paper/stack,
+/obj/structure/barricade/bars,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -21453,6 +21405,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"lTh" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/f13/steak,
+/obj/item/trash/f13/steak,
+/obj/item/trash/f13/rotten,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "lTk" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -21491,14 +21451,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"lTH" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/bubblegum/large,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "lTT" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/dirt{
@@ -21993,9 +21945,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "miS" = (
-/obj/structure/table,
-/obj/structure/fluff/paper/stack,
-/obj/structure/barricade/bars,
+/obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -22289,7 +22239,11 @@
 	},
 /area/f13/building)
 "msy" = (
-/obj/structure/wreck/trash/machinepiletwo,
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "yumail";
+	name = "YuMail Express Button"
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -22600,13 +22554,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"mFs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
 "mGf" = (
 /obj/structure/table/snooker{
 	dir = 6
@@ -22736,15 +22683,6 @@
 	icon_state = "verticaloutermainbottom"
 	},
 /area/f13/wasteland)
-"mKc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "mKe" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -22818,6 +22756,16 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"mLI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/sugarbombs,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "mLN" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -22842,14 +22790,6 @@
 /obj/item/paper/bitterdrink,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"mMF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/light/small/broken,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "mNn" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/knife,
@@ -23246,6 +23186,14 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"mZN" = (
+/obj/structure/fluff/paper,
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "mZX" = (
 /obj/structure/toilet{
 	dir = 1
@@ -23751,11 +23699,9 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "nqw" = (
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "yumail";
-	name = "YuMail Express Button"
-	},
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/pda,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -24056,6 +24002,13 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/tunnel)
+"nAP" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/f13/crisps,
+/obj/item/trash/f13/crisps,
+/obj/item/trash/f13/crisps,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "nBn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -24143,12 +24096,6 @@
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"nEh" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/old/ruinedcornertr,
-/area/f13/bar)
 "nEn" = (
 /obj/structure/holohoop{
 	dir = 8
@@ -24387,12 +24334,6 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"nLN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "nLX" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/machinery/workbench/forge,
@@ -24457,6 +24398,14 @@
 /obj/structure/simple_door/house,
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"nOf" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/yumyum,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/building)
 "nOl" = (
 /obj/structure/table,
@@ -24849,6 +24798,13 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
+"oae" = (
+/obj/structure/fluff/paper/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "oav" = (
 /obj/structure/closet/fridge/standard,
 /obj/effect/decal/cleanable/dirt,
@@ -24932,6 +24888,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"odz" = (
+/obj/effect/mine/explosive,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "odA" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/road,
@@ -25490,9 +25450,8 @@
 	},
 /area/f13/ncr)
 "otQ" = (
-/obj/structure/closet/crate,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/pda,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -25939,12 +25898,6 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
-"oIB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/paper_bin,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
 "oIF" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -26047,9 +26000,8 @@
 	},
 /area/f13/wasteland)
 "oMb" = (
-/obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/f13stool,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -26125,6 +26077,13 @@
 /obj/item/ammo_box/a308,
 /obj/item/ammo_box/a308,
 /turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"oOv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/building)
 "oON" = (
 /obj/effect/decal/waste{
@@ -26253,6 +26212,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"oSo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "oSp" = (
 /obj/structure/chair{
 	dir = 4
@@ -26318,16 +26282,6 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"oUt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/sugarbombs,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "oUy" = (
 /obj/structure/rack,
 /obj/structure/lattice/catwalk,
@@ -26542,6 +26496,13 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"pbi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "pbn" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -26570,14 +26531,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"pcc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/fancy/cigarettes/cigpack_bigboss,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "pck" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -26721,6 +26674,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"pfh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/storage/fancy/cigarettes/cigpack_bigboss,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "pfk" = (
 /obj/structure/flora/wasteplant/wild_punga,
 /turf/open/indestructible/ground/outside/water,
@@ -27287,16 +27248,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"pvv" = (
-/obj/structure/fluff/paper/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "pvx" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/tunnel,
@@ -27721,12 +27672,6 @@
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"pIp" = (
-/mob/living/simple_animal/hostile/eyebot,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland)
 "pIL" = (
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/floor/wood/f13/oak,
@@ -27774,6 +27719,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"pJI" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/crisps,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "pJQ" = (
 /obj/structure/simple_door/wood,
 /obj/structure/decoration/rag,
@@ -27823,6 +27776,14 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt"
+	},
+/area/f13/building)
+"pKN" = (
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "pKP" = (
@@ -27993,7 +27954,11 @@
 /area/f13/caves)
 "pOb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/f13stool,
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Business"
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -29353,15 +29318,6 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"qCC" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavementcorner"
-	},
-/area/f13/wasteland)
 "qCN" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -29385,12 +29341,12 @@
 	},
 /area/f13/legion)
 "qDe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Business"
+/obj/machinery/light/small{
+	dir = 4
 	},
+/obj/structure/closet/crate,
+/obj/item/storage/firstaid,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -29796,6 +29752,14 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"qNV" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/bubblegum/large,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "qOd" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13{
@@ -30144,13 +30108,6 @@
 /obj/structure/simple_door/wood,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
-"qVw" = (
-/obj/structure/fluff/paper/corner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "qVC" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
@@ -30248,11 +30205,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
 "qZN" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/closet/crate,
-/obj/item/storage/firstaid,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -30367,15 +30322,6 @@
 	pixel_y = -7
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"rcw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
 /area/f13/building)
 "rcC" = (
 /obj/structure/table/wood,
@@ -30767,19 +30713,17 @@
 /obj/item/clothing/glasses/regular,
 /turf/open/floor/wood/f13/oak,
 /area/f13/bar)
-"rpM" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "minimart";
-	name = "Minimart Shutters"
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/building)
 "rpS" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2right"
+	},
+/area/f13/wasteland)
+"rqd" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "rqW" = (
@@ -31120,10 +31064,6 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/wood/f13,
 /area/f13/building)
-"rBC" = (
-/obj/item/trash/f13/tin,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/bar)
 "rCt" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road,
@@ -31766,6 +31706,15 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"rYe" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
 "rYl" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -31936,16 +31885,6 @@
 	pixel_x = 16
 	},
 /turf/open/floor/carpet,
-/area/f13/building)
-"sdX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/under/f13/raiderharness,
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
 /area/f13/building)
 "sed" = (
 /obj/effect/decal/cleanable/dirt{
@@ -32252,19 +32191,21 @@
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"skI" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/trash/f13/crisps,
-/obj/item/trash/f13/crisps,
-/obj/item/trash/f13/crisps,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "skZ" = (
 /obj/structure/simple_door/metal/fence{
 	dir = 8
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"slq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
 "slr" = (
@@ -32334,6 +32275,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"smz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/dog,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "smU" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
@@ -32824,6 +32772,15 @@
 	icon_state = "horizontalbottomborderbottom2"
 	},
 /area/f13/wasteland)
+"sBw" = (
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "sBH" = (
 /obj/structure/chair/wood/modern{
 	dir = 1
@@ -33272,13 +33229,6 @@
 /obj/structure/simple_door/tentflap_cloth,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"sQd" = (
-/obj/structure/wreck/trash/five_tires,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 10;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
 "sQv" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -33302,6 +33252,14 @@
 	icon_state = "horizontalbottombordertop3"
 	},
 /area/f13/wasteland)
+"sRO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "sRV" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/light,
@@ -33311,9 +33269,7 @@
 	},
 /area/f13/building)
 "sRX" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/chair/f13chair1,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -33326,6 +33282,13 @@
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"sSG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/bubblegum,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "sSJ" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/plasteel/barber{
@@ -34309,6 +34272,12 @@
 "tsT" = (
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
+"ttb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/paper_bin,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "tte" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -34349,6 +34318,14 @@
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"tuK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/clothing/head/soft/f13/baseball,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "tvl" = (
 /obj/effect/landmark/latejoin,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -34385,9 +34362,23 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"tvP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "twe" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"twi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/borscht,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/building)
 "twq" = (
 /obj/effect/decal/remains{
@@ -34804,14 +34795,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"tJu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/trash/f13/rotten,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "tJv" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -34988,6 +34971,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"tOf" = (
+/obj/structure/window/fulltile/store,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/building)
 "tOg" = (
 /obj/structure/decoration/clock/old/active,
 /turf/closed/wall/f13/wood/house,
@@ -35037,16 +35026,6 @@
 /obj/item/clothing/under/f13/petrochico,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
-	},
-/area/f13/building)
-"tPh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/crisps,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
 	},
 /area/f13/building)
 "tPs" = (
@@ -35781,15 +35760,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"ujz" = (
-/obj/structure/fence/corner{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "ujC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -35998,13 +35968,6 @@
 "uqa" = (
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"uqb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/borscht,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "uqe" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -36184,6 +36147,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"utX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "uuc" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -36225,13 +36196,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"uvo" = (
-/obj/item/trash/f13/tin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
 "uvp" = (
 /obj/effect/landmark/start/f13/legionary,
 /obj/item/bedsheet/brown,
@@ -36307,6 +36271,17 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"uyl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "minimart";
+	name = "Minimart Button"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/building)
 "uyn" = (
@@ -36515,6 +36490,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"uDF" = (
+/obj/structure/bed/old,
+/obj/item/bedsheet/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "uDG" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticaldegraded"
@@ -36993,10 +36976,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"uQg" = (
-/obj/structure/car/rubbish3,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "uQx" = (
 /obj/structure/decoration/clock/old/active,
 /turf/closed/wall/f13/wood/interior,
@@ -37239,13 +37218,6 @@
 	pixel_y = -3
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
-"uVJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
 /area/f13/building)
 "uVM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -37586,6 +37558,13 @@
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"vfI" = (
+/obj/structure/wreck/trash/five_tires,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 10;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "vfU" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/floor/f13/wood,
@@ -37859,13 +37838,6 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"vnU" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
 "vof" = (
 /obj/item/bodypart/l_arm/robot,
 /obj/structure/chair/office/dark,
@@ -37961,12 +37933,6 @@
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"vrN" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/plate,
-/turf/open/floor/wood/f13/oak,
-/area/f13/bar)
 "vsm" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/fence/wooden{
@@ -38209,13 +38175,6 @@
 /obj/item/dice,
 /turf/open/floor/wood/f13/old/ruinedstraightnorth,
 /area/f13/bar)
-"vzE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/porknbeans,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "vzG" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
@@ -38457,12 +38416,6 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
-"vGT" = (
-/obj/structure/window/fulltile/store,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/building)
 "vHa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -38647,7 +38600,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vLy" = (
-/obj/structure/chair/f13chair1,
+/obj/structure/table,
+/obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -38867,6 +38821,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"vTQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/crafting/lunchbox,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "vUa" = (
 /obj/machinery/mineral/wasteland_vendor/attachments{
 	icon_state = "weapon_idle"
@@ -38960,8 +38922,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vWC" = (
-/obj/structure/table,
-/obj/item/pen,
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -40088,6 +40051,16 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building)
+"wGD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	termtag = "Business"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "wGI" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -40569,9 +40542,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "wSn" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/structure/closet/crate,
+/obj/item/clothing/head/festive,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -40827,13 +40799,6 @@
 "wYv" = (
 /obj/structure/chair/wood/worn,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"wYD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/yumyum,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
 /area/f13/building)
 "wYO" = (
 /obj/structure/window/fulltile/house{
@@ -41499,6 +41464,14 @@
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"xqt" = (
+/obj/structure/window/fulltile/store,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/building)
 "xqw" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2bottom"
@@ -41787,7 +41760,9 @@
 /area/f13/wasteland)
 "xxg" = (
 /obj/structure/closet/crate,
-/obj/item/clothing/head/festive,
+/obj/item/wrench,
+/obj/item/screwdriver,
+/obj/item/crowbar,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -41823,6 +41798,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"xyW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/pen,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "xyX" = (
 /obj/structure/fence{
 	dir = 8
@@ -41858,6 +41839,15 @@
 	icon_state = "innershade"
 	},
 /area/f13/wasteland)
+"xAG" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "minimart";
+	name = "Minimart Shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/building)
 "xAX" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
@@ -41903,14 +41893,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"xCi" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/trash/f13/steak,
-/obj/item/trash/f13/steak,
-/obj/item/trash/f13/rotten,
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "xCo" = (
 /obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/dirt{
@@ -42293,12 +42275,6 @@
 	icon_state = "verticalleftborderleft2bottom"
 	},
 /area/f13/wasteland)
-"xMv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/pen,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
 "xMw" = (
 /obj/structure/simple_door/metal/store,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -42342,6 +42318,13 @@
 /obj/structure/weightlifter,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"xOu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/porknbeans,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "xOD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/trash,
@@ -42826,6 +42809,12 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ydy" = (
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2right"
+	},
+/area/f13/wasteland)
 "ydQ" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowdestroyed"
@@ -42874,10 +42863,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "yeF" = (
-/obj/structure/closet/crate,
-/obj/item/wrench,
-/obj/item/screwdriver,
-/obj/item/crowbar,
+/obj/structure/chair/f13chair1{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -43085,6 +43073,11 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"ylk" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/bar)
 "ylC" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/spray/pestspray,
@@ -57652,7 +57645,7 @@ gcK
 kBU
 suS
 suS
-mFs
+pbi
 suS
 kBU
 xuy
@@ -57909,7 +57902,7 @@ gcK
 kBU
 suS
 pes
-xMv
+xyW
 suS
 kBU
 cqe
@@ -57920,7 +57913,7 @@ bmO
 xbv
 gWn
 yhw
-hHy
+ylk
 fyf
 fyf
 dRo
@@ -58166,7 +58159,7 @@ gcK
 kBU
 lGH
 lDy
-elg
+oSo
 suS
 igs
 xuy
@@ -58423,7 +58416,7 @@ gcK
 kBU
 suS
 pRo
-oIB
+ttb
 suS
 kBU
 elF
@@ -58431,7 +58424,7 @@ xuy
 hUK
 qiO
 rCO
-rBC
+hCu
 yhw
 aRp
 kBU
@@ -58686,11 +58679,11 @@ kBU
 lnc
 xuy
 xuy
-nEh
+jSb
 dre
 yhw
 yhw
-rBC
+hCu
 vrz
 kGc
 nPg
@@ -58943,7 +58936,7 @@ tAg
 xuy
 anl
 uBx
-boW
+jLL
 hLc
 lhc
 dre
@@ -59465,7 +59458,7 @@ lhc
 tkd
 kGc
 unI
-jCs
+ydy
 qci
 sQX
 sQX
@@ -60230,8 +60223,8 @@ xuy
 iqx
 hUK
 xuy
-boW
-vrN
+jLL
+gfl
 nsg
 whO
 kGc
@@ -62788,7 +62781,7 @@ fyf
 fyf
 fyf
 fyf
-kUK
+fgj
 ajD
 qnS
 kaM
@@ -63817,17 +63810,17 @@ fyf
 kGc
 dMW
 gts
-jLu
-hwK
-edW
-deZ
-csG
+uyl
+nOf
+sSG
+slq
+khC
 jmr
-cEn
-csG
+kGr
+khC
 jmr
 jmr
-vGT
+tOf
 kGc
 dMW
 fyf
@@ -64073,18 +64066,18 @@ fyf
 fyf
 kGc
 dMW
-rpM
-deP
-hUL
-wYD
+xAG
+dlm
+bcH
+jOn
 gts
-cwk
-gxY
+tuK
+vTQ
 jmr
 gFi
 jmr
-pcc
-jAP
+pfh
+xqt
 kGc
 dMW
 fyf
@@ -64330,18 +64323,18 @@ fyf
 fyf
 kGc
 dMW
-rpM
-nLN
-nLN
-uVJ
+xAG
+gfX
+gfX
+baO
 gts
-oUt
-csG
+mLI
+khC
 jmr
-eKu
+wGD
 jmr
-bMG
-vGT
+aaC
+tOf
 kGc
 obr
 fyf
@@ -64587,20 +64580,20 @@ fyf
 fyf
 kGc
 dMW
-rpM
-izg
-goA
-jzv
+xAG
+igw
+smz
+pJI
 gts
 lLz
 lLz
-uqb
+twi
 gFi
-tJu
-mMF
+aTX
+sRO
 gts
 kGc
-uvo
+fUB
 fyf
 fyf
 sYX
@@ -64845,17 +64838,17 @@ fyf
 kGc
 dMW
 gts
-hBG
-sdX
-lTH
+uDF
+eMZ
+qNV
 gts
-mKc
+hNi
 jmr
-csG
+khC
 jmr
-cEn
+kGr
 jmr
-rcw
+gFt
 kGc
 dMW
 fyf
@@ -65107,11 +65100,11 @@ gts
 gts
 gts
 jfF
-foA
+utX
 jmr
-kbI
-kbI
-kwB
+iEE
+iEE
+oOv
 gts
 kGc
 dMW
@@ -65359,15 +65352,15 @@ fyf
 kGc
 jkJ
 igz
-ehm
-xCi
+rYe
+lTh
 fyf
 gts
-tPh
-csG
+gJe
+khC
 jmr
 jmr
-csG
+khC
 jmr
 fRZ
 kGc
@@ -65620,13 +65613,13 @@ dMW
 fyf
 fyf
 gts
-lBt
+gFV
 jfF
 jmr
 jfF
 ohA
 jmr
-vGT
+tOf
 kGc
 dMW
 fyf
@@ -65873,16 +65866,16 @@ fyf
 fyf
 sND
 nJW
-qCC
-skI
+hzl
+nAP
 fyf
 gts
-csG
-vzE
+khC
+xOu
 jmr
 jmr
 jmr
-irz
+tvP
 fRZ
 kGc
 dMW
@@ -66130,9 +66123,9 @@ qOV
 cWG
 cWG
 cWG
-ujz
+sBw
 vpx
-vnU
+rqd
 gts
 gts
 gts
@@ -66392,7 +66385,7 @@ mvv
 tmA
 wDc
 fyf
-jFx
+kTE
 fyf
 fyf
 fyf
@@ -78635,9 +78628,9 @@ gcK
 gcK
 gts
 ceP
-eqm
+eig
 cGV
-iAz
+guw
 gts
 gts
 gts
@@ -78893,12 +78886,12 @@ gcK
 gts
 nft
 wyM
-gip
-iKm
+eMU
+iAz
 gts
-nqw
+msy
 cfz
-xxg
+wSn
 gts
 igz
 hgX
@@ -79150,14 +79143,14 @@ gcK
 gts
 ctT
 ujC
-gqy
+gip
 ujC
 gts
 ujC
 ujC
 ujC
 nuv
-bLK
+odz
 cpK
 ofX
 hbW
@@ -79408,14 +79401,14 @@ gts
 duK
 wyM
 ujC
-kZH
+iKm
 wkx
 ujC
 ujC
 ujC
 nuv
 glZ
-uQg
+jxP
 unI
 qnS
 erY
@@ -79665,14 +79658,14 @@ gts
 dEB
 wyM
 okg
-lLX
+kZH
 gts
-otQ
-qZN
-yeF
+nqw
+qDe
+xxg
 gts
 ptf
-sQd
+vfI
 unI
 dXy
 dFQ
@@ -79920,7 +79913,7 @@ gts
 gts
 gts
 gts
-ewI
+eqm
 gts
 gts
 gts
@@ -80180,11 +80173,11 @@ clQ
 wyM
 vJL
 gts
-msy
+miS
 ujC
-sRX
+qZN
 ujC
-ddR
+ber
 gts
 kGc
 pBv
@@ -80433,15 +80426,15 @@ gcK
 gts
 xAZ
 ujC
-ebV
+clQ
 wyM
 afs
 wkx
 wyM
 ujC
-vLy
-fkB
-ddR
+sRX
+yeF
+ber
 gts
 kGc
 ajD
@@ -80696,9 +80689,9 @@ boq
 gts
 wyM
 nqZ
-vWC
-hsP
-pvv
+vLy
+pKN
+iuw
 fRZ
 kGc
 jIB
@@ -80947,15 +80940,15 @@ gcK
 gts
 ujC
 bpn
-ecg
-eDc
-guw
+ebV
+ewI
+gqy
 dps
 uVE
 wyM
-gip
-gip
-qVw
+eMU
+eMU
+oae
 fRZ
 kGc
 ofX
@@ -81461,15 +81454,15 @@ gcK
 gts
 wyM
 uLk
-eeN
-eMU
-guw
-miS
+ecg
+eDc
+gqy
+lLX
 uVE
-oMb
+otQ
 uVE
 wyM
-kDa
+mZN
 gts
 jRX
 fsl
@@ -81975,18 +81968,18 @@ gcK
 gts
 ujC
 ccF
-eig
+eeN
 uLk
-guw
+gqy
 dps
 uVE
 uVE
 wyM
 ujC
-pvv
-ewI
+iuw
+eqm
 kGc
-pIp
+lCN
 tbG
 erY
 erY
@@ -82237,9 +82230,9 @@ ujC
 boq
 gts
 wyM
-pOb
+oMb
 ujC
-pOb
+oMb
 wyM
 gts
 kGc
@@ -82494,9 +82487,9 @@ gts
 gts
 gts
 iBu
-qDe
-wSn
-qDe
+pOb
+vWC
+pOb
 cKs
 gts
 jRX

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -7,14 +7,6 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/water,
 /area/f13/caves)
-"aaC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/fancy/cigarettes/cigpack_greytort,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "aaN" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood/f13/oak,
@@ -25,6 +17,15 @@
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
+	},
+/area/f13/wasteland)
+"aby" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
 "abC" = (
@@ -645,6 +646,13 @@
 	dir = 5;
 	icon_state = "rubble"
 	},
+/area/f13/wasteland)
+"aqH" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/f13/crisps,
+/obj/item/trash/f13/crisps,
+/obj/item/trash/f13/crisps,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "aqI" = (
 /obj/effect/decal/cleanable/oil{
@@ -1584,14 +1592,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
-"aTX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/trash/f13/rotten,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "aUl" = (
 /obj/structure/fence,
 /obj/structure/fence,
@@ -1841,13 +1841,6 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/f13/brotherhood)
-"baO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "bbf" = (
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/f13/wood,
@@ -1901,6 +1894,12 @@
 /obj/item/kirbyplants,
 /turf/open/water,
 /area/f13/brotherhood)
+"bbP" = (
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2right"
+	},
+/area/f13/wasteland)
 "bbS" = (
 /turf/closed/wall/f13/wood,
 /area/f13/brotherhood)
@@ -1937,15 +1936,6 @@
 	icon_state = "wooden_chair_settler"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"bcH" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/instamash,
-/obj/item/reagent_containers/food/snacks/f13/instamash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
 /area/f13/building)
 "bcK" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -2014,14 +2004,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/tunnel)
-"ber" = (
-/obj/structure/fluff/paper,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "bet" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/dirt,
@@ -2277,6 +2259,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"bni" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "bnn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office{
@@ -2752,6 +2741,14 @@
 	icon_state = "horizontaltopbordertop3"
 	},
 /area/f13/wasteland)
+"bzH" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/crisps,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "bzK" = (
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/dirt{
@@ -3106,6 +3103,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"bKh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/storage/fancy/cigarettes/cigpack_greytort,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "bKn" = (
 /obj/machinery/door/window/eastleft,
 /obj/effect/decal/cleanable/dirt,
@@ -3330,6 +3335,14 @@
 /obj/item/storage/bag/plants,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"bRd" = (
+/obj/structure/bed/old,
+/obj/item/bedsheet/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "bRi" = (
 /obj/structure/debris/v2,
 /turf/closed/wall/f13/ruins,
@@ -3431,6 +3444,11 @@
 /obj/machinery/mineral/wasteland_vendor/medical,
 /turf/open/floor/plating/f13/inside,
 /area/f13/building)
+"bTB" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/bar)
 "bUF" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -3639,6 +3657,14 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
+"cdL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/trash/f13/rotten,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "ces" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
@@ -3650,7 +3676,7 @@
 /obj/structure/closet,
 /obj/item/storage/backpack/satchel/leather,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/gun/ballistic/automatic/smg10mm,
+/obj/item/gun/ballistic/revolver/detective,
 /obj/item/clothing/mask/rat/raven,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -5444,6 +5470,15 @@
 /obj/item/storage/backpack,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"dkb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/building)
 "dkg" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
@@ -5497,15 +5532,6 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"dlm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "dlp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -6430,6 +6456,14 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"dNo" = (
+/obj/structure/fluff/paper,
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "dNv" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -6765,6 +6799,12 @@
 /obj/structure/flora/ausbushes/palebush,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"dZS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/paper_bin,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "dZT" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
@@ -7052,6 +7092,14 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"ehW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/storage/fancy/cigarettes/cigpack_bigboss,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/building)
 "eic" = (
 /obj/structure/closet/athletic_mixed,
@@ -8232,16 +8280,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"eMZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/under/f13/raiderharness,
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "eNb" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/wolf{
@@ -8265,6 +8303,16 @@
 	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland)
+"eNS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/sugarbombs,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "eNT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -8274,6 +8322,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"eNU" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/old/ruinedcornertr,
+/area/f13/bar)
 "eOc" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/indestructible/ground/outside/dirt{
@@ -8950,6 +9004,15 @@
 	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland)
+"fdI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "fdX" = (
 /obj/structure/table/wood/bar,
 /turf/open/floor/f13/wood,
@@ -9062,13 +9125,6 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"fgj" = (
-/mob/living/simple_animal/hostile/cazador,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 7;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
 "fgp" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -9968,6 +10024,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"fIJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "fIT" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -10368,13 +10429,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"fUB" = (
-/obj/item/trash/f13/tin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
 "fUZ" = (
 /obj/machinery/door/unpowered/wooddoor{
 	max_integrity = 300;
@@ -10728,12 +10782,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building)
-"gfl" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/plate,
-/turf/open/floor/wood/f13/oak,
-/area/f13/bar)
 "gfB" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowright"
@@ -10748,12 +10796,6 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"gfX" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
 /area/f13/building)
 "gfY" = (
 /obj/structure/sink{
@@ -11282,6 +11324,15 @@
 	pixel_y = -16
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/building)
+"gqS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
 /area/f13/building)
 "grc" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -11831,26 +11882,9 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building)
-"gFt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/building)
 "gFR" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland)
-"gFV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/borscht,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "gGp" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road,
@@ -11933,16 +11967,6 @@
 /obj/structure/curtain,
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
-	},
-/area/f13/building)
-"gJe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/crisps,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
 	},
 /area/f13/building)
 "gJp" = (
@@ -12509,6 +12533,10 @@
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"hbg" = (
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/bar)
 "hbj" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical"
@@ -12701,6 +12729,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"hfQ" = (
+/obj/structure/window/fulltile/store,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/building)
 "hfV" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -13489,15 +13525,6 @@
 	icon_state = "horizontalbottomborderbottomright"
 	},
 /area/f13/wasteland)
-"hzl" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavementcorner"
-	},
-/area/f13/wasteland)
 "hzm" = (
 /obj/effect/landmark/start/f13/sheriff,
 /obj/effect/decal/cleanable/dirt,
@@ -13594,10 +13621,6 @@
 	icon_state = "verticalinnermaintop"
 	},
 /area/f13/wasteland)
-"hCu" = (
-/obj/item/trash/f13/tin,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/bar)
 "hCC" = (
 /obj/structure/grille/indestructable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -14044,13 +14067,13 @@
 	icon_state = "horizontalbottombordertop3"
 	},
 /area/f13/wasteland)
-"hNi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/clock{
-	pixel_y = 30
+"hMZ" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "minimart";
+	name = "Minimart Shutters"
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
 "hNo" = (
@@ -14676,15 +14699,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"igw" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
-/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "igz" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -14990,6 +15004,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/building)
+"iqv" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
+/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "iqx" = (
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt,
@@ -15103,6 +15126,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"itn" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "itJ" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
@@ -15131,16 +15158,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/ncr)
-"iuw" = (
-/obj/structure/fluff/paper/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "iuE" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/f13{
@@ -15452,14 +15469,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"iEE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/dog,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "iEX" = (
 /obj/structure/rack,
 /obj/item/storage/fancy/cracker_pack,
@@ -15481,6 +15490,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"iFn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/bubblegum,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "iFu" = (
 /obj/structure/ore_box,
 /obj/machinery/light/small{
@@ -16375,6 +16391,10 @@
 /obj/structure/window/fulltile/house/broken,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
+"iYy" = (
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "iYF" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17346,10 +17366,6 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"jxP" = (
-/obj/structure/car/rubbish3,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "jxY" = (
 /obj/item/stack/sheet/mineral/wood/five,
 /turf/open/floor/f13/wood,
@@ -17697,11 +17713,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"jLL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/oak,
-/area/f13/bar)
 "jMj" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/radiation)
@@ -17771,6 +17782,12 @@
 /obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"jNA" = (
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/plate,
+/turf/open/floor/wood/f13/oak,
+/area/f13/bar)
 "jNJ" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -17785,13 +17802,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"jOn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/yumyum,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "jOq" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -17941,12 +17951,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"jSb" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/old/ruinedcornertr,
-/area/f13/bar)
 "jSj" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18631,13 +18635,6 @@
 	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/wasteland)
-"khC" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "khG" = (
 /obj/item/clothing/head/helmet/f13/motorcycle,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19336,13 +19333,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"kGr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/instamash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "kGy" = (
 /obj/structure/decoration/hatch{
 	dir = 1;
@@ -19565,6 +19555,13 @@
 /obj/machinery/mineral/wasteland_vendor/clothing,
 /turf/open/floor/plating/f13/inside,
 /area/f13/building)
+"kNp" = (
+/obj/structure/wreck/trash/five_tires,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 10;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "kNE" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
@@ -19692,10 +19689,6 @@
 /obj/item/clothing/head/helmet/f13/raidermetal,
 /obj/item/clothing/suit/armor/f13/raider/raidermetal,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"kTE" = (
-/mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "kTP" = (
@@ -19896,6 +19889,12 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"kYr" = (
+/mob/living/simple_animal/hostile/eyebot,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/wasteland)
 "kYz" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -20531,6 +20530,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"lrC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/borscht,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "lrG" = (
 /obj/structure/chair{
 	dir = 8
@@ -20731,6 +20738,16 @@
 	icon_state = "verticalrightborderright2bottom"
 	},
 /area/f13/wasteland)
+"lxl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	termtag = "Business"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "lxJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
@@ -20891,12 +20908,6 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
 	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"lCN" = (
-/mob/living/simple_animal/hostile/eyebot,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
 "lDv" = (
@@ -21405,14 +21416,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"lTh" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/trash/f13/steak,
-/obj/item/trash/f13/steak,
-/obj/item/trash/f13/rotten,
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "lTk" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -21475,6 +21478,17 @@
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/under/f13/caravaneer,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"lUc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "minimart";
+	name = "Minimart Button"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/building)
 "lUe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21735,6 +21749,15 @@
 "mcN" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/wasteland)
+"mcT" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/instamash,
+/obj/item/reagent_containers/food/snacks/f13/instamash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "mdv" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood{
@@ -22756,16 +22779,6 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"mLI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/sugarbombs,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "mLN" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -23186,14 +23199,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"mZN" = (
-/obj/structure/fluff/paper,
-/obj/item/storage/trash_stack,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "mZX" = (
 /obj/structure/toilet{
 	dir = 1
@@ -23619,6 +23624,15 @@
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
+"nnl" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
 "nnn" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/shower{
@@ -24002,13 +24016,14 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/tunnel)
-"nAP" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/trash/f13/crisps,
-/obj/item/trash/f13/crisps,
-/obj/item/trash/f13/crisps,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+"nAO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/dog,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "nBn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -24399,14 +24414,6 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nOf" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/yumyum,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "nOl" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -24750,6 +24757,15 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
+"nYP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "nYW" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -24798,13 +24814,6 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
-"oae" = (
-/obj/structure/fluff/paper/corner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "oav" = (
 /obj/structure/closet/fridge/standard,
 /obj/effect/decal/cleanable/dirt,
@@ -24888,10 +24897,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"odz" = (
-/obj/effect/mine/explosive,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "odA" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/road,
@@ -25689,6 +25694,16 @@
 	icon_state = "horizontalbottombordertopright"
 	},
 /area/f13/wasteland)
+"oBw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/f13/raiderharness,
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "oCg" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -26078,13 +26093,6 @@
 /obj/item/ammo_box/a308,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"oOv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "oON" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
@@ -26212,11 +26220,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"oSo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
 "oSp" = (
 /obj/structure/chair{
 	dir = 4
@@ -26496,13 +26499,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"pbi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
 "pbn" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -26674,14 +26670,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"pfh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/fancy/cigarettes/cigpack_bigboss,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "pfk" = (
 /obj/structure/flora/wasteplant/wild_punga,
 /turf/open/indestructible/ground/outside/water,
@@ -26913,6 +26901,14 @@
 "plt" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"plO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/building)
 "plS" = (
 /obj/structure/fence/handrail{
@@ -27201,6 +27197,16 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"ptD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/crisps,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "ptP" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/desert,
@@ -27294,6 +27300,14 @@
 /obj/structure/chair/wood,
 /turf/open/floor/wood/f13/oak,
 /area/f13/bar)
+"pxE" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/bubblegum/large,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "pxN" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
@@ -27719,14 +27733,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"pJI" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/crisps,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "pJQ" = (
 /obj/structure/simple_door/wood,
 /obj/structure/decoration/rag,
@@ -27776,14 +27782,6 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt"
-	},
-/area/f13/building)
-"pKN" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "pKP" = (
@@ -28143,6 +28141,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"pSu" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/yumyum,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "pSC" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/dirt,
@@ -28289,6 +28295,13 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
+"pWX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/instamash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "pXn" = (
 /obj/structure/chair{
 	dir = 4
@@ -28748,6 +28761,14 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"qjB" = (
+/obj/structure/fluff/paper,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "qkf" = (
 /obj/structure/chair{
 	dir = 8
@@ -29069,6 +29090,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
+"qvp" = (
+/mob/living/simple_animal/hostile/cazador,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 7;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "qvN" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -29182,6 +29210,12 @@
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/water,
 /area/f13/caves)
+"qyO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "qyR" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain0"
@@ -29752,14 +29786,6 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"qNV" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/bubblegum/large,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "qOd" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13{
@@ -30022,6 +30048,13 @@
 /obj/item/chair/stool,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"qSL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/dog,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "qSM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/bars,
@@ -30068,6 +30101,11 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"qTN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood/f13/oak,
+/area/f13/bar)
 "qTP" = (
 /obj/effect/landmark/start/f13/Hhunter,
 /turf/open/indestructible/ground/inside/mountain,
@@ -30653,6 +30691,13 @@
 	icon_state = "plating"
 	},
 /area/f13/bar)
+"rnU" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "rof" = (
 /obj/structure/window/fulltile/ruins,
 /turf/open/floor/f13/wood,
@@ -30717,13 +30762,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2right"
-	},
-/area/f13/wasteland)
-"rqd" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "rqW" = (
@@ -30857,6 +30895,13 @@
 /obj/item/pickaxe,
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"rwf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/building)
 "rwr" = (
 /turf/open/indestructible/ground/outside/road{
@@ -31706,15 +31751,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"rYe" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavementcorner"
-	},
-/area/f13/wasteland)
 "rYl" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -32007,6 +32043,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"sgm" = (
+/obj/structure/fluff/paper/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "sgn" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -32199,15 +32242,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"slq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/building)
 "slr" = (
 /obj/structure/chair/wood/modern,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -32275,13 +32309,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"smz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/dog,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "smU" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
@@ -32453,6 +32480,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"sqZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "srj" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_west_south"
@@ -32488,6 +32522,13 @@
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"srM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/yumyum,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "ssm" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -32758,6 +32799,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"sBa" = (
+/obj/effect/mine/explosive,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "sBf" = (
 /obj/machinery/smartfridge/chemistry,
 /obj/machinery/light{
@@ -32770,15 +32815,6 @@
 "sBk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2"
-	},
-/area/f13/wasteland)
-"sBw" = (
-/obj/structure/fence/corner{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "sBH" = (
@@ -33252,14 +33288,6 @@
 	icon_state = "horizontalbottombordertop3"
 	},
 /area/f13/wasteland)
-"sRO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/light/small/broken,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "sRV" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/light,
@@ -33282,13 +33310,6 @@
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"sSG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/bubblegum,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "sSJ" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/plasteel/barber{
@@ -34143,6 +34164,13 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/tunnel)
+"tpx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/porknbeans,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "tpA" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -34272,12 +34300,6 @@
 "tsT" = (
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
-"ttb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/paper_bin,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
 "tte" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -34318,14 +34340,6 @@
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"tuK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/clothing/head/soft/f13/baseball,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "tvl" = (
 /obj/effect/landmark/latejoin,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -34362,23 +34376,9 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
-"tvP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "twe" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"twi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/borscht,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
 /area/f13/building)
 "twq" = (
 /obj/effect/decal/remains{
@@ -34971,12 +34971,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"tOf" = (
-/obj/structure/window/fulltile/store,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/building)
 "tOg" = (
 /obj/structure/decoration/clock/old/active,
 /turf/closed/wall/f13/wood/house,
@@ -36147,14 +36141,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"utX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "uuc" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -36271,17 +36257,6 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
-	},
-/area/f13/building)
-"uyl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "minimart";
-	name = "Minimart Button"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
 	},
 /area/f13/building)
 "uyn" = (
@@ -36490,14 +36465,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"uDF" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/yellow,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "uDG" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticaldegraded"
@@ -36611,6 +36578,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"uFS" = (
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "uFT" = (
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/wood/f13/oak,
@@ -36693,6 +36667,15 @@
 "uHT" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"uIa" = (
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
 /area/f13/wasteland)
 "uIh" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -37558,13 +37541,6 @@
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"vfI" = (
-/obj/structure/wreck/trash/five_tires,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 10;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
 "vfU" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/floor/f13/wood,
@@ -38496,6 +38472,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"vIh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/crafting/lunchbox,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "vIl" = (
 /obj/item/radio/intercom{
 	frequency = 1891;
@@ -38821,14 +38805,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"vTQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/crafting/lunchbox,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "vUa" = (
 /obj/machinery/mineral/wasteland_vendor/attachments{
 	icon_state = "weapon_idle"
@@ -38991,6 +38967,13 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"vYg" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "vYi" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -39764,6 +39747,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"wza" = (
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "wzh" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/f13/wood{
@@ -40049,16 +40042,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
-	},
-/area/f13/building)
-"wGD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	termtag = "Business"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
 	},
 /area/f13/building)
 "wGI" = (
@@ -40830,6 +40813,13 @@
 /obj/structure/debris/v4,
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
+"xao" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "xay" = (
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -41464,14 +41454,6 @@
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"xqt" = (
-/obj/structure/window/fulltile/store,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/building)
 "xqw" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2bottom"
@@ -41768,6 +41750,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"xxk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/clothing/head/soft/f13/baseball,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "xxL" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -41798,12 +41788,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xyW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/pen,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
 "xyX" = (
 /obj/structure/fence{
 	dir = 8
@@ -41839,15 +41823,14 @@
 	icon_state = "innershade"
 	},
 /area/f13/wasteland)
-"xAG" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "minimart";
-	name = "Minimart Shutters"
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/building)
+"xAm" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/f13/steak,
+/obj/item/trash/f13/steak,
+/obj/item/trash/f13/rotten,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "xAX" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
@@ -41967,6 +41950,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"xFO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/pen,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "xFQ" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -42028,6 +42017,14 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"xGM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "xGR" = (
 /obj/effect/decal/cleanable/robot_debris,
 /obj/effect/decal/cleanable/oil{
@@ -42318,13 +42315,6 @@
 /obj/structure/weightlifter,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"xOu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/porknbeans,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "xOD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/trash,
@@ -42675,6 +42665,12 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
+"yam" = (
+/obj/structure/window/fulltile/store,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/building)
 "yau" = (
 /obj/structure/rack,
 /obj/item/seeds/cabbage,
@@ -42711,6 +42707,14 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"yaZ" = (
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "ybg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/terminal{
@@ -42809,12 +42813,6 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ydy" = (
-/obj/effect/decal/marking,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2right"
-	},
-/area/f13/wasteland)
 "ydQ" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowdestroyed"
@@ -42972,6 +42970,13 @@
 /obj/structure/campfire,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"yhE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/borscht,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "yig" = (
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /obj/structure/table_frame,
@@ -43073,11 +43078,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"ylk" = (
-/obj/effect/decal/cleanable/glass,
-/obj/item/trash/f13/tin,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/bar)
 "ylC" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/spray/pestspray,
@@ -57645,7 +57645,7 @@ gcK
 kBU
 suS
 suS
-pbi
+bni
 suS
 kBU
 xuy
@@ -57902,7 +57902,7 @@ gcK
 kBU
 suS
 pes
-xyW
+xFO
 suS
 kBU
 cqe
@@ -57913,7 +57913,7 @@ bmO
 xbv
 gWn
 yhw
-ylk
+bTB
 fyf
 fyf
 dRo
@@ -58159,7 +58159,7 @@ gcK
 kBU
 lGH
 lDy
-oSo
+fIJ
 suS
 igs
 xuy
@@ -58416,7 +58416,7 @@ gcK
 kBU
 suS
 pRo
-ttb
+dZS
 suS
 kBU
 elF
@@ -58424,7 +58424,7 @@ xuy
 hUK
 qiO
 rCO
-hCu
+hbg
 yhw
 aRp
 kBU
@@ -58679,11 +58679,11 @@ kBU
 lnc
 xuy
 xuy
-jSb
+eNU
 dre
 yhw
 yhw
-hCu
+hbg
 vrz
 kGc
 nPg
@@ -58936,7 +58936,7 @@ tAg
 xuy
 anl
 uBx
-jLL
+qTN
 hLc
 lhc
 dre
@@ -59458,7 +59458,7 @@ lhc
 tkd
 kGc
 unI
-ydy
+bbP
 qci
 sQX
 sQX
@@ -60223,8 +60223,8 @@ xuy
 iqx
 hUK
 xuy
-jLL
-gfl
+qTN
+jNA
 nsg
 whO
 kGc
@@ -62781,7 +62781,7 @@ fyf
 fyf
 fyf
 fyf
-fgj
+qvp
 ajD
 qnS
 kaM
@@ -63810,17 +63810,17 @@ fyf
 kGc
 dMW
 gts
-uyl
-nOf
-sSG
-slq
-khC
+lUc
+pSu
+iFn
+dkb
+vYg
 jmr
-kGr
-khC
+pWX
+vYg
 jmr
 jmr
-tOf
+yam
 kGc
 dMW
 fyf
@@ -64066,18 +64066,18 @@ fyf
 fyf
 kGc
 dMW
-xAG
-dlm
-bcH
-jOn
+hMZ
+fdI
+mcT
+srM
 gts
-tuK
-vTQ
+xxk
+vIh
 jmr
 gFi
 jmr
-pfh
-xqt
+ehW
+hfQ
 kGc
 dMW
 fyf
@@ -64323,18 +64323,18 @@ fyf
 fyf
 kGc
 dMW
-xAG
-gfX
-gfX
-baO
+hMZ
+qyO
+qyO
+rwf
 gts
-mLI
-khC
+eNS
+vYg
 jmr
-wGD
+lxl
 jmr
-aaC
-tOf
+bKh
+yam
 kGc
 obr
 fyf
@@ -64580,20 +64580,20 @@ fyf
 fyf
 kGc
 dMW
-xAG
-igw
-smz
-pJI
+hMZ
+iqv
+qSL
+bzH
 gts
 lLz
 lLz
-twi
+yhE
 gFi
-aTX
-sRO
+cdL
+xGM
 gts
 kGc
-fUB
+uFS
 fyf
 fyf
 sYX
@@ -64838,17 +64838,17 @@ fyf
 kGc
 dMW
 gts
-uDF
-eMZ
-qNV
+bRd
+oBw
+pxE
 gts
-hNi
+nYP
 jmr
-khC
+vYg
 jmr
-kGr
+pWX
 jmr
-gFt
+gqS
 kGc
 dMW
 fyf
@@ -65100,11 +65100,11 @@ gts
 gts
 gts
 jfF
-utX
+plO
 jmr
-iEE
-iEE
-oOv
+nAO
+nAO
+xao
 gts
 kGc
 dMW
@@ -65352,15 +65352,15 @@ fyf
 kGc
 jkJ
 igz
-rYe
-lTh
+aby
+xAm
 fyf
 gts
-gJe
-khC
+ptD
+vYg
 jmr
 jmr
-khC
+vYg
 jmr
 fRZ
 kGc
@@ -65613,13 +65613,13 @@ dMW
 fyf
 fyf
 gts
-gFV
+lrC
 jfF
 jmr
 jfF
 ohA
 jmr
-tOf
+yam
 kGc
 dMW
 fyf
@@ -65866,16 +65866,16 @@ fyf
 fyf
 sND
 nJW
-hzl
-nAP
+nnl
+aqH
 fyf
 gts
-khC
-xOu
+vYg
+tpx
 jmr
 jmr
 jmr
-tvP
+sqZ
 fRZ
 kGc
 dMW
@@ -66123,9 +66123,9 @@ qOV
 cWG
 cWG
 cWG
-sBw
+uIa
 vpx
-rqd
+rnU
 gts
 gts
 gts
@@ -66385,7 +66385,7 @@ mvv
 tmA
 wDc
 fyf
-kTE
+iYy
 fyf
 fyf
 fyf
@@ -79150,7 +79150,7 @@ ujC
 ujC
 ujC
 nuv
-odz
+sBa
 cpK
 ofX
 hbW
@@ -79408,7 +79408,7 @@ ujC
 ujC
 nuv
 glZ
-jxP
+itn
 unI
 qnS
 erY
@@ -79665,7 +79665,7 @@ qDe
 xxg
 gts
 ptf
-vfI
+kNp
 unI
 dXy
 dFQ
@@ -80177,7 +80177,7 @@ miS
 ujC
 qZN
 ujC
-ber
+qjB
 gts
 kGc
 pBv
@@ -80434,7 +80434,7 @@ wyM
 ujC
 sRX
 yeF
-ber
+qjB
 gts
 kGc
 ajD
@@ -80690,8 +80690,8 @@ gts
 wyM
 nqZ
 vLy
-pKN
-iuw
+yaZ
+wza
 fRZ
 kGc
 jIB
@@ -80948,7 +80948,7 @@ uVE
 wyM
 eMU
 eMU
-oae
+sgm
 fRZ
 kGc
 ofX
@@ -81462,7 +81462,7 @@ uVE
 otQ
 uVE
 wyM
-mZN
+dNo
 gts
 jRX
 fsl
@@ -81976,10 +81976,10 @@ uVE
 uVE
 wyM
 ujC
-iuw
+wza
 eqm
 kGc
-lCN
+kYr
 tbG
 erY
 erY

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -76,9 +76,10 @@
 	},
 /area/f13/building)
 "acT" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleslab"
+/obj/machinery/workbench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "ada" = (
@@ -113,10 +114,6 @@
 /obj/item/stack/f13Cash/random/aureus/med,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"adV" = (
-/obj/item/trash/f13/tin,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/bar)
 "aeb" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/dirt{
@@ -152,11 +149,15 @@
 /turf/open/floor/wood/f13/old/ruinedstraightnorth,
 /area/f13/bar)
 "afs" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleplate"
+/obj/structure/fluff/paper/corner,
+/obj/structure/fluff/paper/corner{
+	dir = 8
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "afB" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -694,6 +695,14 @@
 /obj/item/trash/sosjerky,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"arZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/dog,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "ase" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/f13/wood,
@@ -963,13 +972,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/farm)
-"aAh" = (
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 6;
-	icon_state = "rubble"
-	},
-/area/f13/wasteland)
 "aAr" = (
 /obj/machinery/door/unpowered/wooddoor,
 /turf/open/floor/f13/wood{
@@ -2307,9 +2309,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "boq" = (
-/obj/structure/foamedmetal,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/wasteland)
+/obj/structure/fluff/paper,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "bor" = (
 /obj/effect/decal/remains/human,
 /mob/living/simple_animal/hostile/radscorpion,
@@ -2325,8 +2330,14 @@
 	},
 /area/f13/wasteland)
 "boz" = (
-/obj/structure/debris/v4,
-/turf/open/indestructible/ground/outside/ruins,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "boD" = (
 /obj/item/shard,
@@ -2354,9 +2365,13 @@
 	},
 /area/f13/wasteland)
 "bpn" = (
-/obj/machinery/autolathe/constructionlathe,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/structure/table,
+/obj/item/grenade/frag,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "bpA" = (
 /obj/structure/table/wood/settler,
 /obj/item/clothing/head/helmet/f13/raidercombathelmet,
@@ -2489,16 +2504,16 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"btr" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "btN" = (
 /turf/closed/wall/f13/wood,
 /area/f13/ncr)
-"btR" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/building)
 "btW" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2"
@@ -2535,10 +2550,6 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
-"buZ" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
 "bvd" = (
 /obj/structure/table/wood,
@@ -2701,6 +2712,15 @@
 /obj/item/flag/oasis,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland)
+"bzk" = (
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "bzm" = (
@@ -3040,11 +3060,6 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
-"bIY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
 "bJi" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -3125,6 +3140,16 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"bMF" = (
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "bMJ" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/f13/wood,
@@ -3350,6 +3375,14 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"bSS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/trash/f13/rotten,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "bST" = (
 /obj/item/ammo_casing/caseless{
 	dir = 4;
@@ -3547,6 +3580,14 @@
 	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/wasteland)
+"caQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/storage/fancy/cigarettes/cigpack_greytort,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "cbc" = (
 /obj/structure/chair/stool/retro/backed{
 	dir = 8
@@ -3567,6 +3608,16 @@
 "cbr" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"cbK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/f13/raiderharness,
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "cbX" = (
 /obj/structure/car/rubbish3,
 /obj/structure/car/rubbish1,
@@ -3585,12 +3636,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "ccF" = (
-/mob/living/simple_animal/hostile/cazador,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 7;
-	icon_state = "outerpavement"
+/obj/structure/table,
+/obj/item/ammo_box/shotgun/rubber,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "cdc" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
@@ -3614,9 +3666,15 @@
 	},
 /area/f13/farm)
 "ceP" = (
-/obj/structure/wreck/trash/five_tires,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/structure/closet,
+/obj/item/storage/backpack/satchel/leather,
+/obj/item/gun/ballistic/automatic/smg10mm/worn,
+/obj/item/clothing/mask/rat/raven,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "ceT" = (
 /obj/structure/lattice/catwalk,
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse,
@@ -3634,22 +3692,20 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "cfz" = (
-/obj/effect/decal/waste{
-	icon_state = "goo12"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/wasteland)
+/obj/structure/closet/crate,
+/mob/living/simple_animal/hostile/handy,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "cfD" = (
 /obj/structure/flora/junglebush/b,
 /turf/open/water,
 /area/f13/caves)
-"chr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/yumyum,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "cht" = (
 /obj/structure/fence{
 	dir = 1
@@ -3858,14 +3914,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "clQ" = (
-/obj/effect/decal/waste{
-	pixel_x = -4;
-	pixel_y = -7
+/obj/structure/rack,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubblecorner"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "cmx" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4060,6 +4116,15 @@
 "csk" = (
 /turf/open/water,
 /area/f13/caves)
+"csy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/building)
 "csO" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
@@ -4084,16 +4149,15 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/building)
-"ctN" = (
-/obj/structure/window/fulltile/house/broken,
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 4;
-	icon_state = "rubble"
-	},
-/area/f13/building)
 "ctT" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/indestructible/ground/outside/ruins,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "ctY" = (
 /obj/structure/fence{
@@ -4112,15 +4176,6 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"cub" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 9;
-	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "cuv" = (
@@ -4175,11 +4230,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"cvE" = (
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/wasteland)
 "cvH" = (
 /obj/structure/table/wood/settler,
 /obj/item/pickaxe,
@@ -4271,14 +4321,6 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"cBd" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/trash/f13/steak,
-/obj/item/trash/f13/steak,
-/obj/item/trash/f13/rotten,
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "cBq" = (
 /obj/structure/rack,
 /obj/item/storage/backpack,
@@ -4318,6 +4360,14 @@
 /obj/item/shovel,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"cCt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/borscht,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "cCH" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/bandana/skull,
@@ -4347,14 +4397,6 @@
 	light_color = "#d8b1b1"
 	},
 /turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"cDE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/crafting/lunchbox,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
 /area/f13/building)
 "cEc" = (
 /obj/structure/campfire,
@@ -4478,8 +4520,12 @@
 	},
 /area/f13/building)
 "cGV" = (
-/obj/structure/barricade/wooden,
-/turf/closed/mineral/random/low_chance,
+/obj/structure/table,
+/obj/item/trash/f13/electronic/toaster,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "cHk" = (
 /obj/item/stack/sheet/mineral/wood,
@@ -4586,14 +4632,13 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "cKs" = (
-/obj/structure/toilet{
-	dir = 8;
-	icon_state = "toilet00"
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/mob/living/simple_animal/hostile/ghoul,
+/obj/structure/closet/crate/bin,
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "darkdirty"
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "cKN" = (
@@ -4671,12 +4716,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/f13/building)
-"cNE" = (
-/obj/structure/wreck/trash/two_barrels,
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33"
-	},
-/area/f13/wasteland)
 "cNF" = (
 /obj/structure/barricade/bars,
 /obj/structure/table/reinforced,
@@ -5047,6 +5086,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
+"cYk" = (
+/mob/living/simple_animal/hostile/cazador,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 7;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "cYn" = (
 /obj/item/mop,
 /turf/open/floor/f13{
@@ -5658,11 +5704,13 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
 "dps" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubblepillar"
+/obj/structure/table,
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "dpv" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -5738,10 +5786,6 @@
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"dsh" = (
-/obj/structure/wreck/trash/four_barrels,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/wasteland)
 "dsn" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -5839,11 +5883,15 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "duK" = (
-/obj/effect/decal/waste{
-	icon_state = "goo12"
+/obj/structure/closet,
+/obj/item/storage/backpack/satchel/leather,
+/obj/item/crafting/reloader,
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/building)
 "duZ" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -5968,6 +6016,14 @@
 /obj/structure/closet,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"dyD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "dyQ" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -6035,12 +6091,6 @@
 "dAB" = (
 /obj/structure/car/rubbish3,
 /turf/closed/wall/r_wall/rust,
-/area/f13/building)
-"dAC" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
 /area/f13/building)
 "dAW" = (
 /obj/machinery/button/door{
@@ -6196,12 +6246,13 @@
 	},
 /area/f13/building)
 "dEB" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "minimart";
-	name = "Minimart Shutters"
-	},
+/obj/structure/closet,
+/obj/item/storage/backpack/satchel/leather,
+/obj/item/gun/ballistic/shotgun/hunting,
+/obj/item/clothing/mask/rat/bear,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "dER" = (
@@ -6211,7 +6262,7 @@
 "dEW" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
-/obj/item/clothing/under/draculass,
+/obj/item/clothing/under/f13/raiderharness,
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
@@ -6417,6 +6468,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"dMJ" = (
+/obj/structure/fluff/paper,
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "dMW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -6540,10 +6599,6 @@
 /obj/structure/chair/wood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
-"dRx" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/building)
 "dRF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/fo13colored/Red{
@@ -6561,14 +6616,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"dRQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/borscht,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "dRT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/slot_machine,
@@ -6736,6 +6783,12 @@
 /obj/structure/stone_tile/slab,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"dXT" = (
+/obj/structure/window/fulltile/store,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/building)
 "dYY" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt{
@@ -6864,20 +6917,22 @@
 	},
 /area/f13/tunnel)
 "ebV" = (
-/obj/effect/decal/waste{
-	pixel_x = -4;
-	pixel_y = -7
+/obj/structure/table,
+/obj/structure/fluff/paper/stack,
+/obj/item/stamp,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
 "ecg" = (
-/obj/structure/debris/v3,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 7;
-	icon_state = "outerpavement"
+/obj/structure/table,
+/obj/item/storage/box/lights/bulbs,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "ecm" = (
 /obj/structure/table/snooker{
 	dir = 1
@@ -6938,13 +6993,13 @@
 	},
 /area/f13/wasteland)
 "eeN" = (
-/obj/structure/barricade/wooden,
-/obj/structure/debris/v4,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 7;
-	icon_state = "outerpavement"
+/obj/structure/table,
+/obj/item/stamp/denied,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "eeO" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/brews,
 /turf/open/floor/wood/f13,
@@ -7063,12 +7118,14 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "eig" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 7;
-	icon_state = "outerpavement"
+/obj/effect/decal/remains/human,
+/obj/item/clothing/head/mailman,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "eiB" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/item/reagent_containers/food/drinks/beer/light{
@@ -7368,12 +7425,14 @@
 	},
 /area/f13/wasteland)
 "eqm" = (
-/obj/structure/wreck/trash/five_tires,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 7;
-	icon_state = "outerpavement"
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "eqs" = (
 /obj/structure/table/wood/poker,
 /obj/item/radio/intercom{
@@ -7592,12 +7651,13 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "ewI" = (
-/obj/structure/car/rubbish3,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 7;
-	icon_state = "outerpavement"
+/obj/structure/table,
+/obj/item/stack/packageWrap,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "ewO" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -7837,14 +7897,13 @@
 	},
 /area/f13/wasteland)
 "eDc" = (
-/obj/effect/decal/waste{
-	pixel_x = -4;
-	pixel_y = -7
+/obj/structure/table,
+/obj/item/clothing/head/christmashat,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "eDg" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -8203,12 +8262,14 @@
 	},
 /area/f13/wasteland)
 "eMU" = (
-/obj/structure/reagent_dispensers/barrel/three,
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 9;
-	icon_state = "rubble"
+/obj/structure/chair/f13chair1{
+	dir = 8
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "eMW" = (
 /obj/effect/decal/fakelattice{
 	density = 0;
@@ -8500,6 +8561,13 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"eUa" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/f13/crisps,
+/obj/item/trash/f13/crisps,
+/obj/item/trash/f13/crisps,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "eUh" = (
 /obj/machinery/button/door{
 	id = "countershutters";
@@ -8888,6 +8956,13 @@
 	},
 /turf/open/floor/plating,
 /area/f13/tunnel)
+"fcw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/porknbeans,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "fcE" = (
 /obj/structure/reagent_dispensers/barrel/three{
 	pixel_x = -14
@@ -9367,11 +9442,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/building)
-"fqE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/oak,
-/area/f13/bar)
 "fqL" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
@@ -9837,6 +9907,10 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"fDs" = (
+/obj/effect/mine/explosive,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "fDA" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/blood/old,
@@ -10083,7 +10157,6 @@
 	desc = "It stings like hell to be hit by.";
 	name = "Slave whip"
 	},
-/obj/item/restraints/handcuffs/fake/kinky,
 /turf/open/floor/f13,
 /area/f13/building)
 "fNx" = (
@@ -10261,8 +10334,11 @@
 	},
 /area/f13/caves)
 "fRZ" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/f13/ruins,
+/obj/structure/window/fulltile/store,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
 /area/f13/building)
 "fSe" = (
 /obj/structure/fermenting_barrel,
@@ -10316,6 +10392,13 @@
 /obj/item/toy/plush/beeplushie,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
+/area/f13/building)
+"fTR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/instamash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/building)
 "fTT" = (
 /obj/structure/fermenting_barrel,
@@ -10628,6 +10711,15 @@
 /obj/structure/railing,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"gcz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "gcK" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
@@ -10640,6 +10732,11 @@
 /obj/item/stack/sheet/cardboard/twenty,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
+"gdf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "gdJ" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
@@ -10779,6 +10876,14 @@
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/water,
 /area/f13/caves)
+"gii" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/crafting/lunchbox,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "gin" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -10787,14 +10892,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gip" = (
+/mob/living/simple_animal/hostile/eyebot,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "minimart";
-	name = "Minimart Button"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "giq" = (
@@ -11223,11 +11325,13 @@
 	},
 /area/f13/building)
 "gqy" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubble"
+/mob/living/simple_animal/hostile/eyebot,
+/obj/structure/fluff/paper,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "gqz" = (
 /obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/road{
@@ -11433,12 +11537,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
 /area/f13/building)
 "guw" = (
+/obj/structure/fluff/paper,
+/obj/structure/table,
+/obj/item/trash/f13/rotten,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "guA" = (
@@ -11475,6 +11579,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"gvb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/clothing/head/soft/f13/baseball,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "gvc" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/muzzle,
@@ -11523,10 +11635,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"gwr" = (
-/mob/living/simple_animal/hostile/raider/ranged,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "gwJ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -11792,13 +11900,6 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
-"gFh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "gFi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -11808,6 +11909,13 @@
 /area/f13/building)
 "gFR" = (
 /turf/open/indestructible/ground/inside/subway,
+/area/f13/wasteland)
+"gGc" = (
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavement"
+	},
 /area/f13/wasteland)
 "gGp" = (
 /obj/item/storage/trash_stack,
@@ -12090,6 +12198,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
+"gPQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "gPV" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood{
@@ -12189,6 +12304,13 @@
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"gSI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/bubblegum,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "gSS" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt{
@@ -12594,10 +12716,6 @@
 "heB" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
-"heK" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
 "heS" = (
 /obj/effect/decal/cleanable/dirt{
@@ -13301,15 +13419,6 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
-"hvn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "hvp" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -14397,16 +14506,6 @@
 	},
 /turf/open/floor/wood,
 /area/f13/building)
-"ian" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/crisps,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "iap" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -14637,6 +14736,13 @@
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
+"ihU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "iic" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink/kitchen{
@@ -14857,6 +14963,14 @@
 	},
 /turf/open/water,
 /area/f13/caves)
+"inQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "inW" = (
 /obj/structure/flora/tree/joshua,
 /turf/open/indestructible/ground/outside/desert{
@@ -14871,6 +14985,14 @@
 /obj/structure/stacklifter,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"ion" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/yumyum,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "ioH" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -15077,13 +15199,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/ncr)
-"iuO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/porknbeans,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "iuS" = (
 /obj/structure/chair/wood/modern{
 	dir = 4;
@@ -15259,9 +15374,15 @@
 	},
 /area/f13/building)
 "iAz" = (
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "iAB" = (
@@ -15291,8 +15412,12 @@
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
 "iBu" = (
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleplate"
+/mob/living/simple_animal/hostile/eyebot,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "iBv" = (
@@ -15630,9 +15755,13 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
 "iKm" = (
-/obj/machinery/workbench,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/structure/fluff/paper/corner,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "iKD" = (
 /turf/closed/wall/f13/tentwall,
 /area/f13/legion)
@@ -15799,6 +15928,12 @@
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"iNZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/paper_bin,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "iOg" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
@@ -15889,13 +16024,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
-"iPX" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
 "iQs" = (
 /obj/structure/table/wood,
 /obj/structure/reagent_dispensers/beerkeg,
@@ -16205,6 +16333,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"iVV" = (
+/obj/structure/wreck/trash/five_tires,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 10;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "iVW" = (
 /obj/machinery/conveyor/auto{
 	dir = 1
@@ -16307,13 +16442,6 @@
 /obj/machinery/vending/cola/space_up,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"iYL" = (
-/obj/structure/window/fulltile/store,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/building)
 "iYO" = (
 /obj/item/reagent_containers/food/snacks/grown/broc,
 /obj/item/reagent_containers/food/snacks/grown/broc,
@@ -16416,6 +16544,13 @@
 /obj/structure/simple_door/wood,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
+"jaW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "jbj" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
@@ -16550,14 +16685,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"jes" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/light/small/broken,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
 /area/f13/building)
 "jeO" = (
 /obj/structure/barricade/wooden/planks,
@@ -16999,6 +17126,16 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"jqf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/crisps,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "jqX" = (
 /obj/structure/fireplace,
 /turf/open/floor/f13{
@@ -17435,16 +17572,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/ncr)
-"jFC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	termtag = "Business"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "jFE" = (
 /obj/structure/table/wood,
 /obj/item/trash/sosjerky{
@@ -17629,6 +17756,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"jLn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/storage/fancy/cigarettes/cigpack_bigboss,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "jLK" = (
 /obj/structure/closet,
 /obj/item/clothing/gloves/combat,
@@ -17916,6 +18051,15 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"jTn" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/instamash,
+/obj/item/reagent_containers/food/snacks/f13/instamash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "jTq" = (
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood,
@@ -18378,6 +18522,12 @@
 	icon_state = "verticaloutermaintop"
 	},
 /area/f13/wasteland)
+"kdZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/pen,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "keb" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	pixel_y = -6
@@ -18608,6 +18758,15 @@
 "kjR" = (
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"kkj" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
 "kkD" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
@@ -19338,6 +19497,13 @@
 /obj/machinery/workbench,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"kJe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/borscht,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "kJn" = (
 /obj/item/bedsheet,
 /obj/item/clothing/under/f13/cowboyg{
@@ -19345,6 +19511,15 @@
 	},
 /obj/structure/bed/old,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"kJo" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
+/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/building)
 "kJu" = (
 /obj/structure/anvil/obtainable/basic,
@@ -19849,12 +20024,12 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
 "kZH" = (
-/obj/structure/closet/cardboard,
+/obj/structure/fluff/paper,
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/bottle/instacoffee,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
-/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "kZQ" = (
@@ -20231,6 +20406,14 @@
 /obj/structure/table/wood/fancy/royalblack,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"llt" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/bubblegum/large,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "lly" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -20244,6 +20427,10 @@
 /obj/effect/landmark/start/f13/mayor,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"llK" = (
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/bar)
 "lmc" = (
 /obj/structure/bonfire,
 /obj/item/stack/rods/ten,
@@ -21078,13 +21265,14 @@
 	},
 /area/f13/building)
 "lLX" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 7;
-	icon_state = "outerpavement"
+/obj/structure/table,
+/obj/structure/fluff/paper/stack,
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "lMr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit,
@@ -21823,6 +22011,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"miu" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "miw" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/machinery/light/small/broken{
@@ -21837,9 +22029,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "miS" = (
-/mob/living/simple_animal/hostile/ghoul/soldier,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/wasteland)
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "miT" = (
 /obj/structure/decoration/hatch,
 /turf/open/indestructible/ground/outside/road{
@@ -21968,14 +22163,6 @@
 "mnG" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 1
-	},
-/area/f13/building)
-"mnP" = (
-/obj/structure/window/fulltile/store,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
 	},
 /area/f13/building)
 "mof" = (
@@ -22136,11 +22323,14 @@
 	},
 /area/f13/building)
 "msy" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/yellow,
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "yumail";
+	name = "YuMail Express Button"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "msG" = (
@@ -22532,13 +22722,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"mIi" = (
-/obj/effect/decal/waste{
-	pixel_x = -4;
-	pixel_y = -7
-	},
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/wasteland)
 "mIy" = (
 /obj/structure/closet/cabinet,
 /obj/item/storage/box/syringes,
@@ -22681,10 +22864,6 @@
 /obj/item/paper/bitterdrink,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"mNi" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/wasteland)
 "mNn" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/knife,
@@ -22789,15 +22968,6 @@
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
-	},
-/area/f13/building)
-"mQT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
 "mQZ" = (
@@ -23256,11 +23426,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nft" = (
-/obj/structure/window/fulltile/house/broken,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 4;
-	icon_state = "rubble"
+/obj/structure/closet,
+/obj/item/storage/backpack/satchel/leather,
+/obj/item/gun/ballistic/rifle/hunting,
+/obj/item/clothing/mask/rat/fox,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "nfH" = (
@@ -23593,8 +23765,13 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "nqw" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/ruins,
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/pda,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "nqG" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -23603,8 +23780,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nqZ" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/closed/wall/f13/ruins,
+/mob/living/simple_animal/hostile/eyebot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "nrw" = (
 /obj/structure/displaycase,
@@ -23692,8 +23872,13 @@
 	},
 /area/f13/ncr)
 "nuv" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/outside/ruins,
+/obj/machinery/door/poddoor/shutters{
+	id = "yumail";
+	name = "YuMail Express Shutters"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
 /area/f13/building)
 "nvq" = (
 /obj/structure/displaycase,
@@ -23790,13 +23975,6 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building)
-"nxV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/dog,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
 /area/f13/building)
 "nxY" = (
 /obj/structure/flora/grass/wasteland{
@@ -23973,6 +24151,14 @@
 /obj/structure/stone_tile/slab/burnt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"nDK" = (
+/obj/structure/bed/old,
+/obj/item/bedsheet/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "nDY" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/wood/f13/oak,
@@ -23997,13 +24183,6 @@
 	icon_state = "plating"
 	},
 /area/f13/bar)
-"nEH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/instamash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "nFb" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -24418,14 +24597,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"nRW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/dog,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "nSc" = (
 /obj/structure/rack,
 /obj/item/flashlight/seclite,
@@ -24476,14 +24647,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/legion)
-"nTo" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/crisps,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "nTO" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/dirt,
@@ -24721,13 +24884,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/ncr)
-"oaV" = (
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 6;
-	icon_state = "rubble"
-	},
-/area/f13/wasteland)
 "obd" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/road{
@@ -24755,7 +24911,6 @@
 	icon_state = "bench"
 	},
 /obj/effect/decal/cleanable/vomit,
-/obj/item/storage/firstaid,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -24841,6 +24996,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"ofT" = (
+/mob/living/simple_animal/hostile/eyebot,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/wasteland)
 "ofW" = (
 /obj/structure/simple_door/metal/fence{
 	door_type = "fence_wood";
@@ -24912,6 +25073,12 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"oiU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "ojl" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/f13{
@@ -24937,11 +25104,13 @@
 	},
 /area/f13/building)
 "okg" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubblecorner"
+/obj/structure/table,
+/obj/item/crafting/coffee_pot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "okj" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -25341,14 +25510,13 @@
 	},
 /area/f13/ncr)
 "otQ" = (
-/obj/structure/fence{
-	dir = 8
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavementcorner"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "otV" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood{
@@ -25892,10 +26060,14 @@
 	},
 /area/f13/wasteland)
 "oMb" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/obj/structure/closet/crate/bin,
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleplate"
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/closet/crate,
+/obj/item/storage/firstaid,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "oMn" = (
@@ -26308,12 +26480,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/ncr)
-"oZE" = (
-/obj/structure/window/fulltile/store,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/building)
 "oZK" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -26754,13 +26920,6 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
-"pkx" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/trash/f13/crisps,
-/obj/item/trash/f13/crisps,
-/obj/item/trash/f13/crisps,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "pkL" = (
 /obj/machinery/workbench,
 /turf/open/floor/wood/f13/oak,
@@ -26809,12 +26968,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"pmq" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/plate,
-/turf/open/floor/wood/f13/oak,
-/area/f13/bar)
 "pmt" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -27282,6 +27435,11 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"pAL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood/f13/oak,
+/area/f13/bar)
 "pAU" = (
 /obj/structure/sink,
 /turf/open/floor/f13{
@@ -27821,19 +27979,12 @@
 	},
 /area/f13/caves)
 "pOb" = (
-/obj/structure/fence{
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavementcorner"
-	},
-/area/f13/wasteland)
-"pOe" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "pOg" = (
@@ -27948,12 +28099,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"pQQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/paper_bin,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
 "pQX" = (
 /obj/structure/fence/post{
 	desc = "A wooden post.";
@@ -28103,11 +28248,6 @@
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
-"pUP" = (
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
-/area/f13/building)
 "pUQ" = (
 /obj/structure/fluff/railing{
 	dir = 9
@@ -28690,6 +28830,10 @@
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
+"qlb" = (
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "qlv" = (
 /obj/structure/table/wood,
 /obj/item/weldingtool,
@@ -29225,11 +29369,12 @@
 	},
 /area/f13/legion)
 "qDe" = (
-/obj/item/flashlight/lamp,
-/obj/structure/table/wood,
-/obj/item/clothing/head/festive,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/structure/chair/f13chair1,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "qDm" = (
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/floor/wood/f13/oak,
@@ -29524,12 +29669,6 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
-"qLJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/pen,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
 "qLO" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt{
@@ -30082,12 +30221,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
 "qZN" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 5;
-	icon_state = "rubble"
+/obj/structure/table,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "ram" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -30276,15 +30416,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"rex" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 1;
-	icon_state = "rubblecorner"
-	},
-/area/f13/wasteland)
 "reK" = (
 /obj/structure/fence,
 /obj/structure/table/wood,
@@ -30320,11 +30451,6 @@
 	icon_state = "housebase"
 	},
 /area/f13/legion)
-"rgU" = (
-/obj/effect/decal/cleanable/glass,
-/obj/item/trash/f13/tin,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/bar)
 "rhf" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/f13/diesel/alt,
@@ -30385,13 +30511,6 @@
 	},
 /turf/open/floor/wood/f13/stage_r,
 /area/f13/building)
-"riH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
 "riP" = (
 /obj/effect/landmark/start/f13/hunter,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -30525,14 +30644,6 @@
 /obj/item/trash/candy,
 /obj/item/trash/cheesie,
 /turf/open/floor/carpet,
-/area/f13/building)
-"rnk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/fancy/cigarettes/cigpack_bigboss,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
 /area/f13/building)
 "rns" = (
 /obj/effect/decal/cleanable/oil{
@@ -30924,10 +31035,11 @@
 	},
 /area/f13/wasteland)
 "rAv" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
 "rAA" = (
 /obj/structure/chair/office{
@@ -31164,6 +31276,13 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
+"rIt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/dog,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "rIu" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -31268,14 +31387,6 @@
 	icon_state = "crossborder"
 	},
 /area/f13/wasteland)
-"rNs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/fancy/cigarettes/cigpack_greytort,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "rNv" = (
 /obj/structure/sink{
 	dir = 8;
@@ -31340,6 +31451,15 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"rPo" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
 "rPI" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bottle/blackpowder,
@@ -32367,15 +32487,6 @@
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"srF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/building)
 "ssm" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -32946,13 +33057,6 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
-"sLF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/bubblegum,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "sLV" = (
 /obj/machinery/photocopier,
 /turf/open/floor/f13/wood,
@@ -33044,14 +33148,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/building)
-"sPm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/trash/f13/rotten,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
 /area/f13/building)
 "sPr" = (
 /obj/structure/chair/office/dark,
@@ -33146,6 +33242,13 @@
 	icon_state = "horizontalbottombordertop3"
 	},
 /area/f13/wasteland)
+"sRR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/yumyum,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "sRV" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/light,
@@ -33155,8 +33258,13 @@
 	},
 /area/f13/building)
 "sRX" = (
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
-/turf/open/indestructible/ground/outside/ruins,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "sSr" = (
 /turf/open/floor/wood/f13/old/ruinedstraightnorth,
@@ -33480,6 +33588,11 @@
 	icon_state = "innershade"
 	},
 /area/f13/wasteland)
+"taz" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/bar)
 "taF" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -33723,6 +33836,16 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"tiN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/sugarbombs,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "tjB" = (
 /obj/item/ammo_casing/a50MG,
 /turf/open/indestructible/ground/outside/road{
@@ -33906,14 +34029,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"tmP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/clothing/head/soft/f13/baseball,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "tnd" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/wood/f13/oak,
@@ -34263,13 +34378,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/city)
-"twy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/borscht,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "twI" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
@@ -34329,12 +34437,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/brotherhood)
-"txZ" = (
-/obj/effect/decal/marking,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2right"
-	},
-/area/f13/wasteland)
 "tyd" = (
 /obj/docking_port/stationary{
 	area_type = /area/f13;
@@ -34563,14 +34665,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"tFF" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/bubblegum/large,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "tFL" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -34712,6 +34806,16 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"tKB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	termtag = "Business"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
 	},
 /area/f13/building)
 "tKI" = (
@@ -34920,6 +35024,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
+"tPE" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/f13/steak,
+/obj/item/trash/f13/steak,
+/obj/item/trash/f13/rotten,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "tQl" = (
 /obj/structure/chair/wood/modern{
 	dir = 1
@@ -35420,16 +35532,6 @@
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"udJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/under/f13/raiderharness,
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "udT" = (
 /obj/structure/table/wood,
 /obj/item/stack/medical/suture,
@@ -35642,7 +35744,10 @@
 	},
 /area/f13/building)
 "ujC" = (
-/turf/open/indestructible/ground/outside/ruins,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "ujQ" = (
 /obj/structure/fence/corner/wooden{
@@ -36010,6 +36115,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"utq" = (
+/obj/structure/window/fulltile/store,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/building)
 "utB" = (
 /obj/structure/table/wood/settler,
 /obj/item/storage/box/matches,
@@ -36100,18 +36213,13 @@
 	},
 /area/f13/village)
 "uwA" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 8;
-	icon_state = "rubblecorner"
+/obj/structure/fluff/paper,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
-"uwE" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/old/ruinedcornertr,
-/area/f13/bar)
+/area/f13/building)
 "uwG" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -36405,11 +36513,13 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"uEL" = (
+"uER" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
 "uEX" = (
@@ -36653,21 +36763,30 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uLk" = (
-/obj/effect/decal/waste{
-	pixel_x = -4;
-	pixel_y = -7
+/obj/structure/table,
+/obj/item/storage/backpack/satchel/leather,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 4;
-	icon_state = "rubblecorner"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "uLK" = (
 /obj/machinery/computer/operating,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"uLW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "minimart";
+	name = "Minimart Button"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "uMb" = (
 /obj/structure/chair/comfy,
 /obj/machinery/light/small{
@@ -37071,11 +37190,10 @@
 	},
 /area/f13/wasteland)
 "uVE" = (
-/obj/structure/window/fulltile/house/broken,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 6;
-	icon_state = "rubble"
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "uVG" = (
@@ -37153,6 +37271,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"uXF" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "minimart";
+	name = "Minimart Shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/building)
 "uXN" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical"
@@ -37730,13 +37857,6 @@
 	icon_state = "verticaloutermain2"
 	},
 /area/f13/wasteland)
-"vpo" = (
-/obj/item/trash/f13/tin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
 "vpx" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
@@ -37816,13 +37936,6 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
-	},
-/area/f13/building)
-"vsS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
 	},
 /area/f13/building)
 "vsU" = (
@@ -38206,6 +38319,13 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
+"vEv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "vEw" = (
 /obj/item/chair/stool/retro,
 /turf/open/floor/f13/wood,
@@ -38419,12 +38539,15 @@
 	},
 /area/f13/city)
 "vJL" = (
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
+/obj/structure/fluff/paper,
+/obj/item/storage/trash_stack{
+	icon_state = "trash_2"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "vJP" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/indestructible/ground/outside/desert,
@@ -38470,12 +38593,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vLy" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 6;
-	icon_state = "rubble"
+/obj/structure/closet/crate,
+/obj/item/clothing/head/festive,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "vMc" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood/f13/oak,
@@ -38489,6 +38613,13 @@
 	icon_state = "rubbleplate"
 	},
 /area/f13/wasteland)
+"vMt" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "vMu" = (
 /obj/machinery/light{
 	dir = 4;
@@ -38769,14 +38900,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"vVX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "vWo" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6"
@@ -38791,14 +38914,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vWC" = (
-/obj/structure/fence/corner{
-	dir = 4
+/obj/structure/closet/crate,
+/obj/item/wrench,
+/obj/item/screwdriver,
+/obj/item/crowbar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "vWK" = (
 /obj/structure/table,
 /obj/item/storage/box/gloves,
@@ -38820,6 +38944,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"vXe" = (
+/obj/structure/fluff/paper/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "vXh" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
@@ -39031,6 +39162,14 @@
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
+"wgM" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/crisps,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "whm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/autolathe/constructionlathe,
@@ -39157,12 +39296,12 @@
 	},
 /area/f13/wasteland)
 "wkx" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 5;
-	icon_state = "rubble"
+/obj/structure/simple_door/metal/dirtystore,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "wkO" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/shiny,
@@ -39410,16 +39549,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"wrY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/sugarbombs,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "wso" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -39637,12 +39766,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "wyM" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 8;
-	icon_state = "rubblecorner"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "wzh" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/f13/wood{
@@ -39775,6 +39904,12 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/building)
+"wCW" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/old/ruinedcornertr,
+/area/f13/bar)
 "wDc" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -40411,11 +40546,12 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "wSn" = (
-/obj/structure/closet/cardboard,
+/obj/structure/chair/f13chair1{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/yumyum,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "wSw" = (
@@ -41170,6 +41306,15 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"xmH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "xmS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -41262,6 +41407,12 @@
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
+"xoT" = (
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/plate,
+/turf/open/floor/wood/f13/oak,
+/area/f13/bar)
 "xpg" = (
 /obj/structure/barricade/tentclothedge,
 /turf/open/indestructible/ground/outside/dirt{
@@ -41620,12 +41771,11 @@
 	},
 /area/f13/wasteland)
 "xxg" = (
-/obj/structure/closet/cardboard,
+/obj/structure/table,
+/obj/item/folder/yellow,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/instamash,
-/obj/item/reagent_containers/food/snacks/f13/instamash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "xxL" = (
@@ -41644,6 +41794,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"xyf" = (
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2right"
+	},
+/area/f13/wasteland)
 "xys" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -41700,9 +41856,12 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/bar)
 "xAZ" = (
-/obj/structure/car/rubbish4,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/wasteland)
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "xBx" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -42692,10 +42851,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "yeF" = (
-/obj/structure/window/fulltile/house/broken,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/caves)
+/obj/structure/fluff/paper,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "yeJ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainleft"
@@ -57465,7 +57627,7 @@ gcK
 kBU
 suS
 suS
-riH
+vEv
 suS
 kBU
 xuy
@@ -57722,7 +57884,7 @@ gcK
 kBU
 suS
 pes
-qLJ
+kdZ
 suS
 kBU
 cqe
@@ -57733,7 +57895,7 @@ bmO
 xbv
 gWn
 yhw
-rgU
+taz
 fyf
 fyf
 dRo
@@ -57979,7 +58141,7 @@ gcK
 kBU
 lGH
 lDy
-bIY
+gdf
 suS
 igs
 xuy
@@ -58236,7 +58398,7 @@ gcK
 kBU
 suS
 pRo
-pQQ
+iNZ
 suS
 kBU
 elF
@@ -58244,7 +58406,7 @@ xuy
 hUK
 qiO
 rCO
-adV
+llK
 yhw
 aRp
 kBU
@@ -58499,11 +58661,11 @@ kBU
 lnc
 xuy
 xuy
-uwE
+wCW
 dre
 yhw
 yhw
-adV
+llK
 vrz
 kGc
 nPg
@@ -58756,7 +58918,7 @@ tAg
 xuy
 anl
 uBx
-fqE
+pAL
 hLc
 lhc
 dre
@@ -59278,7 +59440,7 @@ lhc
 tkd
 kGc
 unI
-txZ
+xyf
 qci
 sQX
 sQX
@@ -60043,8 +60205,8 @@ xuy
 iqx
 hUK
 xuy
-fqE
-pmq
+pAL
+xoT
 nsg
 whO
 kGc
@@ -62601,7 +62763,7 @@ fyf
 fyf
 fyf
 fyf
-ccF
+cYk
 ajD
 qnS
 kaM
@@ -63630,17 +63792,17 @@ fyf
 kGc
 dMW
 gts
-gip
-wSn
-sLF
-mQT
-uEL
+uLW
+ion
+gSI
+uER
+vMt
 jmr
-nEH
-uEL
+fTR
+vMt
 jmr
 jmr
-oZE
+dXT
 kGc
 dMW
 fyf
@@ -63886,18 +64048,18 @@ fyf
 fyf
 kGc
 dMW
-dEB
-guw
-xxg
-chr
+uXF
+xmH
+jTn
+sRR
 gts
-tmP
-cDE
+gvb
+gii
 jmr
 gFi
 jmr
-rnk
-mnP
+jLn
+utq
 kGc
 dMW
 fyf
@@ -64143,18 +64305,18 @@ fyf
 fyf
 kGc
 dMW
-dEB
-iAz
-iAz
-vsS
+uXF
+oiU
+oiU
+gPQ
 gts
-wrY
-uEL
+tiN
+vMt
 jmr
-jFC
+tKB
 jmr
-rNs
-oZE
+caQ
+dXT
 kGc
 obr
 fyf
@@ -64400,20 +64562,20 @@ fyf
 fyf
 kGc
 dMW
-dEB
-kZH
-nxV
-nTo
+uXF
+kJo
+rIt
+wgM
 gts
 lLz
 lLz
-twy
+kJe
 gFi
-sPm
-jes
+bSS
+inQ
 gts
 kGc
-vpo
+gGc
 fyf
 fyf
 sYX
@@ -64658,17 +64820,17 @@ fyf
 kGc
 dMW
 gts
-msy
-udJ
-tFF
+nDK
+cbK
+llt
 gts
-hvn
+gcz
 jmr
-uEL
+vMt
 jmr
-nEH
+fTR
 jmr
-srF
+csy
 kGc
 dMW
 fyf
@@ -64920,11 +65082,11 @@ gts
 gts
 gts
 jfF
-vVX
+dyD
 jmr
-nRW
-nRW
-gFh
+arZ
+arZ
+ihU
 gts
 kGc
 dMW
@@ -65172,17 +65334,17 @@ fyf
 kGc
 jkJ
 igz
-otQ
-cBd
+rPo
+tPE
 fyf
 gts
-ian
-uEL
+jqf
+vMt
 jmr
 jmr
-uEL
+vMt
 jmr
-iYL
+fRZ
 kGc
 dMW
 fyf
@@ -65433,13 +65595,13 @@ dMW
 fyf
 fyf
 gts
-dRQ
+cCt
 jfF
 jmr
 jfF
 ohA
 jmr
-oZE
+dXT
 kGc
 dMW
 fyf
@@ -65686,17 +65848,17 @@ fyf
 fyf
 sND
 nJW
-pOb
-pkx
+kkj
+eUa
 fyf
 gts
-uEL
-iuO
+vMt
+fcw
 jmr
 jmr
 jmr
-pOe
-iYL
+jaW
+fRZ
 kGc
 dMW
 fyf
@@ -65943,9 +66105,9 @@ qOV
 cWG
 cWG
 cWG
-vWC
+bzk
 vpx
-iPX
+btr
 gts
 gts
 gts
@@ -66205,7 +66367,7 @@ mvv
 tmA
 wDc
 fyf
-gwr
+qlb
 fyf
 fyf
 fyf
@@ -78189,12 +78351,12 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gts
+gts
+gts
+gts
+gts
+gts
 gcK
 gcK
 gcK
@@ -78446,17 +78608,17 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+gts
+ceP
+eig
 cGV
-giZ
-giZ
-giZ
-bbG
-bbG
-bbG
-bbG
+guw
+gts
+gts
+gts
+gts
+gts
+fyf
 kGc
 hto
 dXy
@@ -78466,7 +78628,7 @@ koD
 bFJ
 bFJ
 pcG
-iKm
+uRJ
 cnX
 uRJ
 pcG
@@ -78700,21 +78862,21 @@ gcK
 gcK
 gcK
 gcK
-giZ
-giZ
-giZ
-giZ
+gcK
+gcK
+gcK
+gts
 nft
-ctN
-giZ
-hAC
-nZS
-gPW
+wyM
+eMU
+iAz
+gts
+msy
 cfz
-giZ
-giZ
-giZ
-kGc
+vLy
+gts
+igz
+hgX
 pBv
 rQh
 lZP
@@ -78723,7 +78885,7 @@ koD
 uaf
 bFJ
 pcG
-bpn
+uRJ
 uRJ
 wXv
 pcG
@@ -78957,21 +79119,21 @@ gcK
 gcK
 gcK
 gcK
-giZ
-nqw
+gcK
+gcK
+gcK
+gts
+ctT
 ujC
-pUP
+gip
+ujC
+gts
 ujC
 ujC
-giZ
-cNE
-cAs
-hkv
-heK
-faW
+ujC
 nuv
-giZ
-ecg
+fDs
+cpK
 ofX
 hbW
 bJB
@@ -78986,7 +79148,7 @@ tIM
 pcG
 lok
 pWe
-qDe
+lqr
 pcG
 pcG
 fyf
@@ -79214,21 +79376,21 @@ gcK
 gcK
 gcK
 gcK
-giZ
+gcK
+gcK
+gcK
+gts
+duK
+wyM
+ujC
+iKm
+wkx
+ujC
+ujC
+ujC
 nuv
-acT
-ctT
-faW
-cub
-giZ
-hAC
-xrd
-cAs
-hkv
-jYB
-mNi
-giZ
-iHk
+glZ
+miu
 unI
 qnS
 erY
@@ -79471,21 +79633,21 @@ gcK
 gcK
 gcK
 gcK
-giZ
-ujC
-boz
-faW
-mji
-bph
+gcK
+gcK
+gcK
+gts
+dEB
+wyM
 okg
-rjD
-cdt
-fyf
-cAs
-hkv
-faW
-fRZ
-iHk
+kZH
+gts
+nqw
+oMb
+vWC
+gts
+ptf
+iVV
 unI
 dXy
 dFQ
@@ -79728,21 +79890,21 @@ gcK
 gcK
 gcK
 gcK
-giZ
-pUP
-faW
-mji
-bph
-fyf
-vLy
-miS
-qZN
-cdt
-duK
-gqy
-faW
-dLY
-iHk
+gcK
+gts
+gts
+gts
+gts
+eqm
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+kGc
 unI
 dXy
 cdc
@@ -79985,21 +80147,21 @@ gcK
 gcK
 gcK
 gcK
-giZ
-faW
-faW
-nHP
+gcK
+gts
+acT
+wyM
 clQ
-gPW
+wyM
 vJL
-mji
-hkv
-aqD
-cdt
-cAs
-hkv
-dRx
-lLX
+gts
+miS
+ujC
+pOb
+ujC
+yeF
+gts
+kGc
 pBv
 dXy
 cdc
@@ -80242,22 +80404,22 @@ gcK
 gcK
 gcK
 gcK
-giZ
-faW
+gcK
+gts
 xAZ
-nHP
-stG
-heK
+ujC
+xAZ
+wyM
 afs
 wkx
-aAh
-dsh
-nHP
-hAC
-cAs
-ebV
-lLX
-eDc
+wyM
+ujC
+qDe
+wSn
+yeF
+gts
+kGc
+ajD
 lSD
 cdc
 snB
@@ -80499,21 +80661,21 @@ gcK
 gcK
 gcK
 gcK
-giZ
-nIp
-mji
-bph
+gcK
+gts
+ujC
+ujC
 wyM
-hkv
-giZ
-giZ
-giZ
+ujC
+boq
+gts
+wyM
 nqZ
-nHP
-hAC
-giZ
+qZN
+xxg
+bMF
 fRZ
-iHk
+kGc
 jIB
 hbW
 apk
@@ -80756,21 +80918,21 @@ gcK
 gcK
 gcK
 gcK
-giZ
-eMU
-rex
-fyf
-hAC
-cAs
-giZ
+gcK
+gts
+ujC
+bpn
+ebV
+ewI
+gqy
 dps
-faW
-mji
-bph
-nZS
-gPW
-giZ
-eeN
+uVE
+wyM
+eMU
+eMU
+vXe
+fRZ
+kGc
 ofX
 hbW
 erY
@@ -81013,20 +81175,20 @@ gcK
 gcK
 gcK
 gcK
-giZ
-nHP
-fyf
-hAC
-xrd
-fyf
+gcK
+gts
+boz
+ujC
+ujC
+wyM
 uwA
-wOw
-hkv
-nHP
-nZS
-gPW
+gts
+ujC
+wyM
+ujC
+wyM
 boq
-giZ
+fRZ
 kGc
 unI
 hbW
@@ -81270,23 +81432,23 @@ gcK
 gcK
 gcK
 gcK
-giZ
-aqD
-rjD
+gcK
+gts
+wyM
 uLk
-nZS
-rjD
-nft
-cdt
-cAs
-bph
-stG
-mIi
-jYB
-giZ
-eig
-unI
-hbW
+ecg
+eDc
+gqy
+lLX
+uVE
+otQ
+uVE
+wyM
+dMJ
+gts
+jRX
+fsl
+tbG
 cdc
 dmL
 tUb
@@ -81527,23 +81689,23 @@ gcK
 gcK
 gcK
 gcK
-giZ
-faW
-buZ
-aqD
-oaV
-faW
-giZ
-aqD
-cdt
-nZS
-gPW
-giZ
-giZ
-giZ
-jRX
+gcK
+gts
+wyM
+ujC
+ujC
+wyM
+boq
+gts
+ujC
+ujC
+wyM
+ujC
+boq
+gts
+kGc
 unI
-hbW
+tbG
 apk
 apk
 ehN
@@ -81784,23 +81946,23 @@ gcK
 gcK
 gcK
 gcK
-giZ
+gcK
+gts
 ujC
-faW
-faW
-faW
-heK
-giZ
-ujC
-feR
+ccF
+eeN
+uLk
+gqy
+dps
 uVE
-faW
-dRx
-pUP
-giZ
+uVE
+wyM
+ujC
+bMF
+eqm
 kGc
-unI
-hbW
+ofT
+tbG
 erY
 erY
 kaM
@@ -82041,23 +82203,23 @@ gcK
 gcK
 gcK
 gcK
-giZ
-ujC
+gcK
+gts
 rAv
 ujC
+wyM
 ujC
-cvE
-giZ
+boq
+gts
+wyM
 ujC
-btR
-giZ
-pUP
-giZ
-dAC
-giZ
-eqm
+ujC
+ujC
+wyM
+gts
+kGc
 pBv
-box
+fdA
 erY
 gmX
 geM
@@ -82298,23 +82460,23 @@ gcK
 gcK
 gcK
 gcK
-giZ
-oMb
-ujC
-nuv
-ujC
-cvE
-giZ
-sRX
+gcK
+gts
+gts
+gts
+gts
+gts
+gts
+gts
 iBu
-giZ
-pUP
-giZ
+ujC
+sRX
+ujC
 cKs
-giZ
-ewI
-ajD
-lSD
+gts
+jRX
+jSj
+vOx
 erY
 gmX
 koD
@@ -82555,20 +82717,20 @@ gcK
 gcK
 gcK
 gcK
-giZ
-giZ
-giZ
-giZ
-giZ
-giZ
-giZ
-yeF
-yeF
-pLw
-pLw
-pLw
-pLw
-pLw
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gts
+gts
+gts
+gts
+gts
+gts
+gts
 kGc
 jIB
 hbW
@@ -82814,7 +82976,7 @@ gcK
 gcK
 gcK
 gcK
-ceP
+gcK
 gcK
 gcK
 gcK

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -695,14 +695,6 @@
 /obj/item/trash/sosjerky,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"arZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/dog,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "ase" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/f13/wood,
@@ -2358,6 +2350,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"boW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood/f13/oak,
+/area/f13/bar)
 "bph" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
@@ -2504,13 +2501,6 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"btr" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
 "btN" = (
 /turf/closed/wall/f13/wood,
 /area/f13/ncr)
@@ -2712,15 +2702,6 @@
 /obj/item/flag/oasis,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/wasteland)
-"bzk" = (
-/obj/structure/fence/corner{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "bzm" = (
@@ -3114,6 +3095,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"bLK" = (
+/obj/effect/mine/explosive,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "bLL" = (
 /obj/structure/table/snooker{
 	dir = 9
@@ -3140,14 +3125,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"bMF" = (
-/obj/structure/fluff/paper/corner{
-	dir = 8
-	},
+"bMG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/rack,
+/obj/item/storage/fancy/cigarettes/cigpack_greytort,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
 	},
 /area/f13/building)
 "bMJ" = (
@@ -3375,14 +3358,6 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"bSS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/trash/f13/rotten,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "bST" = (
 /obj/item/ammo_casing/caseless{
 	dir = 4;
@@ -3580,14 +3555,6 @@
 	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/wasteland)
-"caQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/fancy/cigarettes/cigpack_greytort,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "cbc" = (
 /obj/structure/chair/stool/retro/backed{
 	dir = 8
@@ -3607,16 +3574,6 @@
 /area/f13/village)
 "cbr" = (
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
-"cbK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/under/f13/raiderharness,
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
 /area/f13/building)
 "cbX" = (
 /obj/structure/car/rubbish3,
@@ -4116,13 +4073,11 @@
 "csk" = (
 /turf/open/water,
 /area/f13/caves)
-"csy" = (
+"csG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
-	},
+/mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+	icon_state = "floorgrime"
 	},
 /area/f13/building)
 "csO" = (
@@ -4236,6 +4191,14 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"cwk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/clothing/head/soft/f13/baseball,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "cwV" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -4360,14 +4323,6 @@
 /obj/item/shovel,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"cCt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/borscht,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "cCH" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/bandana/skull,
@@ -4405,6 +4360,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"cEn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/instamash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "cEv" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/outside/dirt,
@@ -5086,13 +5048,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
-"cYk" = (
-/mob/living/simple_animal/hostile/cazador,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 7;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
 "cYn" = (
 /obj/item/mop,
 /turf/open/floor/f13{
@@ -5279,6 +5234,14 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/city)
+"ddR" = (
+/obj/structure/fluff/paper,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "dea" = (
 /obj/item/stack/sheet/mineral/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -5300,6 +5263,15 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
+"deP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/building)
 "deT" = (
 /obj/machinery/light/small{
@@ -5324,6 +5296,15 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"deZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
 /area/f13/building)
 "dfo" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -6016,14 +5997,6 @@
 /obj/structure/closet,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"dyD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "dyQ" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -6468,14 +6441,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"dMJ" = (
-/obj/structure/fluff/paper,
-/obj/item/storage/trash_stack,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "dMW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -6783,12 +6748,6 @@
 /obj/structure/stone_tile/slab,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"dXT" = (
-/obj/structure/window/fulltile/store,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/building)
 "dYY" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt{
@@ -6917,9 +6876,7 @@
 	},
 /area/f13/tunnel)
 "ebV" = (
-/obj/structure/table,
-/obj/structure/fluff/paper/stack,
-/obj/item/stamp,
+/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -6927,7 +6884,8 @@
 /area/f13/building)
 "ecg" = (
 /obj/structure/table,
-/obj/item/storage/box/lights/bulbs,
+/obj/structure/fluff/paper/stack,
+/obj/item/stamp,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -6977,6 +6935,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"edW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/bubblegum,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "eeh" = (
 /obj/effect/decal/marking,
 /turf/open/indestructible/ground/outside/road{
@@ -6994,7 +6959,7 @@
 /area/f13/wasteland)
 "eeN" = (
 /obj/structure/table,
-/obj/item/stamp/denied,
+/obj/item/storage/box/lights/bulbs,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -7056,6 +7021,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/building)
+"ehm" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
 "ehx" = (
 /obj/effect/spawner/lootdrop/trash,
 /mob/living/simple_animal/hostile/ghoul/reaver,
@@ -7118,9 +7092,8 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "eig" = (
-/obj/effect/decal/remains/human,
-/obj/item/clothing/head/mailman,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/stamp/denied,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -7215,6 +7188,11 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"elg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "ely" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice/catwalk,
@@ -7425,9 +7403,9 @@
 	},
 /area/f13/wasteland)
 "eqm" = (
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
-	},
+/obj/effect/decal/remains/human,
+/obj/item/clothing/head/mailman,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -7651,8 +7629,9 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "ewI" = (
-/obj/structure/table,
-/obj/item/stack/packageWrap,
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -7898,7 +7877,7 @@
 /area/f13/wasteland)
 "eDc" = (
 /obj/structure/table,
-/obj/item/clothing/head/christmashat,
+/obj/item/stack/packageWrap,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -8180,6 +8159,16 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"eKu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	termtag = "Business"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "eKB" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8262,9 +8251,8 @@
 	},
 /area/f13/wasteland)
 "eMU" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/item/clothing/head/christmashat,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -8561,13 +8549,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"eUa" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/trash/f13/crisps,
-/obj/item/trash/f13/crisps,
-/obj/item/trash/f13/crisps,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "eUh" = (
 /obj/machinery/button/door{
 	id = "countershutters";
@@ -8956,13 +8937,6 @@
 	},
 /turf/open/floor/plating,
 /area/f13/tunnel)
-"fcw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/porknbeans,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "fcE" = (
 /obj/structure/reagent_dispensers/barrel/three{
 	pixel_x = -14
@@ -9238,6 +9212,15 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
+"fkB" = (
+/obj/structure/chair/f13chair1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "fkD" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -9356,6 +9339,14 @@
 "foz" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"foA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/building)
 "foM" = (
 /obj/structure/chair/wood,
@@ -9907,10 +9898,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"fDs" = (
-/obj/effect/mine/explosive,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "fDA" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/blood/old,
@@ -10393,13 +10380,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/building)
-"fTR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/instamash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "fTT" = (
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10711,15 +10691,6 @@
 /obj/structure/railing,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"gcz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "gcK" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
@@ -10732,11 +10703,6 @@
 /obj/item/stack/sheet/cardboard/twenty,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
-"gdf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
 "gdJ" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
@@ -10876,14 +10842,6 @@
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/water,
 /area/f13/caves)
-"gii" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/crafting/lunchbox,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "gin" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -10892,8 +10850,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gip" = (
-/mob/living/simple_animal/hostile/eyebot,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -11209,6 +11168,13 @@
 	icon_state = "cross3"
 	},
 /area/f13/wasteland)
+"goA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/dog,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "goC" = (
 /obj/structure/chair/comfy{
 	dir = 8
@@ -11326,7 +11292,7 @@
 /area/f13/building)
 "gqy" = (
 /mob/living/simple_animal/hostile/eyebot,
-/obj/structure/fluff/paper,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -11537,9 +11503,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
 /area/f13/building)
 "guw" = (
+/mob/living/simple_animal/hostile/eyebot,
 /obj/structure/fluff/paper,
-/obj/structure/table,
-/obj/item/trash/f13/rotten,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -11579,14 +11544,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"gvb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/clothing/head/soft/f13/baseball,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "gvc" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/muzzle,
@@ -11674,6 +11631,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"gxY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/crafting/lunchbox,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "gyd" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -11909,13 +11874,6 @@
 /area/f13/building)
 "gFR" = (
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/wasteland)
-"gGc" = (
-/obj/item/trash/f13/tin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
-	},
 /area/f13/wasteland)
 "gGp" = (
 /obj/item/storage/trash_stack,
@@ -12198,13 +12156,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
-"gPQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "gPV" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood{
@@ -12304,13 +12255,6 @@
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"gSI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/bubblegum,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "gSS" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt{
@@ -13327,6 +13271,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"hsP" = (
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "htf" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -13455,6 +13407,14 @@
 "hwC" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/wasteland)
+"hwK" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/yumyum,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "hwO" = (
 /obj/structure/fence,
 /turf/closed/wall/f13/tunnel,
@@ -13626,6 +13586,14 @@
 "hBr" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
+"hBG" = (
+/obj/structure/bed/old,
+/obj/item/bedsheet/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "hBN" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2top"
@@ -13847,6 +13815,11 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
+"hHy" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/bar)
 "hHz" = (
 /obj/structure/table,
 /obj/item/crafting/abraxo,
@@ -14317,6 +14290,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
 /area/f13/bar)
+"hUL" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/instamash,
+/obj/item/reagent_containers/food/snacks/f13/instamash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "hUN" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
@@ -14736,13 +14718,6 @@
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
-"ihU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "iic" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink/kitchen{
@@ -14963,14 +14938,6 @@
 	},
 /turf/open/water,
 /area/f13/caves)
-"inQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/light/small/broken,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "inW" = (
 /obj/structure/flora/tree/joshua,
 /turf/open/indestructible/ground/outside/desert{
@@ -14985,14 +14952,6 @@
 /obj/structure/stacklifter,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"ion" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/yumyum,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "ioH" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -15096,6 +15055,13 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
+"irz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "irF" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper,
 /turf/open/water,
@@ -15346,6 +15312,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"izg" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
+/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "izr" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -15374,12 +15349,9 @@
 	},
 /area/f13/building)
 "iAz" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/obj/structure/fluff/paper/corner{
-	dir = 8
-	},
+/obj/structure/fluff/paper,
+/obj/structure/table,
+/obj/item/trash/f13/rotten,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -15755,8 +15727,12 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
 "iKm" = (
-/obj/structure/fluff/paper/corner,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -15928,12 +15904,6 @@
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
-"iNZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/paper_bin,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
 "iOg" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
@@ -16333,13 +16303,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"iVV" = (
-/obj/structure/wreck/trash/five_tires,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 10;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
 "iVW" = (
 /obj/machinery/conveyor/auto{
 	dir = 1
@@ -16544,13 +16507,6 @@
 /obj/structure/simple_door/wood,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
-"jaW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "jbj" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
@@ -17126,16 +17082,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"jqf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/crisps,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "jqX" = (
 /obj/structure/fireplace,
 /turf/open/floor/f13{
@@ -17439,6 +17385,14 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/ncr)
+"jzv" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/crisps,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "jzB" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 8
@@ -17471,6 +17425,14 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/brotherhood)
+"jAP" = (
+/obj/structure/window/fulltile/store,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/building)
 "jAZ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -17524,6 +17486,12 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"jCs" = (
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2right"
+	},
+/area/f13/wasteland)
 "jCC" = (
 /obj/structure/musician/piano,
 /turf/open/floor/f13{
@@ -17572,6 +17540,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/ncr)
+"jFx" = (
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "jFE" = (
 /obj/structure/table/wood,
 /obj/item/trash/sosjerky{
@@ -17756,12 +17728,15 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"jLn" = (
+"jLu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/fancy/cigarettes/cigpack_bigboss,
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "minimart";
+	name = "Minimart Button"
+	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/building)
 "jLK" = (
@@ -18051,15 +18026,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
-"jTn" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/instamash,
-/obj/item/reagent_containers/food/snacks/f13/instamash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "jTq" = (
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood,
@@ -18443,6 +18409,14 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/building)
+"kbI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/dog,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "kbQ" = (
 /obj/structure/table/wood/poker,
 /obj/effect/holodeck_effect/cards,
@@ -18522,12 +18496,6 @@
 	icon_state = "verticaloutermaintop"
 	},
 /area/f13/wasteland)
-"kdZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/pen,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
 "keb" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	pixel_y = -6
@@ -18758,15 +18726,6 @@
 "kjR" = (
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"kkj" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavementcorner"
-	},
-/area/f13/wasteland)
 "kkD" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
@@ -19117,6 +19076,13 @@
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kwB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "kwK" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19284,6 +19250,14 @@
 /obj/structure/pondlily_small,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"kDa" = (
+/obj/structure/fluff/paper,
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "kDj" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -19497,13 +19471,6 @@
 /obj/machinery/workbench,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"kJe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/borscht,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "kJn" = (
 /obj/item/bedsheet,
 /obj/item/clothing/under/f13/cowboyg{
@@ -19511,15 +19478,6 @@
 	},
 /obj/structure/bed/old,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"kJo" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
-/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
 /area/f13/building)
 "kJu" = (
 /obj/structure/anvil/obtainable/basic,
@@ -19843,6 +19801,13 @@
 /obj/item/binoculars,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"kUK" = (
+/mob/living/simple_animal/hostile/cazador,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 7;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "kUM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -20024,9 +19989,8 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
 "kZH" = (
-/obj/structure/fluff/paper,
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/instacoffee,
+/obj/structure/fluff/paper/corner,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -20406,14 +20370,6 @@
 /obj/structure/table/wood/fancy/royalblack,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"llt" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/bubblegum/large,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "lly" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -20427,10 +20383,6 @@
 /obj/effect/landmark/start/f13/mayor,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"llK" = (
-/obj/item/trash/f13/tin,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/bar)
 "lmc" = (
 /obj/structure/bonfire,
 /obj/item/stack/rods/ten,
@@ -20918,6 +20870,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"lBt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/borscht,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "lBD" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -21265,9 +21225,9 @@
 	},
 /area/f13/building)
 "lLX" = (
+/obj/structure/fluff/paper,
 /obj/structure/table,
-/obj/structure/fluff/paper/stack,
-/obj/structure/barricade/bars,
+/obj/item/reagent_containers/food/drinks/bottle/instacoffee,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -21531,6 +21491,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"lTH" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/bubblegum/large,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "lTT" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/dirt{
@@ -22011,10 +21979,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"miu" = (
-/obj/structure/car/rubbish3,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "miw" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/machinery/light/small/broken{
@@ -22029,7 +21993,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "miS" = (
-/obj/structure/wreck/trash/machinepiletwo,
+/obj/structure/table,
+/obj/structure/fluff/paper/stack,
+/obj/structure/barricade/bars,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -22323,11 +22289,7 @@
 	},
 /area/f13/building)
 "msy" = (
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "yumail";
-	name = "YuMail Express Button"
-	},
+/obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -22638,6 +22600,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"mFs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "mGf" = (
 /obj/structure/table/snooker{
 	dir = 6
@@ -22767,6 +22736,15 @@
 	icon_state = "verticaloutermainbottom"
 	},
 /area/f13/wasteland)
+"mKc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "mKe" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -22864,6 +22842,14 @@
 /obj/item/paper/bitterdrink,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"mMF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "mNn" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/knife,
@@ -23765,9 +23751,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "nqw" = (
-/obj/structure/closet/crate,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/pda,
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "yumail";
+	name = "YuMail Express Button"
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -24151,18 +24139,16 @@
 /obj/structure/stone_tile/slab/burnt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"nDK" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/yellow,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "nDY" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"nEh" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/old/ruinedcornertr,
+/area/f13/bar)
 "nEn" = (
 /obj/structure/holohoop{
 	dir = 8
@@ -24401,6 +24387,12 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"nLN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "nLX" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/machinery/workbench/forge,
@@ -24996,12 +24988,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"ofT" = (
-/mob/living/simple_animal/hostile/eyebot,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland)
 "ofW" = (
 /obj/structure/simple_door/metal/fence{
 	door_type = "fence_wood";
@@ -25073,12 +25059,6 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"oiU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "ojl" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/f13{
@@ -25510,8 +25490,9 @@
 	},
 /area/f13/ncr)
 "otQ" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/pda,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -25958,6 +25939,12 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"oIB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/paper_bin,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "oIF" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -26060,11 +26047,8 @@
 	},
 /area/f13/wasteland)
 "oMb" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/closet/crate,
-/obj/item/storage/firstaid,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -26334,6 +26318,16 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"oUt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/sugarbombs,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "oUy" = (
 /obj/structure/rack,
 /obj/structure/lattice/catwalk,
@@ -26576,6 +26570,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"pcc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/storage/fancy/cigarettes/cigpack_bigboss,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "pck" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -27285,6 +27287,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"pvv" = (
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "pvx" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/tunnel,
@@ -27435,11 +27447,6 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
-"pAL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood/f13/oak,
-/area/f13/bar)
 "pAU" = (
 /obj/structure/sink,
 /turf/open/floor/f13{
@@ -27714,6 +27721,12 @@
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"pIp" = (
+/mob/living/simple_animal/hostile/eyebot,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/wasteland)
 "pIL" = (
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/floor/wood/f13/oak,
@@ -27979,10 +27992,8 @@
 	},
 /area/f13/caves)
 "pOb" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/f13stool,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -28830,10 +28841,6 @@
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
-"qlb" = (
-/mob/living/simple_animal/hostile/raider/ranged,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "qlv" = (
 /obj/structure/table/wood,
 /obj/item/weldingtool,
@@ -29346,6 +29353,15 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"qCC" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
 "qCN" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -29369,8 +29385,12 @@
 	},
 /area/f13/legion)
 "qDe" = (
-/obj/structure/chair/f13chair1,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Business"
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -30124,6 +30144,13 @@
 /obj/structure/simple_door/wood,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
+"qVw" = (
+/obj/structure/fluff/paper/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "qVC" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
@@ -30221,8 +30248,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
 "qZN" = (
-/obj/structure/table,
-/obj/item/pen,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/closet/crate,
+/obj/item/storage/firstaid,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -30337,6 +30367,15 @@
 	pixel_y = -7
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"rcw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
 /area/f13/building)
 "rcC" = (
 /obj/structure/table/wood,
@@ -30728,6 +30767,15 @@
 /obj/item/clothing/glasses/regular,
 /turf/open/floor/wood/f13/oak,
 /area/f13/bar)
+"rpM" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "minimart";
+	name = "Minimart Shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/building)
 "rpS" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -31072,6 +31120,10 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/wood/f13,
 /area/f13/building)
+"rBC" = (
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/bar)
 "rCt" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road,
@@ -31276,13 +31328,6 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
-"rIt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/dog,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "rIu" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -31451,15 +31496,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"rPo" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavementcorner"
-	},
-/area/f13/wasteland)
 "rPI" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bottle/blackpowder,
@@ -31901,6 +31937,16 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/building)
+"sdX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/f13/raiderharness,
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "sed" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -32204,6 +32250,13 @@
 "skE" = (
 /obj/structure/table,
 /obj/item/flashlight/lantern,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"skI" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/f13/crisps,
+/obj/item/trash/f13/crisps,
+/obj/item/trash/f13/crisps,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "skZ" = (
@@ -33219,6 +33272,13 @@
 /obj/structure/simple_door/tentflap_cloth,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"sQd" = (
+/obj/structure/wreck/trash/five_tires,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 10;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "sQv" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -33242,13 +33302,6 @@
 	icon_state = "horizontalbottombordertop3"
 	},
 /area/f13/wasteland)
-"sRR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/yumyum,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "sRV" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/light,
@@ -33259,7 +33312,7 @@
 /area/f13/building)
 "sRX" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -33588,11 +33641,6 @@
 	icon_state = "innershade"
 	},
 /area/f13/wasteland)
-"taz" = (
-/obj/effect/decal/cleanable/glass,
-/obj/item/trash/f13/tin,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/bar)
 "taF" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -33835,16 +33883,6 @@
 	color = "#363636"
 	},
 /turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"tiN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/sugarbombs,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
 /area/f13/building)
 "tjB" = (
 /obj/item/ammo_casing/a50MG,
@@ -34766,6 +34804,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"tJu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/trash/f13/rotten,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "tJv" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -34806,16 +34852,6 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
-"tKB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	termtag = "Business"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
 	},
 /area/f13/building)
 "tKI" = (
@@ -35003,6 +35039,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"tPh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/crisps,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "tPs" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/inside/mountain,
@@ -35024,14 +35070,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
-"tPE" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/trash/f13/steak,
-/obj/item/trash/f13/steak,
-/obj/item/trash/f13/rotten,
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "tQl" = (
 /obj/structure/chair/wood/modern{
 	dir = 1
@@ -35743,6 +35781,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"ujz" = (
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "ujC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -35951,6 +35998,13 @@
 "uqa" = (
 /turf/closed/wall/f13/wood,
 /area/f13/building)
+"uqb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/borscht,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "uqe" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -36115,14 +36169,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"utq" = (
-/obj/structure/window/fulltile/store,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/building)
 "utB" = (
 /obj/structure/table/wood/settler,
 /obj/item/storage/box/matches,
@@ -36179,6 +36225,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"uvo" = (
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "uvp" = (
 /obj/effect/landmark/start/f13/legionary,
 /obj/item/bedsheet/brown,
@@ -36513,15 +36566,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"uER" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/building)
 "uEX" = (
 /obj/structure/decoration/clock{
 	pixel_y = 27
@@ -36776,17 +36820,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
-"uLW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "minimart";
-	name = "Minimart Button"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "uMb" = (
 /obj/structure/chair/comfy,
 /obj/machinery/light/small{
@@ -36960,6 +36993,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"uQg" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "uQx" = (
 /obj/structure/decoration/clock/old/active,
 /turf/closed/wall/f13/wood/interior,
@@ -37203,6 +37240,13 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"uVJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "uVM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -37271,15 +37315,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"uXF" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "minimart";
-	name = "Minimart Shutters"
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/building)
 "uXN" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical"
@@ -37824,6 +37859,13 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"vnU" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "vof" = (
 /obj/item/bodypart/l_arm/robot,
 /obj/structure/chair/office/dark,
@@ -37919,6 +37961,12 @@
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"vrN" = (
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/plate,
+/turf/open/floor/wood/f13/oak,
+/area/f13/bar)
 "vsm" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/fence/wooden{
@@ -38161,6 +38209,13 @@
 /obj/item/dice,
 /turf/open/floor/wood/f13/old/ruinedstraightnorth,
 /area/f13/bar)
+"vzE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/porknbeans,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/building)
 "vzG" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
@@ -38319,13 +38374,6 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
-"vEv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
-/turf/open/floor/wood/f13/carpet,
-/area/f13/bar)
 "vEw" = (
 /obj/item/chair/stool/retro,
 /turf/open/floor/f13/wood,
@@ -38409,6 +38457,12 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"vGT" = (
+/obj/structure/window/fulltile/store,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/building)
 "vHa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -38593,8 +38647,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vLy" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/head/festive,
+/obj/structure/chair/f13chair1,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -38613,13 +38666,6 @@
 	icon_state = "rubbleplate"
 	},
 /area/f13/wasteland)
-"vMt" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "vMu" = (
 /obj/machinery/light{
 	dir = 4;
@@ -38914,10 +38960,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vWC" = (
-/obj/structure/closet/crate,
-/obj/item/wrench,
-/obj/item/screwdriver,
-/obj/item/crowbar,
+/obj/structure/table,
+/obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -38944,13 +38988,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"vXe" = (
-/obj/structure/fluff/paper/corner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "vXh" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
@@ -39162,14 +39199,6 @@
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
-"wgM" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/crisps,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "whm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/autolathe/constructionlathe,
@@ -39904,12 +39933,6 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/building)
-"wCW" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/old/ruinedcornertr,
-/area/f13/bar)
 "wDc" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -40546,7 +40569,7 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "wSn" = (
-/obj/structure/chair/f13chair1{
+/obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -40804,6 +40827,13 @@
 "wYv" = (
 /obj/structure/chair/wood/worn,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"wYD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/yumyum,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/building)
 "wYO" = (
 /obj/structure/window/fulltile/house{
@@ -41306,15 +41336,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"xmH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "xmS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -41407,12 +41428,6 @@
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
-"xoT" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/plate,
-/turf/open/floor/wood/f13/oak,
-/area/f13/bar)
 "xpg" = (
 /obj/structure/barricade/tentclothedge,
 /turf/open/indestructible/ground/outside/dirt{
@@ -41771,8 +41786,8 @@
 	},
 /area/f13/wasteland)
 "xxg" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
+/obj/structure/closet/crate,
+/obj/item/clothing/head/festive,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -41794,12 +41809,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"xyf" = (
-/obj/effect/decal/marking,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2right"
-	},
-/area/f13/wasteland)
 "xys" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -41856,8 +41865,8 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/bar)
 "xAZ" = (
-/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/photocopier,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -41894,6 +41903,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"xCi" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/f13/steak,
+/obj/item/trash/f13/steak,
+/obj/item/trash/f13/rotten,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "xCo" = (
 /obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/dirt{
@@ -42276,6 +42293,12 @@
 	icon_state = "verticalleftborderleft2bottom"
 	},
 /area/f13/wasteland)
+"xMv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/pen,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/bar)
 "xMw" = (
 /obj/structure/simple_door/metal/store,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -42851,8 +42874,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "yeF" = (
-/obj/structure/fluff/paper,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/item/wrench,
+/obj/item/screwdriver,
+/obj/item/crowbar,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -57627,7 +57652,7 @@ gcK
 kBU
 suS
 suS
-vEv
+mFs
 suS
 kBU
 xuy
@@ -57884,7 +57909,7 @@ gcK
 kBU
 suS
 pes
-kdZ
+xMv
 suS
 kBU
 cqe
@@ -57895,7 +57920,7 @@ bmO
 xbv
 gWn
 yhw
-taz
+hHy
 fyf
 fyf
 dRo
@@ -58141,7 +58166,7 @@ gcK
 kBU
 lGH
 lDy
-gdf
+elg
 suS
 igs
 xuy
@@ -58398,7 +58423,7 @@ gcK
 kBU
 suS
 pRo
-iNZ
+oIB
 suS
 kBU
 elF
@@ -58406,7 +58431,7 @@ xuy
 hUK
 qiO
 rCO
-llK
+rBC
 yhw
 aRp
 kBU
@@ -58661,11 +58686,11 @@ kBU
 lnc
 xuy
 xuy
-wCW
+nEh
 dre
 yhw
 yhw
-llK
+rBC
 vrz
 kGc
 nPg
@@ -58918,7 +58943,7 @@ tAg
 xuy
 anl
 uBx
-pAL
+boW
 hLc
 lhc
 dre
@@ -59440,7 +59465,7 @@ lhc
 tkd
 kGc
 unI
-xyf
+jCs
 qci
 sQX
 sQX
@@ -60205,8 +60230,8 @@ xuy
 iqx
 hUK
 xuy
-pAL
-xoT
+boW
+vrN
 nsg
 whO
 kGc
@@ -62763,7 +62788,7 @@ fyf
 fyf
 fyf
 fyf
-cYk
+kUK
 ajD
 qnS
 kaM
@@ -63792,17 +63817,17 @@ fyf
 kGc
 dMW
 gts
-uLW
-ion
-gSI
-uER
-vMt
+jLu
+hwK
+edW
+deZ
+csG
 jmr
-fTR
-vMt
+cEn
+csG
 jmr
 jmr
-dXT
+vGT
 kGc
 dMW
 fyf
@@ -64048,18 +64073,18 @@ fyf
 fyf
 kGc
 dMW
-uXF
-xmH
-jTn
-sRR
+rpM
+deP
+hUL
+wYD
 gts
-gvb
-gii
+cwk
+gxY
 jmr
 gFi
 jmr
-jLn
-utq
+pcc
+jAP
 kGc
 dMW
 fyf
@@ -64305,18 +64330,18 @@ fyf
 fyf
 kGc
 dMW
-uXF
-oiU
-oiU
-gPQ
+rpM
+nLN
+nLN
+uVJ
 gts
-tiN
-vMt
+oUt
+csG
 jmr
-tKB
+eKu
 jmr
-caQ
-dXT
+bMG
+vGT
 kGc
 obr
 fyf
@@ -64562,20 +64587,20 @@ fyf
 fyf
 kGc
 dMW
-uXF
-kJo
-rIt
-wgM
+rpM
+izg
+goA
+jzv
 gts
 lLz
 lLz
-kJe
+uqb
 gFi
-bSS
-inQ
+tJu
+mMF
 gts
 kGc
-gGc
+uvo
 fyf
 fyf
 sYX
@@ -64820,17 +64845,17 @@ fyf
 kGc
 dMW
 gts
-nDK
-cbK
-llt
+hBG
+sdX
+lTH
 gts
-gcz
+mKc
 jmr
-vMt
+csG
 jmr
-fTR
+cEn
 jmr
-csy
+rcw
 kGc
 dMW
 fyf
@@ -65082,11 +65107,11 @@ gts
 gts
 gts
 jfF
-dyD
+foA
 jmr
-arZ
-arZ
-ihU
+kbI
+kbI
+kwB
 gts
 kGc
 dMW
@@ -65334,15 +65359,15 @@ fyf
 kGc
 jkJ
 igz
-rPo
-tPE
+ehm
+xCi
 fyf
 gts
-jqf
-vMt
+tPh
+csG
 jmr
 jmr
-vMt
+csG
 jmr
 fRZ
 kGc
@@ -65595,13 +65620,13 @@ dMW
 fyf
 fyf
 gts
-cCt
+lBt
 jfF
 jmr
 jfF
 ohA
 jmr
-dXT
+vGT
 kGc
 dMW
 fyf
@@ -65848,16 +65873,16 @@ fyf
 fyf
 sND
 nJW
-kkj
-eUa
+qCC
+skI
 fyf
 gts
-vMt
-fcw
+csG
+vzE
 jmr
 jmr
 jmr
-jaW
+irz
 fRZ
 kGc
 dMW
@@ -66105,9 +66130,9 @@ qOV
 cWG
 cWG
 cWG
-bzk
+ujz
 vpx
-btr
+vnU
 gts
 gts
 gts
@@ -66367,7 +66392,7 @@ mvv
 tmA
 wDc
 fyf
-qlb
+jFx
 fyf
 fyf
 fyf
@@ -78610,9 +78635,9 @@ gcK
 gcK
 gts
 ceP
-eig
+eqm
 cGV
-guw
+iAz
 gts
 gts
 gts
@@ -78868,12 +78893,12 @@ gcK
 gts
 nft
 wyM
-eMU
-iAz
+gip
+iKm
 gts
-msy
+nqw
 cfz
-vLy
+xxg
 gts
 igz
 hgX
@@ -79125,14 +79150,14 @@ gcK
 gts
 ctT
 ujC
-gip
+gqy
 ujC
 gts
 ujC
 ujC
 ujC
 nuv
-fDs
+bLK
 cpK
 ofX
 hbW
@@ -79383,14 +79408,14 @@ gts
 duK
 wyM
 ujC
-iKm
+kZH
 wkx
 ujC
 ujC
 ujC
 nuv
 glZ
-miu
+uQg
 unI
 qnS
 erY
@@ -79640,14 +79665,14 @@ gts
 dEB
 wyM
 okg
-kZH
+lLX
 gts
-nqw
-oMb
-vWC
+otQ
+qZN
+yeF
 gts
 ptf
-iVV
+sQd
 unI
 dXy
 dFQ
@@ -79895,7 +79920,7 @@ gts
 gts
 gts
 gts
-eqm
+ewI
 gts
 gts
 gts
@@ -80155,11 +80180,11 @@ clQ
 wyM
 vJL
 gts
-miS
+msy
 ujC
-pOb
+sRX
 ujC
-yeF
+ddR
 gts
 kGc
 pBv
@@ -80408,15 +80433,15 @@ gcK
 gts
 xAZ
 ujC
-xAZ
+ebV
 wyM
 afs
 wkx
 wyM
 ujC
-qDe
-wSn
-yeF
+vLy
+fkB
+ddR
 gts
 kGc
 ajD
@@ -80671,9 +80696,9 @@ boq
 gts
 wyM
 nqZ
-qZN
-xxg
-bMF
+vWC
+hsP
+pvv
 fRZ
 kGc
 jIB
@@ -80922,15 +80947,15 @@ gcK
 gts
 ujC
 bpn
-ebV
-ewI
-gqy
+ecg
+eDc
+guw
 dps
 uVE
 wyM
-eMU
-eMU
-vXe
+gip
+gip
+qVw
 fRZ
 kGc
 ofX
@@ -81436,15 +81461,15 @@ gcK
 gts
 wyM
 uLk
-ecg
-eDc
-gqy
-lLX
+eeN
+eMU
+guw
+miS
 uVE
-otQ
+oMb
 uVE
 wyM
-dMJ
+kDa
 gts
 jRX
 fsl
@@ -81950,18 +81975,18 @@ gcK
 gts
 ujC
 ccF
-eeN
+eig
 uLk
-gqy
+guw
 dps
 uVE
 uVE
 wyM
 ujC
-bMF
-eqm
+pvv
+ewI
 kGc
-ofT
+pIp
 tbG
 erY
 erY
@@ -82212,9 +82237,9 @@ ujC
 boq
 gts
 wyM
+pOb
 ujC
-ujC
-ujC
+pOb
 wyM
 gts
 kGc
@@ -82469,9 +82494,9 @@ gts
 gts
 gts
 iBu
-ujC
-sRX
-ujC
+qDe
+wSn
+qDe
 cKs
 gts
 jRX


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://user-images.githubusercontent.com/38540951/123861992-ca722f00-d8f5-11eb-927c-0cf9161bbff7.png)
Replacing the stop-gap ruin that was placed to fill in the gap from the followers outpost. Say hello to the YuMail Express, where the mailmen were planning to shoot apart the eyebots that were replacing them on the same day. They didn't have the chance to get embarrassed about scheduling their workplace shooting on the same day though, as the bombs dropped beforehand.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives us another themed little ruin instead of a generic rubble with some random ghouls. I wanna fill the map with cool ruins.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added YuMail Express ruin.
del: Removed old filler ghoul ruin.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
