### PR TITLE
Better call the plumber next time you want to build a toilet

### DIFF
--- a/code/controllers/subsystem/materials.dm
+++ b/code/controllers/subsystem/materials.dm
@@ -17,8 +17,6 @@ SUBSYSTEM_DEF(materials)
 	///List of stackcrafting recipes for materials using rigid materials
 	var/list/rigid_stack_recipes = list(
 		new /datum/stack_recipe("chair", /obj/structure/chair/greyscale, one_per_turf = TRUE, on_floor = TRUE, applies_mats = TRUE),
-		new /datum/stack_recipe("toilet", /obj/structure/toilet/greyscale, one_per_turf = TRUE, on_floor = TRUE, applies_mats = TRUE),
-		new /datum/stack_recipe("sink", /obj/structure/sink/greyscale, one_per_turf = TRUE, on_floor = TRUE, applies_mats = TRUE),
 		new /datum/stack_recipe("Floor tile", /obj/item/stack/tile/material, 1, 4, 20, applies_mats = TRUE)
 	)
 


### PR DESCRIPTION
## About The Pull Request

...cause you cant stack craft it no more. Inspired by the avante garde artists who paved Yuma with gold and uranium toilets.

## Changelog
:cl:
del: toilet + sink stack crafting gone.
/:cl:
