### PR TITLE
Sticky hud icons fix #19851959 (actually #17)

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -86,7 +86,7 @@
 	var/slot_id	// The indentifier for the slot. It has nothing to do with ID cards.
 	var/icon_empty // Icon when empty. For now used only by humans.
 	var/icon_full  // Icon when contains an item. For now used only by humans.
-	var/list/object_overlay = list()
+	var/image/object_overlay
 	layer = HUD_LAYER
 	plane = HUD_PLANE
 
@@ -104,6 +104,15 @@
 		usr.update_inv_hands()
 	return TRUE
 
+/obj/screen/inventory/MouseEntered()
+	..()
+	add_overlays()
+
+/obj/screen/inventory/MouseExited()
+	..()
+	cut_overlay(object_overlay)
+	QDEL_NULL(object_overlay)
+
 /obj/screen/inventory/update_icon_state()
 	if(!icon_empty)
 		icon_empty = icon_state
@@ -113,15 +122,6 @@
 			icon_state = icon_full
 		else
 			icon_state = icon_empty
-
-/obj/screen/inventory/MouseEntered()
-	..()
-	add_overlay()
-
-/obj/screen/inventory/MouseExited()
-	..()
-	cut_overlay(object_overlay)
-	object_overlay.Cut()
 
 /obj/screen/inventory/proc/add_overlays()
 	var/mob/user = hud?.mymob
@@ -142,8 +142,10 @@
 	else
 		item_overlay.color = "#00ff00"
 
-	object_overlay += item_overlay
+	cut_overlay(object_overlay)
+	object_overlay = item_overlay
 	add_overlay(object_overlay)
+	update_icon(object_overlay)
 
 /obj/screen/inventory/hand
 	var/mutable_appearance/handcuff_overlay

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -86,7 +86,7 @@
 	var/slot_id	// The indentifier for the slot. It has nothing to do with ID cards.
 	var/icon_empty // Icon when empty. For now used only by humans.
 	var/icon_full  // Icon when contains an item. For now used only by humans.
-	var/image/object_overlay
+	var/list/object_overlay = list()
 	layer = HUD_LAYER
 	plane = HUD_PLANE
 
@@ -104,15 +104,6 @@
 		usr.update_inv_hands()
 	return TRUE
 
-/obj/screen/inventory/MouseEntered()
-	..()
-	add_overlays()
-
-/obj/screen/inventory/MouseExited()
-	..()
-	cut_overlay(object_overlay)
-	QDEL_NULL(object_overlay)
-
 /obj/screen/inventory/update_icon_state()
 	if(!icon_empty)
 		icon_empty = icon_state
@@ -122,6 +113,15 @@
 			icon_state = icon_full
 		else
 			icon_state = icon_empty
+
+/obj/screen/inventory/MouseEntered()
+	..()
+	add_overlay()
+
+/obj/screen/inventory/MouseExited()
+	..()
+	cut_overlay(object_overlay)
+	object_overlay.Cut()
 
 /obj/screen/inventory/proc/add_overlays()
 	var/mob/user = hud?.mymob
@@ -142,8 +142,7 @@
 	else
 		item_overlay.color = "#00ff00"
 
-	cut_overlay(object_overlay)
-	object_overlay = item_overlay
+	object_overlay += item_overlay
 	add_overlay(object_overlay)
 
 /obj/screen/inventory/hand


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes the green/red icons for objects becoming permanantly stuck in slots (hopefully)

## Why It's Good For The Game

Fucked up slots are annoying

Feel free to clone this branch and fuck around, it's mostly up to what seems to be random chance, so it's hard to test and make sure this works/doesn't work.
## Changelog
:cl:
fix: Icons in slots not clearing on MouseExited
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
