### PR TITLE
gives troopers an M1 instead of varmint rifle, changes up 2 of the loadouts, adds trekking to Corporal Spotter since I forgot it 

### DIFF
--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -414,7 +414,7 @@ Sergeant
 	suit_store = /obj/item/gun/ballistic/shotgun/trench //Over thereee over thereeeee spread the spread the word over thereeee
 	head = /obj/item/clothing/head/f13/ncr/goggles
 	backpack_contents = list(
-		/obj/item/storage/fancy/ammobox/lethalshot=2, \
+		/obj/item/ammo_box/shotgun/buck=2, \
 		/obj/item/clothing/mask/gas=1, \
 		/obj/item/tank/internals/emergency_oxygen/engi=1, \
 		/obj/item/grenade/smokebomb=3, \
@@ -721,18 +721,19 @@ Trooper
 
 /datum/outfit/loadout/trooperpathfinder
 	name = "Pathfinder"
-	suit_store = /obj/item/gun/ballistic/automatic/m1carbine/m1n //Generally worse weapon, though can be upgraded
+	suit_store = /obj/item/gun/ballistic/automatic/smg/rockwell
 	backpack_contents = list(
 		/obj/item/book/granter/trait/trekking=1, //You get a worse weapon, but are good at scouting. Hence "Pathfinder."
 		/obj/item/storage/box/ration/menu_eight=1,
-		/obj/item/ammo_box/magazine/m10mm_adv/ext=1)
+		/obj/item/ammo_box/magazine/uzim9mm=2)
 
 /datum/outfit/loadout/trooperfiresupport
-	name = "Fire Support"
-	suit_store = /obj/item/gun/ballistic/automatic/smg/rockwell //Barely better then a pipe gun but you get a pretty rapid burst fire. Intended for suppression/CQC
+	name = "Pointman"
+	suit_store = /obj/item/gun/ballistic/shotgun/police 
 	backpack_contents = list(
 		/obj/item/storage/box/ration/menu_one=1,
-		/obj/item/ammo_box/magazine/uzim9mm=1)
+		/obj/item/flashlight/seclite=1, //for putting on your shotgun. You're a pointman, you lead the way in attacks.
+		/obj/item/ammo_box/shotgun/buck=2)
 
 
 

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -713,10 +713,10 @@ Trooper
 
 /datum/outfit/loadout/trooperrifleman
 	name = "Rifleman"
-	suit_store = /obj/item/gun/ballistic/automatic/varmint //Service rifle is dead, long live the varmint rifle! Higher tier roles still get the Service Rifle.
+	suit_store = /obj/item/gun/ballistic/automatic/service
 	backpack_contents = list(
 		/obj/item/storage/box/ration/menu_two=1,
-		/obj/item/ammo_box/magazine/m556/rifle=1)
+		/obj/item/ammo_box/magazine/m556/rifle=2)
 
 /datum/outfit/loadout/trooperpathfinder
 	name = "Pathfinder"

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -524,6 +524,7 @@ Corporal
 	head = /obj/item/clothing/head/beret/ncr_recon/worn
 	backpack_contents = list(
 		/obj/item/storage/box/ration/menu_eight=1, 
+		/obj/item/book/granter/trait/trekking=1,
 		/obj/item/binoculars=1,
 		/obj/item/ammo_box/magazine/m10mm_adv/ext=2)
 
@@ -713,10 +714,10 @@ Trooper
 
 /datum/outfit/loadout/trooperrifleman
 	name = "Rifleman"
-	suit_store = /obj/item/gun/ballistic/automatic/service
+	suit_store = /obj/item/gun/ballistic/automatic/m1carbine/m1n 
 	backpack_contents = list(
 		/obj/item/storage/box/ration/menu_two=1,
-		/obj/item/ammo_box/magazine/m556/rifle=2)
+		/obj/item/ammo_box/magazine/m10mm_adv/ext=2)
 
 /datum/outfit/loadout/trooperpathfinder
 	name = "Pathfinder"


### PR DESCRIPTION
exactly what it says. Varmint Rifle doesnt fit troopers very well, the M1/N is a good middleground between the varmint and the SR. Fire support basically didnt get used and the pathfinder loadout had the M1. With this, fire support is now "pointman" who gets a police shotgun and a flashlight to lead the way during attacks. It's not very strong, but it is niche and adds a cool loadout. Pathfinder now has the rockwell SMG since they're a light scout