### PR TITLE
General Small Fixes

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -16977,7 +16977,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jlD" = (
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/f13{
@@ -26974,12 +26974,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"pfB" = (
-/obj/machinery/vending/autodrobe,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "pfK" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -36772,12 +36766,6 @@
 	icon_state = "wooden_chair_settler"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"uDX" = (
-/obj/machinery/vending/clothing,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
 /area/f13/building)
 "uEc" = (
 /obj/structure/window{
@@ -85444,7 +85432,7 @@ gcK
 gcK
 gts
 uvk
-pfB
+vYv
 aUu
 vYv
 ufN
@@ -85703,7 +85691,7 @@ gts
 gts
 gts
 gts
-uDX
+vYv
 dMc
 xFS
 vYv
@@ -85959,7 +85947,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+gts
 gts
 gts
 gts

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -569,7 +569,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/bedsheet,
 /obj/effect/landmark/start/f13/usprivate,
-/obj/structure/bed/old,
+/obj/structure/bed,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -3024,7 +3024,7 @@
 "cOS" = (
 /obj/item/bedsheet/brown,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/old,
+/obj/structure/bed,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/leisure)
 "cPA" = (
@@ -4015,7 +4015,7 @@
 "dFh" = (
 /obj/item/bedsheet/red,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/old,
+/obj/structure/bed,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "dFz" = (
@@ -4073,7 +4073,7 @@
 	dir = 1;
 	pixel_x = 16
 	},
-/obj/structure/bed/old,
+/obj/structure/bed,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "dHQ" = (
@@ -4217,7 +4217,7 @@
 /area/f13/brotherhood/operations)
 "dML" = (
 /obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "dMQ" = (
@@ -4418,11 +4418,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/den)
 "dVJ" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
-	},
-/area/f13/caves)
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "dVL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/vent{
@@ -4480,7 +4479,7 @@
 "dYM" = (
 /obj/item/bedsheet,
 /obj/effect/landmark/start/f13/usspy,
-/obj/structure/bed/old,
+/obj/structure/bed,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -5890,7 +5889,7 @@
 "fji" = (
 /obj/item/bedsheet,
 /obj/effect/landmark/start/f13/usprivate,
-/obj/structure/bed/old,
+/obj/structure/bed,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -6983,7 +6982,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bedsheet/brown,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/old,
+/obj/structure/bed,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -10080,11 +10079,9 @@
 	},
 /area/f13/bunker)
 "isr" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/trash/f13/dog,
-/turf/open/indestructible/ground/inside/subway,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "isG" = (
 /obj/structure/simple_door/metal/ventilation,
@@ -10959,7 +10956,7 @@
 "jak" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "jaY" = (
@@ -11546,7 +11543,7 @@
 /area/f13/tunnel)
 "jwN" = (
 /obj/item/bedsheet/medical,
-/obj/structure/bed/old,
+/obj/structure/bed,
 /turf/open/floor/f13{
 	icon_state = "bluedirtyfull"
 	},
@@ -12375,7 +12372,7 @@
 	name = "Head Knight Action Figure";
 	toysay = "Victory is our tradition!"
 	},
-/obj/structure/bed/old,
+/obj/structure/bed,
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
 "kcD" = (
@@ -12487,12 +12484,14 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
 "kfQ" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "mine"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/f13/caves)
 "kfV" = (
 /obj/structure/simple_door/room,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12975,7 +12974,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/bedsheet,
 /obj/effect/landmark/start/f13/usspy,
-/obj/structure/bed/old,
+/obj/structure/bed,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -13483,9 +13482,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "kYT" = (
-/mob/living/simple_animal/hostile/centaur,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	icon_state = "bluerustyfull"
+	},
+/area/f13/caves)
 "kZs" = (
 /obj/structure/toilet{
 	pixel_y = 10
@@ -13701,7 +13702,7 @@
 "leT" = (
 /obj/machinery/light,
 /obj/item/bedsheet/medical,
-/obj/structure/bed/old,
+/obj/structure/bed,
 /turf/open/floor/f13{
 	icon_state = "bluerustyfull"
 	},
@@ -13764,7 +13765,6 @@
 	light_color = "#800080";
 	name = "light fixture"
 	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "liq" = (
@@ -14614,7 +14614,7 @@
 "lTX" = (
 /obj/item/bedsheet,
 /obj/effect/landmark/start/f13/ussgt,
-/obj/structure/bed/old,
+/obj/structure/bed,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -14912,7 +14912,7 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/item/storage/fancy/candle_box,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "miy" = (
@@ -16128,7 +16128,7 @@
 	specialfunctions = 4
 	},
 /obj/item/bedsheet/hos,
-/obj/structure/bed/old,
+/obj/structure/bed,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "ncX" = (
@@ -16137,7 +16137,7 @@
 /area/f13/den)
 "ncY" = (
 /obj/item/bedsheet/rd,
-/obj/structure/bed/old,
+/obj/structure/bed,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "ndi" = (
@@ -21605,7 +21605,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/bed/old,
+/obj/structure/bed,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "rex" = (
@@ -21757,7 +21757,7 @@
 "rjQ" = (
 /obj/item/bedsheet/black,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/old,
+/obj/structure/bed,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "rjY" = (
@@ -21828,7 +21828,7 @@
 	name = "NCR banner";
 	pixel_y = 32
 	},
-/mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
+/mob/living/simple_animal/hostile/supermutant/nightkin,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "rlz" = (
@@ -21887,7 +21887,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/bedsheet,
 /obj/effect/landmark/start/f13/ussgt,
-/obj/structure/bed/old,
+/obj/structure/bed,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -22045,7 +22045,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rsg" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/decal/remains/human,
+/obj/item/clothing/head/hardhat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "rsj" = (
@@ -25377,15 +25378,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"uaf" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "mine"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
-	},
-/area/f13/caves)
 "uas" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/glasses/sunglasses{
@@ -25718,7 +25710,7 @@
 /area/f13/brotherhood/offices1st)
 "urc" = (
 /obj/item/bedsheet/hos,
-/obj/structure/bed/old,
+/obj/structure/bed,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "urg" = (
@@ -27005,11 +26997,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
-"vsw" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/centaur,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "vsC" = (
 /obj/structure/window/fulltile/store,
 /obj/structure/barricade/wooden/planks,
@@ -28643,6 +28630,9 @@
 /obj/structure/table/wood/settler,
 /obj/item/hatchet,
 /obj/item/twohanded/sledgehammer,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "wRA" = (
@@ -29819,10 +29809,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/closed/wall/f13/wood,
 /area/f13/tunnel)
-"xPN" = (
-/mob/living/simple_animal/hostile/supermutant/nightkin,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
 "xRm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
@@ -30013,7 +29999,7 @@
 	dir = 8
 	},
 /obj/item/stack/f13Cash/random/med,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "xYV" = (
@@ -31469,7 +31455,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+hQE
 uoO
 uoO
 uoO
@@ -31724,11 +31710,11 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+rRo
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -31980,13 +31966,13 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -32236,15 +32222,15 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -32493,15 +32479,15 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+hQE
+hQE
+hQE
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -32749,17 +32735,17 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+hQE
+dYY
+xVz
+xVz
+hQE
+kfQ
+kYT
+xVz
+xVz
+wcF
+hQE
 uoO
 uoO
 uoO
@@ -33007,15 +32993,15 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+hQE
+hQE
+hQE
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -33264,15 +33250,15 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -33522,13 +33508,13 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
+xVz
+xVz
+xVz
+xVz
+rsg
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -33780,11 +33766,11 @@ uoO
 uoO
 uoO
 uoO
-uoO
-aoj
-aoj
-uoO
-uoO
+xVz
+xVz
+bjI
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -34039,9 +34025,9 @@ uoO
 uoO
 uoO
 aoj
+hQE
 uoO
-uoO
-uoO
+xVz
 uoO
 uoO
 uoO
@@ -34298,7 +34284,7 @@ uoO
 aoj
 uoO
 uoO
-uoO
+xVz
 uoO
 uoO
 uoO
@@ -34555,8 +34541,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+xVz
+xVz
 uoO
 uoO
 xVz
@@ -34813,7 +34799,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+xVz
 aoj
 aoj
 xVz
@@ -35070,7 +35056,7 @@ uoO
 aoj
 aoj
 uoO
-uoO
+xVz
 uoO
 xVz
 xVz
@@ -35327,7 +35313,7 @@ uoO
 aoj
 aoj
 uoO
-uoO
+xVz
 uoO
 xVz
 xVz
@@ -35584,7 +35570,7 @@ uoO
 aoj
 aoj
 uoO
-uoO
+xVz
 uoO
 xVz
 xVz
@@ -50455,7 +50441,7 @@ uoO
 uoO
 uoO
 xVz
-wyu
+xVz
 xVz
 xVz
 xVz
@@ -50712,7 +50698,7 @@ uoO
 uoO
 xVz
 xVz
-jiP
+xVz
 xVz
 xVz
 xVz
@@ -50970,9 +50956,9 @@ uoO
 xVz
 xVz
 xVz
-hQE
-hQE
-hQE
+xVz
+xVz
+xVz
 xVz
 xVz
 uoO
@@ -51227,9 +51213,9 @@ uoO
 xVz
 xVz
 xVz
-hQE
-uaf
-dVJ
+xVz
+xVz
+xVz
 xVz
 wcF
 hQE
@@ -51484,9 +51470,9 @@ uoO
 xVz
 xVz
 xVz
-hQE
-hQE
-hQE
+xVz
+xVz
+xVz
 xVz
 xVz
 uoO
@@ -62300,7 +62286,7 @@ vYC
 qhk
 xVz
 uoO
-rsg
+tiS
 tur
 bEw
 hME
@@ -72580,7 +72566,7 @@ tur
 vuv
 vuj
 lhQ
-qVG
+isr
 mkY
 vuv
 vuv
@@ -74117,7 +74103,7 @@ tjd
 tjd
 tjd
 dMQ
-tjA
+dVJ
 tur
 vuv
 lnr
@@ -76180,7 +76166,7 @@ iNY
 gni
 vuv
 hfb
-kfQ
+ydV
 vuv
 hkD
 hkD
@@ -79281,7 +79267,7 @@ uoO
 uoO
 uoO
 eLE
-uoO
+hQE
 qhB
 nBk
 nBk
@@ -79816,7 +79802,7 @@ nBk
 nBk
 mPr
 pYA
-kYT
+hkn
 ckc
 hkn
 rNO
@@ -80589,7 +80575,7 @@ mPr
 rsB
 dEg
 qpM
-kYT
+hkn
 wWd
 xyk
 uoO
@@ -81345,7 +81331,7 @@ toA
 lnr
 rQP
 uoO
-uoO
+hQE
 bqO
 nBk
 uoO
@@ -81357,7 +81343,7 @@ nBk
 nBk
 nBk
 uhE
-vsw
+wHf
 tkt
 rNO
 eRu
@@ -82890,7 +82876,7 @@ uoO
 uoO
 nBk
 dJm
-uoO
+hQE
 uoO
 uoO
 uoO
@@ -83153,8 +83139,8 @@ uoO
 uoO
 uoO
 uoO
-xPN
-uoO
+myb
+hQE
 bqO
 nBk
 uoO
@@ -83422,7 +83408,7 @@ nBk
 wHB
 nBk
 dJm
-uoO
+hQE
 eLE
 uoO
 uoO
@@ -83656,7 +83642,7 @@ oPR
 oPR
 dbx
 dcf
-uoO
+hQE
 bqO
 nBk
 uoO
@@ -83666,7 +83652,7 @@ wHB
 sHo
 lsP
 gGG
-uoO
+hQE
 nBk
 nBk
 uoO
@@ -83674,7 +83660,7 @@ uoO
 uoO
 uoO
 uoO
-isr
+fMj
 nBk
 xSW
 piI
@@ -83917,7 +83903,7 @@ nBk
 nBk
 uoO
 uoO
-uoO
+hQE
 nBk
 uoO
 lnr
@@ -84186,7 +84172,7 @@ nBk
 nAf
 uoO
 uoO
-uoO
+hQE
 wRf
 nBk
 nBk
@@ -84450,7 +84436,7 @@ nBk
 wHB
 nBk
 dJm
-uoO
+hQE
 eLE
 uoO
 uoO
@@ -85213,7 +85199,7 @@ nBk
 nBk
 wHi
 hXd
-uoO
+hQE
 uoO
 uoO
 uoO
@@ -85460,7 +85446,7 @@ uoO
 nBk
 uoO
 uoO
-uoO
+hQE
 rxw
 nBk
 nBk
@@ -86750,7 +86736,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+hQE
 nBk
 uoO
 aoj
@@ -87000,7 +86986,7 @@ xyk
 xyk
 uoO
 uoO
-xPN
+myb
 uoO
 noQ
 nBk
@@ -88290,7 +88276,7 @@ wHi
 nBk
 nBk
 nBk
-aoj
+hQE
 bqO
 nBk
 uoO

--- a/_maps/map_files/templates/dungeons/north_bunker_2.dmm
+++ b/_maps/map_files/templates/dungeons/north_bunker_2.dmm
@@ -210,10 +210,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"eG" = (
-/obj/item/reagent_containers/food/snacks/banana_split,
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/bunker)
 "eN" = (
 /mob/living/simple_animal/hostile/handy{
 	faction = list("ant")
@@ -507,10 +503,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"kq" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "ky" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -656,12 +648,6 @@
 /obj/item/seeds/sunflower/novaflower,
 /turf/open/floor/grass,
 /area/f13/bunker)
-"nU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "nW" = (
 /mob/living/simple_animal/opossum{
 	name = "Fudge"
@@ -750,10 +736,6 @@
 /area/f13/bunker)
 "pP" = (
 /obj/structure/barricade/wooden/strong,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"pQ" = (
-/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "pR" = (
@@ -1426,11 +1408,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"DM" = (
-/mob/living/simple_animal/hostile/alien,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "DY" = (
 /obj/structure/barricade/wooden/strong,
 /obj/effect/decal/cleanable/dirt,
@@ -1443,12 +1420,6 @@
 "Ee" = (
 /obj/item/circuitboard/machine/chem_master,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"Eg" = (
-/mob/living/simple_animal/hostile/alien{
-	faction = list("hostile","goodboy")
-	},
-/turf/open/floor/plasteel/showroomfloor,
 /area/f13/bunker)
 "Eo" = (
 /mob/living/simple_animal/hostile/deathclaw,
@@ -1594,11 +1565,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"HC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "HO" = (
 /obj/machinery/workbench/advanced,
 /turf/open/floor/plasteel/barber{
@@ -1729,11 +1695,6 @@
 "KN" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/grass,
-/area/f13/bunker)
-"KO" = (
-/mob/living/simple_animal/hostile/alien,
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
-/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "KR" = (
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -2139,10 +2100,6 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/grass,
 /area/f13/bunker)
-"RB" = (
-/mob/living/simple_animal/hostile/alien,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "RH" = (
 /obj/item/reagent_containers/food/snacks/grown/citrus/orange,
 /turf/open/floor/grass,
@@ -2255,9 +2212,6 @@
 	},
 /area/f13/bunker)
 "Ui" = (
-/mob/living/simple_animal/hostile/alien{
-	faction = list("hostile","goodboy")
-	},
 /obj/effect/decal/cleanable/blood/gibs/body,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/showroomfloor,
@@ -2403,10 +2357,6 @@
 	id = 806
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"XS" = (
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/turf/open/floor/plasteel/showroomfloor,
 /area/f13/bunker)
 "XX" = (
 /obj/item/fusion_fuel,
@@ -2967,7 +2917,7 @@ Rl
 xG
 bN
 Hf
-Eg
+qV
 tQ
 xG
 Rl
@@ -3041,9 +2991,9 @@ Rl
 Rl
 Rl
 xG
-eG
+qV
 sJ
-XS
+qV
 qV
 xG
 Rl
@@ -3642,10 +3592,10 @@ Rl
 Rl
 Rl
 xG
-HC
-RB
+Zf
 oj
-RB
+oj
+oj
 xG
 XM
 Bw
@@ -3682,7 +3632,7 @@ Rl
 xG
 Mf
 oj
-kq
+oj
 oj
 Pp
 yr
@@ -3719,7 +3669,7 @@ Rl
 Rl
 xG
 IY
-pQ
+oj
 Zf
 oj
 Pp
@@ -3794,10 +3744,10 @@ Rl
 Rl
 Rl
 xG
-KO
+oj
 Zf
 Zf
-DM
+Zf
 xG
 OR
 cQ
@@ -3989,7 +3939,7 @@ XM
 mj
 XM
 xG
-gk
+oj
 xG
 AE
 Bw
@@ -4065,7 +4015,7 @@ kj
 vp
 Cp
 xG
-nU
+sl
 Pp
 XM
 jX
@@ -4103,7 +4053,7 @@ XM
 mX
 XM
 xG
-DM
+Zf
 xG
 jQ
 XN
@@ -4971,7 +4921,7 @@ Rl
 Rl
 Rl
 xG
-RB
+oj
 FV
 Zf
 rC
@@ -5018,7 +4968,7 @@ oj
 YR
 gu
 oj
-RB
+oj
 oj
 Rl
 Rl
@@ -5048,7 +4998,7 @@ Rl
 Rl
 xG
 oj
-RB
+oj
 bP
 Zf
 iJ
@@ -5166,10 +5116,10 @@ oh
 oj
 XO
 XO
-RB
+oj
 oh
 oh
-RB
+oj
 oh
 XO
 Rl

--- a/_maps/map_files/templates/dungeons/north_bunker_3.dmm
+++ b/_maps/map_files/templates/dungeons/north_bunker_3.dmm
@@ -25,11 +25,6 @@
 	},
 /turf/open/floor/grass,
 /area/f13/bunker)
-"aL" = (
-/obj/effect/spawner/lootdrop/bedsheet,
-/obj/structure/bed/pod,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "aM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/workbench,
@@ -203,13 +198,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
-/obj/item/paper/fluff/stations/lavaland/sloth/note{
-	desc = "Enclave sucks, LMAO";
-	info = "Enclave is stinky";
-	name = "A note to the Enclave"
-	},
 /obj/structure/rack,
-/obj/item/clothing/accessory/medal/gold/heroism,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "fx" = (
@@ -479,7 +468,6 @@
 /area/f13/bunker)
 "mG" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf,
-/obj/item/reagent_containers/food/snacks/store/bread/spidermeat,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "mN" = (
@@ -632,9 +620,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "sA" = (
-/obj/effect/spawner/lootdrop/bedsheet,
-/obj/structure/bed/pod,
-/obj/effect/decal/cleanable/semen/femcum,
+/obj/structure/bed/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "sN" = (
@@ -664,9 +650,8 @@
 /turf/closed/indestructible/fakeglass,
 /area/f13/bunker)
 "th" = (
-/obj/effect/spawner/lootdrop/bedsheet,
-/obj/structure/bed/pod,
 /obj/item/clothing/suit/armor/f13/battlecoat/vault,
+/obj/structure/bed/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "tn" = (
@@ -991,12 +976,12 @@
 /area/f13/tunnel)
 "Ca" = (
 /obj/effect/spawner/lootdrop/bedsheet,
-/obj/structure/bed/pod,
 /obj/structure/spacevine{
 	name = "vines"
 	},
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
 /mob/living/simple_animal/hostile/supermutant,
+/obj/structure/bed/old,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "Cm" = (
@@ -1053,7 +1038,6 @@
 /obj/structure/spacevine{
 	name = "vines"
 	},
-/obj/item/dildo/flared/huge,
 /obj/machinery/light/broken{
 	dir = 8
 	},
@@ -1193,10 +1177,6 @@
 "Hb" = (
 /obj/structure/junk/small/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"HZ" = (
-/obj/structure/sign/poster/contraband/lusty_xenomorph,
-/turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
 "Ic" = (
 /turf/closed/wall/r_wall/rust{
@@ -1471,10 +1451,6 @@
 /obj/structure/chair,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"Pu" = (
-/obj/effect/decal/cleanable/cum,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "PO" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
 /turf/open/floor/grass,
@@ -1596,10 +1572,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "TI" = (
-/obj/structure/junk/small/bed,
 /obj/structure/spacevine{
 	name = "vines"
 	},
+/obj/structure/bed/old,
 /turf/open/floor/grass,
 /area/f13/bunker)
 "TM" = (
@@ -3813,7 +3789,7 @@ YT
 YT
 WC
 Xm
-aL
+Ye
 CW
 Xm
 Ye
@@ -3876,7 +3852,7 @@ YT
 WC
 Xm
 Go
-Pu
+Ye
 Xm
 wd
 Ye
@@ -4854,7 +4830,7 @@ Xm
 Gp
 Ye
 Xm
-HZ
+Xm
 Td
 eT
 Go

--- a/_maps/map_files/templates/dungeons/oasis_bunker_2.dmm
+++ b/_maps/map_files/templates/dungeons/oasis_bunker_2.dmm
@@ -53,7 +53,6 @@
 /area/f13/radiation)
 "aS" = (
 /obj/structure/bed/mattress,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /obj/effect/decal/remains/human,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
@@ -279,12 +278,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"eB" = (
-/mob/living/simple_animal/hostile/alien{
-	faction = list("ghoul")
-	},
-/turf/open/floor/padded,
-/area/f13/bunker)
 "eN" = (
 /obj/item/lipstick/random,
 /obj/structure/table,
@@ -324,21 +317,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
-"fn" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker)
-"fy" = (
-/mob/living/simple_animal/hostile/ghoul/coldferal,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker)
 "fD" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -356,16 +334,6 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"fQ" = (
-/obj/item/storage/trash_stack,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
 /area/f13/bunker)
 "fR" = (
 /obj/machinery/light/fo13colored/Aqua,
@@ -652,11 +620,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"lN" = (
-/obj/item/storage/trash_stack,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "lS" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -708,10 +671,6 @@
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/engine,
 /area/f13/radiation)
-"mF" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/padded,
-/area/f13/bunker)
 "mQ" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/mob_spawn/human/corpse/raidermelee,
@@ -919,10 +878,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"qG" = (
-/obj/structure/sign/poster/contraband/lusty_xenomorph,
-/turf/closed/wall/r_wall/rust,
-/area/f13/bunker)
 "qZ" = (
 /mob/living/simple_animal/hostile/gecko,
 /obj/effect/decal/cleanable/dirt,
@@ -962,7 +917,6 @@
 	dir = 4;
 	pixel_x = 12
 	},
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splats,
 /turf/open/floor/mineral/plastitanium,
@@ -1119,11 +1073,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"ut" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/bunker)
 "uH" = (
 /obj/effect/decal/cleanable/blood/splatter/xeno,
 /obj/effect/decal/cleanable/dirt,
@@ -1244,10 +1193,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"xs" = (
-/mob/living/simple_animal/hostile/handy/assaultron,
-/turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "xu" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -1623,11 +1568,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"Dc" = (
-/mob/living/simple_animal/hostile/handy/assaultron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "De" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plasteel/barber{
@@ -1687,7 +1627,7 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/bunker)
 "DV" = (
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -1703,7 +1643,6 @@
 	dir = 4;
 	pixel_x = -3
 	},
-/obj/effect/spawner/lootdrop/high_loot_toilet,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -1781,7 +1720,6 @@
 "ET" = (
 /obj/structure/toilet,
 /obj/effect/decal/remains/human,
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -2050,11 +1988,11 @@
 	},
 /area/f13/bunker)
 "KN" = (
-/mob/living/simple_animal/hostile/ghoul/frozenreaver,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -2762,27 +2700,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"WA" = (
-/mob/living/simple_animal/hostile/alien{
-	faction = list("ghoul")
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker)
 "WB" = (
 /obj/structure/bed,
 /obj/effect/spawner/lootdrop/bedsheet,
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/bunker)
-"WI" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "WO" = (
 /obj/structure/sink{
@@ -2803,10 +2726,6 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/bunker)
-"WR" = (
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
-/turf/open/floor/padded,
 /area/f13/bunker)
 "WS" = (
 /obj/structure/table/reinforced,
@@ -3090,9 +3009,9 @@ Zs
 rW
 fg
 fg
-Dc
+fg
 rW
-lN
+fg
 oF
 fg
 rW
@@ -3130,11 +3049,11 @@ Zs
 Zs
 Zs
 rW
-WI
+fg
 fg
 PN
 rW
-xs
+oF
 fg
 rJ
 rW
@@ -3259,7 +3178,7 @@ rW
 Zz
 Un
 uf
-ut
+uf
 tO
 uf
 uI
@@ -3459,7 +3378,7 @@ Zs
 Zs
 "}
 (12,1,1) = {"
-qG
+rW
 tY
 cw
 BJ
@@ -3932,7 +3851,7 @@ BD
 rW
 Cv
 BD
-WA
+lp
 rW
 Bb
 Ny
@@ -4058,7 +3977,7 @@ Ai
 rW
 XU
 tS
-fy
+DV
 BD
 BD
 DV
@@ -4066,7 +3985,7 @@ lp
 lp
 lp
 Qv
-fQ
+Vl
 rW
 Ua
 An
@@ -4268,10 +4187,10 @@ ec
 rW
 wc
 BA
-fn
+En
 pb
 vS
-eB
+vS
 vS
 rW
 fa
@@ -4313,8 +4232,8 @@ BA
 En
 pb
 vS
-mF
-WR
+vS
+vS
 rW
 ve
 az


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
AutoDrobe and ClothesMate have been removed, the centaurs and nightkin count in Radtown has been lowered, Enclave and Brotherhood now have clean beds unlike the rest of the Yuma wastelanders, moved the public mine ladder to where it belongs on the second z-level, removed some overpowered guns from the Oasis citizen basements, removed sex things from north bunker 3. I might have done some more small fixes but I can't recall the specifics at this moment in time.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Its just general tunes and fixes, I regret the name I gave this branch but that is the primary point of the PR, removing the vendors full of SS13 meme light roleplay clothes that do not belong in Yuma. I have a lot of work ahead of me and had to redo this.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed Autodrobe and Clothesmate, again. Removed sex toys from North Bunker 3.
tweak: Brotherhood and Enclave get clean beds. The public mine dungeon now has its z-levels aligned. Guns in Oasis undertown have been made into random lowspawn guns and the detective gets a random highspawn gun instead of a guaranteed tier 7.
balance: Oasis no longer has guaranteed tier 6, 7 and 8 guns in its lower levels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
