### PR TITLE
Enclave minor tweaks

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -9038,6 +9038,8 @@
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/fridge/standard,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
@@ -9954,6 +9956,16 @@
 /obj/item/clothing/gloves/f13/military,
 /obj/item/clothing/gloves/f13/military,
 /obj/item/clothing/gloves/f13/military,
+/obj/item/clothing/shoes/f13/enclave/serviceboots,
+/obj/item/clothing/shoes/f13/enclave/serviceboots,
+/obj/item/clothing/shoes/f13/enclave/serviceboots,
+/obj/item/clothing/shoes/f13/enclave/serviceboots,
+/obj/item/clothing/shoes/f13/enclave/serviceboots,
+/obj/item/clothing/under/f13/enclave/peacekeeper,
+/obj/item/clothing/under/f13/enclave/peacekeeper,
+/obj/item/clothing/under/f13/enclave/peacekeeper,
+/obj/item/clothing/under/f13/enclave/peacekeeper,
+/obj/item/clothing/under/f13/enclave/peacekeeper,
 /turf/open/floor/f13{
 	icon_state = "redmark"
 	},
@@ -19084,6 +19096,7 @@
 "prL" = (
 /obj/machinery/light,
 /obj/structure/table,
+/obj/item/hand_labeler,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
@@ -23689,6 +23702,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
+"sKR" = (
+/obj/structure/simple_door/metal/dirtystore,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/tunnel)
 "sLx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -25373,6 +25392,8 @@
 /obj/item/clothing/under/f13/lumberjack,
 /obj/item/clothing/under/f13/vault,
 /obj/item/clothing/under/f13/raider_leather,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
 /turf/open/floor/f13{
 	icon_state = "redmark"
 	},
@@ -25927,6 +25948,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/brotherhood/reactor)
+"uEj" = (
+/obj/machinery/processor,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/enclave)
 "uEm" = (
 /obj/effect/landmark/start/f13/enforcer,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -26624,6 +26651,18 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"vfo" = (
+/obj/structure/rack,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/enclave)
 "vfx" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -28162,10 +28201,8 @@
 	name = "MRE Crate"
 	},
 /obj/effect/spawner/lootdrop/mre,
+/obj/effect/spawner/lootdrop/mre,
 /obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/trash/f13/mre,
-/obj/item/trash/f13/mre,
-/obj/item/trash/f13/mre,
 /obj/item/trash/f13/mre,
 /obj/item/trash/f13/mre,
 /obj/item/trash/f13/mre,
@@ -28415,6 +28452,9 @@
 /area/f13/tunnel)
 "wJo" = (
 /obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/food/snacks/meat/slab/gecko,
+/obj/item/reagent_containers/food/snacks/meat/slab/gecko,
+/obj/item/reagent_containers/food/snacks/meat/slab/gecko,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
@@ -30065,6 +30105,18 @@
 /area/f13/bunker)
 "ydf" = (
 /obj/structure/rack,
+/obj/item/storage/belt/military/assault/enclave,
+/obj/item/storage/belt/military/assault/enclave,
+/obj/item/storage/belt/military/assault/enclave,
+/obj/item/storage/belt/military/assault/enclave,
+/obj/item/storage/belt/military/assault/enclave,
+/obj/item/storage/belt/military/assault/enclave,
+/obj/item/clothing/head/helmet/f13/helmet/enclave/peacekeeper,
+/obj/item/clothing/head/helmet/f13/helmet/enclave/peacekeeper,
+/obj/item/clothing/head/helmet/f13/helmet/enclave/peacekeeper,
+/obj/item/clothing/head/helmet/f13/helmet/enclave/peacekeeper,
+/obj/item/clothing/head/helmet/f13/helmet/enclave/peacekeeper,
+/obj/item/clothing/head/helmet/f13/helmet/enclave/peacekeeper,
 /turf/open/floor/f13{
 	icon_state = "redmark"
 	},
@@ -61024,9 +61076,9 @@ weW
 weW
 weW
 weW
-weW
-weW
-weW
+wWF
+tur
+wWF
 weW
 weW
 weW
@@ -61281,9 +61333,9 @@ weW
 weW
 weW
 weW
-weW
-weW
-weW
+wWF
+tur
+wWF
 weW
 weW
 weW
@@ -61539,11 +61591,11 @@ miI
 wWF
 wWF
 wWF
+sKR
+miI
+wWF
 bcM
 bcM
-pBk
-miI
-miI
 wWF
 miI
 bcM
@@ -63611,7 +63663,7 @@ joH
 wXe
 mOw
 mOw
-ydf
+vfo
 joH
 niW
 wpj
@@ -66967,7 +67019,7 @@ hvr
 joH
 niW
 ekj
-pon
+uEj
 joH
 uoO
 uoO

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -436,7 +436,7 @@ obj/item/storage/box/stingbangs
 /obj/item/storage/box/bowls/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/reagent_containers/glass/bowl(src)
-	
+
 /obj/item/storage/box/donkpockets
 	name = "box of donk-pockets"
 	desc = "<B>Instructions:</B> <I>Heat in microwave. Product will cool if not eaten within seven minutes.</I>"
@@ -1193,8 +1193,8 @@ obj/item/storage/box/stingbangs
 	illustration = null
 
 /obj/item/storage/box/mre //base MRE type.
-	name = "Nanotrasen MRE Ration Kit Menu 0"
-	desc = "A package containing food suspended in an outdated bluespace pocket which lasts for centuries. If you're lucky you may even be able to enjoy the meal without getting food poisoning."
+	name = "Enclave MRE Ration Kit Menu 0"
+	desc = "A package containing food suspended in an outdated preservation substance which lasts for centuries. If you're lucky you may even be able to enjoy the meal without getting food poisoning."
 	icon_state = "mre"
 	illustration = null
 	var/can_expire = TRUE
@@ -1219,10 +1219,10 @@ obj/item/storage/box/stingbangs
 					ENABLE_BITFIELD(S.foodtype, TOXIC)
 
 /obj/item/storage/box/mre/menu1
-	name = "\improper Nanotrasen MRE Ration Kit Menu 1"
+	name = "\improper Enclave MRE Ration Kit Menu 1"
 
 /obj/item/storage/box/mre/menu1/safe
-	desc = "A package containing food suspended in a bluespace pocket capable of lasting till the end of time."
+	desc = "A package containing food suspended in a preservation substance capable of lasting till the end of time."
 	spawner_chance = 0
 	can_expire = FALSE
 
@@ -1234,11 +1234,11 @@ obj/item/storage/box/stingbangs
 	new /obj/item/tank/internals/emergency_oxygen(src)
 
 /obj/item/storage/box/mre/menu2
-	name = "\improper Nanotrasen MRE Ration Kit Menu 2"
+	name = "\improper Enclave MRE Ration Kit Menu 2"
 
 /obj/item/storage/box/mre/menu2/safe
 	spawner_chance = 0
-	desc = "A package containing food suspended in a bluespace pocket capable of lasting till the end of time."
+	desc = "A package containing food suspended in a preservation substance capable of lasting till the end of time."
 	can_expire = FALSE
 
 /obj/item/storage/box/mre/menu2/PopulateContents()
@@ -1249,7 +1249,7 @@ obj/item/storage/box/stingbangs
 	new /obj/item/tank/internals/emergency_oxygen(src)
 
 /obj/item/storage/box/mre/menu3
-	name = "\improper Nanotrasen MRE Ration Kit Menu 3"
+	name = "\improper Enclave MRE Ration Kit Menu 3"
 	desc = "The holy grail of MREs. This item contains the fabled MRE pizza, spicy nachos and a sample of coffee instant type 2. Any NT employee lucky enough to get their hands on one of these is truly blessed."
 	icon_state = "menu3"
 	can_expire = FALSE //always fresh, never expired.
@@ -1264,11 +1264,11 @@ obj/item/storage/box/stingbangs
 	new /obj/item/tank/internals/emergency_oxygen(src)
 
 /obj/item/storage/box/mre/menu4
-	name = "\improper Nanotrasen MRE Ration Kit Menu 4"
+	name = "\improper Enclave MRE Ration Kit Menu 4"
 
 /obj/item/storage/box/mre/menu4/safe
 	spawner_chance = 0
-	desc = "A package containing food suspended in a bluespace pocket capable of lasting till the end of time."
+	desc = "A package containing food suspended in a preservation substance capable of lasting till the end of time."
 	can_expire = FALSE
 
 /obj/item/storage/box/mre/menu4/PopulateContents()

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -69,9 +69,11 @@
 	ears = 			/obj/item/radio/headset/headset_enclave
 	glasses = 		/obj/item/clothing/glasses/night
 	uniform =		/obj/item/clothing/under/f13/enclave/peacekeeper
+	accessory =     /obj/item/clothing/accessory/ncr/SGT
 	suit = 			/obj/item/clothing/suit/armor/f13/power_armor/x02
 	belt = 			/obj/item/storage/belt/military/assault/enclave
 	shoes = 		/obj/item/clothing/shoes/f13/enclave/serviceboots
+	gloves = 		/obj/item/clothing/gloves/combat
 	id = 			/obj/item/card/id/dogtag/enclave
 	suit_store =  	/obj/item/gun/energy/laser/aer12
 
@@ -147,7 +149,7 @@
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
 	ADD_TRAIT(H, TRAIT_MASTER_GUNSMITH, src)
 	ADD_TRAIT(H, TRAIT_UNETHICAL_PRACTITIONER, src) // Brainwashing
-	
+
 
 /datum/job/wasteland/enclavelt
 	title = "Enclave Lieutenant"
@@ -177,8 +179,10 @@
 	glasses = 		/obj/item/clothing/glasses/night
 	mask = 			/obj/item/clothing/mask/gas/enclave
 	uniform =		/obj/item/clothing/under/f13/enclave/officer
+	accessory =		/obj/item/clothing/accessory/ncr/LT1
 	belt = 			/obj/item/storage/belt/military/assault/enclave
 	shoes = 		/obj/item/clothing/shoes/f13/enclave/serviceboots
+	gloves = 		/obj/item/clothing/gloves/combat
 	id = 			/obj/item/card/id/dogtag/enclave
 
 	backpack_contents = list(
@@ -550,7 +554,7 @@ Raider
 	backpack_contents = list(
 		/obj/item/gun/ballistic/revolver/widowmaker=1)
 
-/datum/outfit/loadout/raider_tribal 
+/datum/outfit/loadout/raider_tribal
 	name = "Tribal Outcast"
 	suit = 		/obj/item/clothing/suit/hooded/tribaloutcast
 	uniform = 	/obj/item/clothing/under/f13/exile/tribal
@@ -725,7 +729,7 @@ Raider
 	selection_color = "#ff4747"
 	exp_requirements = 600
 	exp_type = EXP_TYPE_OUTLAW
-	
+
 	outfit = /datum/outfit/job/wasteland/f13enforcer
 
 	access = list(ACCESS_DEN)
@@ -736,7 +740,7 @@ Raider
 							/datum/outfit/loadout/hitman,
 							/datum/outfit/loadout/bodyguard)
 
-					
+
 
 
 /datum/outfit/job/wasteland/f13enforcer
@@ -804,7 +808,7 @@ Raider
 						/obj/item/kitchen/knife/combat=1
 							)
 
-							
+
 
 
 /datum/job/wasteland/f13mobboss
@@ -819,7 +823,7 @@ Raider
 	selection_color = "#ff4747"
 	exp_requirements = 1000
 	exp_type = EXP_TYPE_OUTLAW
-	
+
 	outfit = /datum/outfit/job/wasteland/f13mobboss
 
 	access = list(ACCESS_DEN)
@@ -847,7 +851,7 @@ Raider
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1, \
 		/obj/item/restraints/handcuffs=1, \
 		/obj/item/ammo_box/magazine/m10mm_p90=2, \
-		/obj/item/storage/bag/money/small/raider/mobboss)	
+		/obj/item/storage/bag/money/small/raider/mobboss)
 
 /datum/outfit/job/wasteland/f13mobboss/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -865,7 +869,7 @@ Raider
 		GLOB.all_gangs |= DM
 		DM.add_member(H)
 		H.gang = DM
-	
+
 //vigilante
 
 
@@ -887,7 +891,7 @@ Raider
 							/datum/outfit/loadout/desert_ranger,
 							/datum/outfit/loadout/bounty_hunter,
 							/datum/outfit/loadout/retired_ranger)
-		
+
 
 /datum/outfit/job/wasteland/f13vigilante
 	name = "Vigilante"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Changes MRE descriptions to "Enclave" instead of "Nanotrasen".
- Puts peacekeeper uniforms, hats, normal headsets, military belts, and random clothing to the Enclave armory.
- Adds a food processor to the kitchen and a bit more food in the freezers.
- Enclave sergeants and lieutenants now spawn with combat gloves and rank tags.

## Why It's Good For The Game

- Nanotrasen doesn't exist.
- There was no uniforms for new recruits to wear at all; No belts as well; Now there are more options for stealth operations.
- Kitchen was quite empty. Sure, they don't really have to eat thanks to the implants, but hey, food.
- Just a small detail. The path is of NCR tags, but the items themselves never mention NCR, so it works.

## Changelog
:cl:
tweak: Enclave officer snow spawn with combat gloves and rank tags on the uniform.
tweak: Enclave armory now has more clothes, hats, and belts.
tweak: Enclave kitchen is less miserable. It now has a food processor and more food in general.
/:cl:
