### PR TITLE
Gun Adjustments Sunday edition

### DIFF
--- a/_maps/RandomZLevels/VR/snowdin_VR.dmm
+++ b/_maps/RandomZLevels/VR/snowdin_VR.dmm
@@ -15678,8 +15678,7 @@
 /area/awaymission/snowdin/cave/cavern)
 "WT" = (
 /obj/structure/rack,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot{
+/obj/item/ammo_box/shotgun/buck{
 	pixel_x = 2;
 	pixel_y = 2
 	},
@@ -15687,12 +15686,8 @@
 /area/awaymission/snowdin/post/secpost)
 "Xa" = (
 /obj/structure/rack,
-/obj/item/storage/fancy/ammobox,
+/obj/item/ammo_box/shotgun/buck,
 /obj/machinery/light/small,
-/obj/item/storage/fancy/ammobox{
-	pixel_x = 2;
-	pixel_y = 2
-	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/snowdin/post/secpost)
 "XB" = (
@@ -15740,7 +15735,7 @@
 	},
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/flash,
-/obj/item/storage/fancy/ammobox,
+/obj/item/ammo_box/shotgun/buck,
 /obj/structure/fireaxecabinet{
 	pixel_y = 32
 	},

--- a/_maps/RandomZLevels/away_mission/snowdin.dmm
+++ b/_maps/RandomZLevels/away_mission/snowdin.dmm
@@ -15550,12 +15550,8 @@
 /area/awaymission/snowdin/cave/cavern)
 "Nc" = (
 /obj/structure/rack,
-/obj/item/storage/fancy/ammobox,
+/obj/item/ammo_box/shotgun/buck,
 /obj/machinery/light/small,
-/obj/item/storage/fancy/ammobox{
-	pixel_x = 2;
-	pixel_y = 2
-	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/snowdin/post/secpost)
 "NB" = (
@@ -15645,7 +15641,7 @@
 	},
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/flash,
-/obj/item/storage/fancy/ammobox,
+/obj/item/ammo_box/shotgun/buck,
 /obj/structure/fireaxecabinet{
 	pixel_y = 32
 	},
@@ -15670,11 +15666,7 @@
 /area/awaymission/snowdin/cave/cavern)
 "VV" = (
 /obj/structure/rack,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot{
-	pixel_x = 2;
-	pixel_y = 2
-	},
+/obj/item/ammo_box/shotgun/buck,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/snowdin/post/secpost)
 "VW" = (

--- a/_maps/map_files/Pahrump/old/Pahrump.dmm
+++ b/_maps/map_files/Pahrump/old/Pahrump.dmm
@@ -20059,11 +20059,10 @@
 /obj/structure/closet/crate/secure/weapon,
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/white/box,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/slugshot,
-/obj/item/storage/fancy/ammobox/slugshot,
-/obj/item/storage/fancy/ammobox/slugshot,
+/obj/item/ammo_box/shotgun/bean,
+/obj/item/ammo_box/shotgun/bean,
+/obj/item/ammo_box/shotgun/slug,
+/obj/item/ammo_box/shotgun/slug,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "bqr" = (
@@ -27479,7 +27478,7 @@
 "bQh" = (
 /obj/structure/rack,
 /obj/item/gun/ballistic/shotgun/trench,
-/obj/item/storage/fancy/ammobox/slugshot,
+/obj/item/ammo_box/shotgun/slug,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "reddirtyfull"
 	},
@@ -34661,14 +34660,9 @@
 /obj/item/restraints/legcuffs/bola,
 /obj/item/restraints/legcuffs/bola,
 /obj/item/restraints/legcuffs/bola,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
+/obj/item/ammo_box/shotgun/bean,
+/obj/item/ammo_box/shotgun/bean,
+/obj/item/ammo_box/shotgun/bean,
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -35588,7 +35582,7 @@
 /area/f13/tunnel)
 "ggk" = (
 /obj/structure/table,
-/obj/item/storage/fancy/ammobox/slugshot,
+/obj/item/ammo_box/shotgun/slug,
 /obj/item/gun/ballistic/revolver/caravan_shotgun,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
@@ -41188,8 +41182,8 @@
 /area/f13/wasteland)
 "ose" = (
 /obj/structure/table,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
+/obj/item/ammo_box/shotgun/bean,
+/obj/item/ammo_box/shotgun/bean,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -43239,12 +43233,10 @@
 /area/f13/building)
 "rrb" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
+/obj/item/ammo_box/shotgun/bean,
+/obj/item/ammo_box/shotgun/bean,
+/obj/item/ammo_box/shotgun/buck,
+/obj/item/ammo_box/shotgun/buck,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
@@ -45151,10 +45143,8 @@
 /area/f13/tunnel)
 "unQ" = (
 /obj/structure/rack,
-/obj/item/storage/fancy/ammobox/magnumshot,
-/obj/item/storage/fancy/ammobox/magnumshot,
-/obj/item/storage/fancy/ammobox/slugshot,
-/obj/item/storage/fancy/ammobox/slugshot,
+/obj/item/ammo_box/shotgun/slug,
+/obj/item/ammo_box/shotgun/slug,
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"

--- a/_maps/map_files/PossumMap/PossumParadise.dmm
+++ b/_maps/map_files/PossumMap/PossumParadise.dmm
@@ -221,12 +221,9 @@
 "aaL" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
+/obj/item/ammo_box/shotgun/buck,
+/obj/item/ammo_box/shotgun/buck,
+/obj/item/ammo_box/shotgun/buck,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/vault/security/checkpoint)
 "aaM" = (
@@ -6669,8 +6666,7 @@
 "atZ" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
-/obj/item/storage/fancy/ammobox,
-/obj/item/storage/fancy/ammobox,
+/obj/item/ammo_box/shotgun/buck,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
 /turf/open/floor/plasteel/darkred,
 /area/f13/brotherhood)

--- a/_maps/map_files/StJeromes/StJeromesValley.dmm
+++ b/_maps/map_files/StJeromes/StJeromesValley.dmm
@@ -7634,12 +7634,9 @@
 "avv" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
+/obj/item/ammo_box/shotgun/buck,
+/obj/item/ammo_box/shotgun/buck,
+/obj/item/ammo_box/shotgun/buck,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/vault/security/checkpoint)
 "avw" = (
@@ -16395,12 +16392,9 @@
 /area/f13/underground/mountain)
 "aXA" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
+/obj/item/ammo_box/shotgun/buck,
+/obj/item/ammo_box/shotgun/buck,
+/obj/item/ammo_box/shotgun/buck,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/klamat)
@@ -24062,8 +24056,7 @@
 "bve" = (
 /obj/structure/table/wood,
 /obj/item/storage/bag/trash,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
+/obj/item/ammo_box/shotgun/buck,
 /turf/open/floor/wood/f13/old,
 /area/f13/ncr)
 "bvf" = (
@@ -25946,8 +25939,7 @@
 /area/f13/legion)
 "bAf" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
+/obj/item/ammo_box/shotgun/buck,
 /obj/item/crafting/campfirekit,
 /obj/item/crafting/campfirekit,
 /obj/item/crafting/campfirekit,

--- a/_maps/map_files/Sunnyvale/Dungeons.dmm
+++ b/_maps/map_files/Sunnyvale/Dungeons.dmm
@@ -3594,10 +3594,7 @@
 /area/medical/abandoned)
 "iL" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/ammobox,
-/obj/item/storage/fancy/ammobox,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
+/obj/item/ammo_box/shotgun/buck,
 /obj/effect/turf_decal/stripes/red/full,
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/west,

--- a/_maps/map_files/Sunnyvale/Sunnyvale.dmm
+++ b/_maps/map_files/Sunnyvale/Sunnyvale.dmm
@@ -1035,14 +1035,9 @@
 /area/f13/tunnel)
 "adw" = (
 /obj/structure/closet/cardboard,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
+/obj/item/ammo_box/shotgun/buck,
+/obj/item/ammo_box/shotgun/buck,
+/obj/item/ammo_box/shotgun/buck,
 /turf/open/floor/wood/f13/old,
 /area/f13/legioncamp)
 "adx" = (
@@ -1050,14 +1045,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
+/obj/item/ammo_box/shotgun/buck,
+/obj/item/ammo_box/shotgun/buck,
+/obj/item/ammo_box/shotgun/buck,
 /turf/open/floor/wood/f13/old,
 /area/f13/legioncamp)
 "ady" = (
@@ -11002,11 +10992,9 @@
 /area/f13/underground/enclave_base)
 "aDE" = (
 /obj/structure/rack,
-/obj/item/storage/fancy/ammobox,
-/obj/item/storage/fancy/ammobox,
-/obj/item/storage/fancy/ammobox,
-/obj/item/storage/fancy/ammobox,
-/obj/item/storage/fancy/ammobox,
+/obj/item/ammo_box/shotgun/buck,
+/obj/item/ammo_box/shotgun/buck,
+/obj/item/ammo_box/shotgun/buck,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/ai_monitored/security/armory)
@@ -26177,10 +26165,8 @@
 	dir = 5
 	},
 /obj/structure/closet/crate/secure/weapon,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
+/obj/item/ammo_box/shotgun/buck,
+/obj/item/ammo_box/shotgun/buck,
 /turf/open/floor/plating,
 /area/f13/ncr_main)
 "buD" = (
@@ -32009,7 +31995,7 @@
 /area/f13/ncr_main)
 "bLP" = (
 /obj/structure/rack,
-/obj/item/storage/fancy/ammobox/lethalshot,
+/obj/item/ammo_box/shotgun/buck,
 /obj/item/gun/ballistic/shotgun/trench,
 /obj/machinery/light/small{
 	brightness = 3;

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -1067,7 +1067,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/storage/fancy/ammobox/lethalshot,
+/obj/item/ammo_box/shotgun/buck,
 /obj/item/gun/ballistic/shotgun/automatic/combat{
 	pixel_x = -2;
 	pixel_y = 2

--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -1037,7 +1037,7 @@
 /area/shuttle/caravan/pirate)
 "Yo" = (
 /obj/structure/table,
-/obj/item/storage/fancy/ammobox/lethalshot,
+/obj/item/ammo_box/shotgun/buck,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -492,10 +492,6 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 		new /datum/stack_recipe("egg box", /obj/item/storage/fancy/egg_box), 					\
 		new /datum/stack_recipe("nugget box", /obj/item/storage/fancy/nugget_box),				\
 		new /datum/stack_recipe("security-styled box", /obj/item/storage/box/seclooking), 		\
-		new /datum/stack_recipe("buckshot shell box", /obj/item/storage/fancy/ammobox/lethalshot),		\
-		new /datum/stack_recipe("rubber shot shell box", /obj/item/storage/fancy/ammobox),		\
-		new /datum/stack_recipe("beanbag shell box", /obj/item/storage/fancy/ammobox/beanbag),			\
-		new /datum/stack_recipe("slug shell box", /obj/item/storage/box/lethalslugs), 			\
 		new /datum/stack_recipe("mouse traps box", /obj/item/storage/box/mousetraps),
 		null,																					\
 		new /datum/stack_recipe("pill bottle box", /obj/item/storage/box/pillbottles),			\

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -23,7 +23,6 @@
 	new /obj/item/clothing/shoes/sneakers/black(src)
 	new /obj/item/reagent_containers/rag(src)
 	new /obj/item/reagent_containers/rag(src)
-	new /obj/item/storage/fancy/ammobox/beanbag(src)
 	new /obj/item/clothing/suit/armor/vest/alt(src)
 	new /obj/item/circuitboard/machine/dish_drive(src)
 	new /obj/item/clothing/glasses/sunglasses/reagent(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -232,7 +232,7 @@
 	..()
 	new /obj/item/storage/box/firingpins(src)
 	for(var/i in 1 to 3)
-		new /obj/item/storage/fancy/ammobox(src)
+		new /obj/item/ammo_box/shotgun/buck(src)
 /obj/structure/closet/secure_closet/armory3
 	name = "armory energy gun locker"
 	req_access = list(ACCESS_ARMORY)
@@ -260,7 +260,7 @@
 	new /obj/item/electrostaff(src)
 	new /obj/item/electrostaff(src)
 	for(var/i in 1 to 3)
-		new /obj/item/storage/fancy/ammobox/lethalshot(src)
+		new /obj/item/ammo_box/shotgun/buck(src)
 
 /obj/structure/closet/secure_closet/labor_camp_security
 	name = "labor camp security locker"

--- a/code/modules/cargo/packs/armory.dm
+++ b/code/modules/cargo/packs/armory.dm
@@ -47,8 +47,7 @@
 					/obj/item/storage/belt/bandolier,
 					/obj/item/storage/belt/bandolier,
 					/obj/item/storage/belt/bandolier,
-					/obj/item/storage/fancy/ammobox/lethalshot,
-					/obj/item/storage/box/lethalslugs)
+					/obj/item/ammo_box/shotgun/buck)
 	crate_name = "combat shotguns crate"
 
 /datum/supply_pack/security/armory/dragnetgun

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -16,14 +16,8 @@
 	name = "Ammo Crate - General Purpose"
 	desc = "Contains two 20-round magazines for the WT-550 Auto Rifle, three boxes of buckshot ammo, three boxes of rubber ammo and special .38 speedloarders. Requires Security access to open."
 	cost = 2500
-	contains = list(/obj/item/ammo_box/magazine/wt550m9,
-					/obj/item/ammo_box/magazine/wt550m9,
-					/obj/item/storage/fancy/ammobox/lethalshot,
-					/obj/item/storage/fancy/ammobox/lethalshot,
-					/obj/item/storage/fancy/ammobox/lethalshot,
-					/obj/item/storage/fancy/ammobox,
-					/obj/item/storage/fancy/ammobox,
-					/obj/item/storage/fancy/ammobox)
+	contains = list(/obj/item/ammo_box/shotgun/buck,
+					/obj/item/ammo_box/shotgun/buck)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/security/armor

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -320,7 +320,7 @@ Head Knight
 	name = "Warden-Defender"
 	backpack_contents = list(
 		/obj/item/gun/ballistic/shotgun/police=1,
-		/obj/item/storage/fancy/ammobox/lethalshot=2,
+		/obj/item/ammo_casing/shotgun/buckshot=2,
 		/obj/item/stock_parts/cell/ammo/ec=2,
 		/obj/item/gun/energy/laser/pistol=1
 		)
@@ -670,7 +670,7 @@ datum/job/bos/f13seniorknight
 	name = "Knight-Defender"
 	backpack_contents = list(
 		/obj/item/gun/ballistic/shotgun/police=1,
-		/obj/item/storage/fancy/ammobox/lethalshot=2,
+		/obj/item/ammo_casing/shotgun/buckshot=2,
 		/obj/item/stock_parts/cell/ammo/ec=2,
 		/obj/item/gun/energy/laser/pistol=1
 		)
@@ -733,7 +733,7 @@ Knight
 	backpack_contents = list(
 		/obj/item/clothing/accessory/bos/juniorknight=1,
 		/obj/item/gun/ballistic/shotgun/trench=1,
-		/obj/item/storage/fancy/ammobox/lethalshot=2
+		/obj/item/ammo_casing/shotgun/buckshot=2
 		)
 
 /datum/outfit/loadout/knightc
@@ -749,7 +749,7 @@ Knight
 	backpack_contents = list(
 		/obj/item/clothing/accessory/bos/knight=1,
 		/obj/item/gun/ballistic/shotgun/trench=1,
-		/obj/item/storage/fancy/ammobox/lethalshot=2,
+		/obj/item/ammo_casing/shotgun/buckshot=2,
 		/obj/item/shield/riot=1
 		)
 /*

--- a/code/modules/jobs/job_types/den.dm
+++ b/code/modules/jobs/job_types/den.dm
@@ -501,7 +501,7 @@ Mayor
 	backpack = /obj/item/storage/backpack/satchel/leather
 	backpack_contents = list(
 		/obj/item/storage/bag/money/small/settler = 1,
-		/obj/item/storage/fancy/ammobox/beanbag = 2
+		/obj/item/ammo_box/shotgun/bean = 2
 		)
 
 /datum/outfit/loadout/rugged

--- a/code/modules/jobs/job_types/followers.dm
+++ b/code/modules/jobs/job_types/followers.dm
@@ -360,6 +360,6 @@ Follower Guard
 	name = "Followers Close Protection Guard"
 	suit_store = /obj/item/gun/ballistic/shotgun/hunting
 	backpack_contents = list(
-		/obj/item/storage/fancy/ammobox/beanbag=1,
-		/obj/item/storage/fancy/ammobox/lethalshot=1
+		/obj/item/ammo_box/shotgun/bean=1,
+		/obj/item/ammo_casing/shotgun/buckshot=1
 	)

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -106,7 +106,7 @@
 	r_pocket =      /obj/item/storage/bag/money/small/legion
 	l_pocket = 		/obj/item/flashlight/lantern
 	r_hand = 		/obj/item/gun/ballistic/revolver/ballisticfist
-	l_hand = 		/obj/item/storage/fancy/ammobox/slugshot
+	l_hand = 		/obj/item/ammo_casing/shotgun/slug
 	backpack = 		null
 	satchel = 		null
 	box = 			/obj/item/storage/box/legate
@@ -706,7 +706,7 @@ commented out pending rework*/
 // For both : Defend camp, help out there, dont run off, Mars teachings to help make potions.
 
 /datum/job/CaesarsLegion/Legionnaire/f13campfollower
-	title = "Camp Duty"
+	title = "Legion Camp Duty"
 	flag = F13CAMPFOLLOWER
 	faction = "Legion"
 	total_positions = 2

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -106,7 +106,7 @@
 	r_pocket =      /obj/item/storage/bag/money/small/legion
 	l_pocket = 		/obj/item/flashlight/lantern
 	r_hand = 		/obj/item/gun/ballistic/revolver/ballisticfist
-	l_hand = 		/obj/item/ammo_casing/shotgun/slug
+	l_hand = 		/obj/item/ammo_box/shotgun/slug
 	backpack = 		null
 	satchel = 		null
 	box = 			/obj/item/storage/box/legate

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -846,7 +846,7 @@ Rear Echelon
 		/obj/item/metaldetector=1, \
 		/obj/item/shovel/spade=1, \
 		/obj/item/gun/ballistic/shotgun/hunting=1, \
-		/obj/item/storage/fancy/ammobox/lethalshot=2, \
+		/obj/item/ammo_casing/shotgun/buckshot=2, \
 		/obj/item/weldingtool/largetank)
 
 /datum/outfit/loadout/offduty //Fuck having an entire role just for off duty, making it a rear-eche loadout
@@ -1076,8 +1076,8 @@ Veteran Ranger
 	belt =	/obj/item/storage/belt/military/assault/ncr
 	suit_store = /obj/item/gun/ballistic/shotgun/automatic/combat/auto5
 	backpack_contents = list(
-		/obj/item/storage/fancy/ammobox/lethalshot = 1,
-		/obj/item/storage/fancy/ammobox/slugshot = 1,
+		/obj/item/ammo_casing/shotgun/buckshot = 1,
+		/obj/item/ammo_box/shotgun/slug = 1,
 		/obj/item/clothing/head/helmet/f13/combat/ncr_patrol = 1,
 		/obj/item/storage/survivalkit_aid = 1,
 		/obj/item/gun/ballistic/revolver/m29/snub=1,

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -315,8 +315,8 @@ Great Khan
 	name = "Enforcer"
 	suit_store = /obj/item/gun/ballistic/revolver/caravan_shotgun
 	backpack_contents = list(
-		/obj/item/storage/fancy/ammobox/lethalshot=1, \
-		/obj/item/storage/fancy/ammobox/beanbag=1, \
+		/obj/item/ammo_casing/shotgun/buckshot=1, \
+		/obj/item/ammo_box/shotgun/bean=1, \
 		/obj/item/restraints/legcuffs/bola/tactical=1, \
 		/obj/item/restraints/handcuffs=2)
 
@@ -496,8 +496,8 @@ Raider
 	head = /obj/item/clothing/head/helmet/f13/raider/psychotic
 	backpack_contents = list(
 		/obj/item/gun/ballistic/revolver/caravan_shotgun=1,
-		/obj/item/storage/fancy/ammobox/lethalshot=1,
-		/obj/item/storage/fancy/ammobox/beanbag=1,
+		/obj/item/ammo_casing/shotgun/buckshot=1,
+		/obj/item/ammo_box/shotgun/bean=1,
 		/obj/item/claymore/machete/pipe/tireiron=1,
 		/obj/item/claymore/machete/pipe/pan=1,
 		/obj/item/grenade/chem_grenade/cleaner=1)

--- a/code/modules/projectiles/ammunition/ballistic/pistol.dm
+++ b/code/modules/projectiles/ammunition/ballistic/pistol.dm
@@ -38,16 +38,16 @@
 	projectile_type = /obj/item/projectile/bullet/c9mm/op
 
 //14mm
-/obj/item/ammo_casing/a127mm
+/obj/item/ammo_casing/p14mm
 	name = "14mm FMJ bullet casing"
 	desc = "A 14mm FMJ bullet casing."
 	caliber = "14"
-	projectile_type = /obj/item/projectile/bullet/a127mm
+	projectile_type = /obj/item/projectile/bullet/14mm
 
-/obj/item/ammo_casing/a127mm/jhp
+/obj/item/ammo_casing/p14mm/jhp
 	name = "14mm JHP bullet casing"
 	desc = "A 14mm JHP bullet casing"
-	projectile_type = /obj/item/projectile/bullet/a127mm/jhp
+	projectile_type = /obj/item/projectile/bullet/14mm/jhp
 
 // 22lr
 /obj/item/ammo_casing/a22

--- a/code/modules/projectiles/ammunition/ballistic/pistol.dm
+++ b/code/modules/projectiles/ammunition/ballistic/pistol.dm
@@ -42,12 +42,12 @@
 	name = "14mm FMJ bullet casing"
 	desc = "A 14mm FMJ bullet casing."
 	caliber = "14"
-	projectile_type = /obj/item/projectile/bullet/14mm
+	projectile_type = /obj/item/projectile/bullet/mm14
 
 /obj/item/ammo_casing/p14mm/jhp
 	name = "14mm JHP bullet casing"
 	desc = "A 14mm JHP bullet casing"
-	projectile_type = /obj/item/projectile/bullet/14mm/jhp
+	projectile_type = /obj/item/projectile/bullet/mm14/jhp
 
 // 22lr
 /obj/item/ammo_casing/a22

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -321,14 +321,14 @@
 	icon_state = "14mmbox"
 	multiple_sprites = 2
 	caliber = "14"
-	ammo_type = /obj/item/ammo_casing/a127mm
+	ammo_type = /obj/item/ammo_casing/p14mm
 	max_ammo = 30
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron = 11000, /datum/material/blackpowder = 1500)
 
 /obj/item/ammo_box/m127mm/jhp
 	name = "ammo box (14mm JHP)"
-	ammo_type = /obj/item/ammo_casing/a127mm/jhp
+	ammo_type = /obj/item/ammo_casing/p14mm/jhp
 	custom_materials = list(/datum/material/iron = 11000)
 
 

--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -147,8 +147,9 @@
 	name = "automag magazine (.44 magnum)"
 	icon = 'icons/fallout/objects/guns/ammo.dmi'
 	icon_state = "magnum"
+	ammo_type = /obj/item/ammo_casing/m44
 	max_ammo = 7
-
+	multiple_sprites = 2
 
 //14mm
 /obj/item/ammo_box/magazine/m14mm

--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -155,7 +155,7 @@
 	name = "handgun magazine (14mm)"
 	icon = 'icons/fallout/objects/guns/ammo.dmi'
 	icon_state = "50ae"
-	ammo_type = /obj/item/ammo_casing/a127mm
+	ammo_type = /obj/item/ammo_casing/p14mm
 	caliber = "14"
 	max_ammo = 7
 	multiple_sprites = 2

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -37,6 +37,7 @@
 			src.desc += " It has an automatic sear installed."
 			src.burst_size += 1
 			src.spread += 6
+			src.recoil += 0.1
 			src.automatic_burst_overlay = TRUE
 			src.semi_auto = FALSE
 			to_chat(user, "<span class='notice'>You attach \the [A] to \the [src].</span>")
@@ -165,7 +166,7 @@
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 
 
-//Rockwell gun					Keywords: 9mm, Automatic, 20/32 rounds. Special modifiers: damage -1
+//Rockwell gun								Keywords: 9mm, Automatic, 20/32 rounds. Special modifiers: damage -1
 /obj/item/gun/ballistic/automatic/smg/rockwell
 	name = "the Rockwell gun"
 	desc = "Post-war submachine gun in 9mm, based on old schematics by T.G. Rockwell for home-made weapons if under enemy occupation. Basically a toploaded sten gun with a pistol grip, allowing makeshift magazines without a spring."
@@ -174,12 +175,13 @@
 	mag_type = /obj/item/ammo_box/magazine/uzim9mm
 	init_mag_type = /obj/item/ammo_box/magazine/uzim9mm/rockwell
 	burst_shot_delay = 3
+	recoil = 0.1
 	spread = 13
 	extra_damage = -1
 	can_attachments = TRUE
 
 
-//American 180					Keywords: .22 LR, Automatic, 180 rounds
+//American 180								Keywords: .22 LR, Automatic, 180 rounds
 /obj/item/gun/ballistic/automatic/smg/american180
 	name = "American 180"
 	desc = "An integrally suppressed submachinegun chambered in the common .22 long rifle. Top loaded drum magazine."
@@ -194,7 +196,7 @@
 	fire_sound = 'sound/f13weapons/american180.ogg'
 
 
-//Greasegun						Keywords: .45 ACP, Automatic, 30 rounds
+//Greasegun									Keywords: .45 ACP, Automatic, 30 rounds
 /obj/item/gun/ballistic/automatic/smg/greasegun
 	name = "M3A1 Grease Gun"
 	desc = "An inexpensive submachine gun chambered in .45 ACP. Slow fire rate allows the operator to conserve ammunition in controllable bursts."
@@ -225,13 +227,14 @@
 			burst_size = 1
 			fire_delay = 4.5
 			spread = 3
+			recoil = 0.1
 			weapon_weight = WEAPON_MEDIUM
 			to_chat(user, "<span class='notice'>You switch to semi-auto.</span>")
 	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
 	update_icon()
 	return
 
-//10mm SMG						Keywords: 10mm, Automatic, 12/24 rounds
+//10mm SMG									Keywords: 10mm, Automatic, 12/24 rounds
 /obj/item/gun/ballistic/automatic/smg/smg10mm
 	name = "10mm submachine gun"
 	desc = "One of the most common personal-defense weapons of the Great War, a sturdy and reliable open-bolt 10mm submachine gun."
@@ -244,6 +247,7 @@
 	suppressor_state = "10mm_suppressor" //activate if sprited 
 	suppressor_x_offset = 30
 	suppressor_y_offset = 16
+	actions_types = list(/datum/action/item_action/toggle_firemode)
 	fire_sound = 'sound/f13weapons/10mm_fire_03.ogg'
 
 /obj/item/gun/ballistic/automatic/smg/smg10mm/worn
@@ -260,6 +264,7 @@
 			burst_size = 2
 			spread = 10
 			fire_delay = 4
+			recoil = 0.1
 			weapon_weight = WEAPON_HEAVY
 			to_chat(user, "<span class='notice'>You switch to automatic fire.</span>")
 		if(1)
@@ -273,7 +278,7 @@
 	update_icon()
 	return
 
-//Uzi							Keywords: 9mm, Automatic, 32 rounds
+//Uzi										Keywords: 9mm, Automatic, 32 rounds
 /obj/item/gun/ballistic/automatic/smg/mini_uzi
 	name = "Uzi"
 	desc = "A lightweight, burst-fire submachine gun, for when you really want someone dead. Uses 9mm rounds."
@@ -288,6 +293,7 @@
 	suppressor_state = "uzi_suppressor"
 	suppressor_x_offset = 29
 	suppressor_y_offset = 16
+	actions_types = list(/datum/action/item_action/toggle_firemode)
 
 /obj/item/gun/ballistic/automatic/smg/mini_uzi/burst_select()
 	var/mob/living/carbon/human/user = usr
@@ -297,6 +303,7 @@
 			burst_size = 2
 			spread = 11
 			fire_delay = 3
+			recoil = 0.1
 			weapon_weight = WEAPON_HEAVY
 			to_chat(user, "<span class='notice'>You switch to automatic fire.</span>")
 		if(1)
@@ -310,7 +317,7 @@
 	update_icon()
 	return
 
-//Carl Gustaf					Keywords: 10mm, Automatic, 36 rounds
+//Carl Gustaf								Keywords: 10mm, Automatic, 36 rounds
 /obj/item/gun/ballistic/automatic/smg/cg45
 	name = "Carl Gustaf 10mm"
 	desc = "Post-war submachine gun made in workshops in Phoenix, a copy of a simple old foreign design."
@@ -320,11 +327,12 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	fire_delay = 3
 	spread = 9
+	recoil = 0.1
 	can_attachments = TRUE
 	fire_sound = 'sound/f13weapons/10mm_fire_03.ogg'
 
 
-//Ppsh-41						Keywords: 9mm, Automatic, 71 rounds. Special modifiers: damage -4
+//Ppsh-41									Keywords: 9mm, Automatic, 71 rounds. Special modifiers: damage -4
 /obj/item/gun/ballistic/automatic/smg/ppsh
 	name = "Ppsh-41"
 	desc = "An extremely fast firing, inaccurate submachine gun from World War 2. Low muzzle velocity. Uses 9mm rounds."
@@ -337,6 +345,7 @@
 	fire_delay = 6
 	burst_shot_delay = 1.5
 	extra_damage = -4
+	recoil = 0.25
 	can_attachments = TRUE
 	can_scope = TRUE
 	scope_state = "AEP7_scope"
@@ -344,7 +353,7 @@
 	scope_y_offset = 21
 
 
-//MP-5 SD						Keywords: 9mm, Automatic, 32 rounds, Suppressed
+//MP-5 SD									Keywords: 9mm, Automatic, 32 rounds, Suppressed
 /obj/item/gun/ballistic/automatic/smg/mp5
 	name = "MP-5 SD"
 	desc = "An integrally suppressed sub machine chambered in 9mm."
@@ -355,13 +364,14 @@
 	fire_delay = 4
 	burst_shot_delay = 2
 	suppressed = 1
+	recoil = 0.1
 	can_attachments = TRUE
 	can_suppress = FALSE
 	can_unsuppress = FALSE
 	fire_sound = 'sound/weapons/Gunshot_silenced.ogg'
 
 
-//Tommygun						Keywords: .45 ACP, Automatic, 50 rounds. Special modifiers: damage -1
+//Tommygun									Keywords: .45 ACP, Automatic, 50 rounds. Special modifiers: damage -1
 /obj/item/gun/ballistic/automatic/smg/tommygun
 	name = "ancient Thompson SMG"
 	desc = "Rusty, dinged up, but somehow still functional."
@@ -376,21 +386,23 @@
 	fire_delay = 5
 	extra_damage = -1
 	spread = 12
+	recoil = 0.5
 
 
-//P90							Keywords: 9mm, Automatic, 50 rounds. Special modifiers: damage +2
+//P90										Keywords: 10mm, Automatic, 50 rounds. Special modifiers: damage +1
 /obj/item/gun/ballistic/automatic/smg/p90
 	name = "FN P90c"
 	desc = "The Fabrique Nationale P90c was just coming into use at the time of the war. The weapon's bullpup layout, and compact design, make it easy to control. The durable P90c is prized for its reliability, and high firepower in a ruggedly-compact package. Chambered in 10mm."
 	icon_state = "p90"
 	item_state = "m90"
+	w_class = WEIGHT_CLASS_NORMAL
+	mag_type = /obj/item/ammo_box/magazine/m10mm_p90
 	burst_size = 3
 	fire_delay = 3
 	spread = 7
-	burst_shot_delay = 1.5
-	mag_type = /obj/item/ammo_box/magazine/m10mm_p90
-	w_class = WEIGHT_CLASS_NORMAL
-	extra_damage = 2
+	burst_shot_delay = 2
+	extra_damage = 1
+	recoil = 0.25
 	can_suppress = TRUE
 	suppressor_state = "pistol_suppressor"
 	suppressor_x_offset = 29
@@ -405,28 +417,13 @@
 	extra_damage = 0
 
 
+
 ////////////
 //CARBINES//
 ////////////
 
 
-//Auto-pipe rifle. The ultimate in hobo firearms. .357 autofire, inaccurate as hell, slow RoF.
-/obj/item/gun/ballistic/automatic/autopipe
-	name = "Auto-pipe rifle (.357)"
-	desc = "A belt fed pipe rifle held together with duct tape. Highly inaccurate. What could go wrong."
-	icon = 'icons/fallout/objects/guns/ballistic.dmi'
-	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'
-	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
-	icon_state = "autopipe"
-	item_state = "autopipe"
-	mag_type = /obj/item/ammo_box/magazine/autopipe
-	burst_size = 4
-	fire_delay = 26
-	burst_shot_delay = 5
-	spread = 24
-	fire_sound = 'sound/weapons/Gunshot.ogg'
-
-//M1 Carbine						Keywords: 10mm, Semi-auto, 12/24 rounds, Long barrel
+//M1 Carbine								Keywords: 10mm, Semi-auto, 12/24 rounds, Long barrel
 /obj/item/gun/ballistic/automatic/m1carbine
 	name = "m1 carbine"
 	desc = "The M1 Carbine was mass produced during some old war, and at some point NCR found stockpiles and rechambered them to 10mm to make up for the fact their service rifle production can't keep up with demand."
@@ -456,7 +453,7 @@
 	fire_sound = 'sound/f13weapons/varmint_rifle.ogg'
 
 
-//M1/n Carbine						Keywords: NCR, 10mm, Semi-auto, 12/24 rounds, Long barrel, No autosear, No tinker.  Special modifiers: damage +1
+//M1/n Carbine								Keywords: NCR, 10mm, Semi-auto, 12/24 rounds, Long barrel, No autosear, No tinker.  Special modifiers: damage +1
 /obj/item/gun/ballistic/automatic/m1carbine/m1n
 	name = "m1/n carbine"
 	desc = "An M1 Carbine with markings identifying it as issued to the NCR Mojave Expedtionary Force. Looks beat up but functional."
@@ -468,7 +465,7 @@
 	untinkerable = TRUE
 
 
-//M1A! Carbine						Keywords: 10mm, Semi-auto, 12/24 rounds, Long barrel, Folding stock.
+//M1A! Carbine								Keywords: 10mm, Semi-auto, 12/24 rounds, Long barrel, Folding stock.
 /obj/item/gun/ballistic/automatic/m1carbine/compact
 	name = "m1a1 carbine"
 	desc = "The M1A1 carbine is an improvement of the original, with this particular model having a folding stock allowing for greater mobility. Chambered in 10mm."
@@ -502,7 +499,7 @@
 	icon_state = "[initial(icon_state)][magazine ? "-[magazine.max_ammo]" : ""][chambered ? "" : "-e"][stock ? "" : "-f"]"
 
 
-//Destroyer carbine						Keywords: .45 ACP, Automatic, 30 rounds, Long barrel, Suppressor
+//Destroyer carbine							Keywords: .45 ACP, Automatic, 30 rounds, Long barrel, Suppressor
 /obj/item/gun/ballistic/automatic/destroyer
 	name = "destroyer carbine"
 	desc = "There are many ways to describe this, very few of them nice. This is a .45 caliber silenced bolt action rifle - that via the expertise of a gun runner mainlining 50 liters of psycho, mentats, and turbo - has been converted into a semi auto."
@@ -530,7 +527,7 @@
 //////////
 
 
-//Service rifle							Keywords: NCR, 5.56mm, Semi-auto, 20/30 rounds
+//Service rifle								Keywords: NCR, 5.56mm, Semi-auto, 20 (10-50) round magazine
 /obj/item/gun/ballistic/automatic/service
 	name = "service rifle"
 	desc = "A 5.56x45 semi-automatic service rifle manufactured by the NCR and issued to all combat personnel."
@@ -540,34 +537,30 @@
 	fire_delay = 4.5
 	burst_size = 1
 	spread = 1
+	can_attachments = TRUE
 	automatic_burst_overlay = FALSE
 	semi_auto = TRUE
 	can_bayonet = TRUE
 	bayonet_state = "bayonet"
-	can_attachments = TRUE
 	knife_x_offset = 22
 	knife_y_offset = 21
-	can_suppress = TRUE
-	suppressor_state = "rifle_suppressor"
-	suppressor_x_offset = 28
-	suppressor_y_offset = 30
 	fire_sound = 'sound/f13weapons/varmint_rifle.ogg'
 
 
-//R82 Heavy service rifle				Keywords: NCR, 5.56mm, Semi-auto, 20/30 rounds
+//R82 Heavy service rifle					Keywords: NCR, 5.56mm, Semi-auto, 20 (10-50) round magazine
 /obj/item/gun/ballistic/automatic/service/r82
 	name = "R82 heavy service rifle"
 	desc = "The assault rifle variant of the R84, based off the pre-war FN FNC. Issued to high-ranking troopers and specialized units. Chambered in 5.56."
 	icon_state = "R82"
 	item_state = "R84"
-	spread = 2
 	fire_delay = 4
+	can_suppress = TRUE
 	suppressor_state = "rifle_suppressor"
 	suppressor_x_offset = 27
 	suppressor_y_offset = 28
 
 
-//Scout carbine							Keywords: NCR, 5.56mm, Semi-auto, 20/30 rounds. Special modifiers: spread +1
+//Scout carbine								Keywords: NCR, 5.56mm, Semi-auto, 20 (10-50) round magazine. Special modifiers: spread -1
 /obj/item/gun/ballistic/automatic/service/carbine
 	name = "scout carbine"
 	desc = "A cut down version of the standard-issue service rifle tapped with mounting holes for a scope. Shorter barrel, lower muzzle velocity."
@@ -583,7 +576,7 @@
 	suppressor_y_offset = 28
 
 
-//Marksman carbine						Keywords: 5.56mm, Semi-auto, 20/30 rounds. Special modifiers: damage +1
+//Marksman carbine							Keywords: 5.56mm, Semi-auto, 20 (10-50) round magazine. Special modifiers: damage +1
 /obj/item/gun/ballistic/automatic/marksman
 	name = "marksman carbine"
 	desc = "A marksman carbine built off the AR platform chambered in 5.56x45. Seen heavy usage in pre-war conflicts. This particular model is a civilian version and is semi-auto only."
@@ -612,7 +605,7 @@
 	fire_sound = 'sound/f13weapons/marksman_rifle.ogg'
 
 
-//Colt Rangemaster						Keywords: 7.62mm, Semi-auto, 10/20 rounds
+//Colt Rangemaster							Keywords: 7.62mm, Semi-auto, 10/20 round magazine
 /obj/item/gun/ballistic/automatic/rangemaster
 	name = "Colt Rangemaster"
 	desc = "A Colt Rangemaster semi-automatic rifle, chambered for 7.62x51. Single-shot only."
@@ -637,7 +630,7 @@
 	fire_sound = 'sound/f13weapons/hunting_rifle.ogg'
 
 
-// Enfield SLR							Keywords: 7.62mm, Semi-auto, 10/20 rounds
+// Enfield SLR								Keywords: 7.62mm, Semi-auto, 10/20 round magazine
 /obj/item/gun/ballistic/automatic/slr
 	name = "Enfield SLR"
 	desc = "A self-loading rifle in 7.62mm NATO. Semi-auto only."
@@ -665,7 +658,7 @@
 	fire_sound = 'sound/f13weapons/hunting_rifle.ogg'
 
 
-//M1 Garand								Keywords: .308, Semi-auto, 8 rounds
+//M1 Garand									Keywords: .308, Semi-auto, 8 rounds internal
 /obj/item/gun/ballistic/automatic/m1garand
 	name = "M1 Garand"
 	desc = "The WWII American Classic. Still has that satisfiying ping."
@@ -699,14 +692,14 @@
 	if(.)
 		return
 
-//Old Glory								Keywords: Unique, .308, Semi-auto, 18 rounds. Special modifiers: damage +10
+//Old Glory									Keywords: UNIQUE, .308, Semi-auto, 8 rounds internal. Special modifiers: damage +10
 /obj/item/gun/ballistic/automatic/m1garand/oldglory
 	name = "Old Glory"
 	desc = "This Machine kills communists!"
 	icon_state = "oldglory"
 	extra_damage = 10
 
-//Republics Pride						Keywords: Unique, 7.62mm, Semi-auto, 8 rounds. Special modifiers: damage +8, penetration +0.1
+//Republics Pride							Keywords: UNIQUE, 7.62mm, Semi-auto, 8 rounds internal. Special modifiers: damage +8, penetration +0.1
 /obj/item/gun/ballistic/automatic/m1garand/republicspride
 	name = "Republic's Pride"
 	desc = "A well-tuned scoped M1C rifle crafted by master gunsmith from the Gunrunners. Chambered in 7.62x51."
@@ -720,7 +713,7 @@
 	can_scope = FALSE
 
 
-//SKS									Keywords: LEGION, .308, Semi-auto, 10 rounds. Special modifiers: penetration +0.1
+//SKS										Keywords: LEGION, .308, Semi-auto, 10 rounds internal. Special modifiers: penetration +0.1
 /obj/item/gun/ballistic/automatic/m1garand/sks
 	name = "SKS"
 	desc = "Old hunting rifle taken from disovered stockpiles and refurbished in Phoenix workshops. The standard heavy rifle of the Legion, still rare. .308, semi-auto only, internal magazine."
@@ -742,13 +735,13 @@
 	fire_sound = 'sound/f13weapons/hunting_rifle.ogg'
 
 
-//DKS 501 sniper rifle					Keywords: .308, Semi-auto, 7 rounds. Special modifiers: extra projectile speed +500, fire delay +4
+//DKS 501 sniper rifle						Keywords: .308, Semi-auto, 7 round magazine. Special modifiers: extra projectile speed +500, fire delay +4
 /obj/item/gun/ballistic/automatic/marksman/sniper
 	name = "sniper rifle"
 	desc = "A DKS 501, chambered in .308 Winchester.  With a light polymer body, it's suited for long treks through the desert."
-	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "sniper_rifle"
 	item_state = "sniper_rifle"
+	w_class = WEIGHT_CLASS_NORMAL
 	mag_type = /obj/item/ammo_box/magazine/w308
 	fire_delay = 10
 	burst_size = 1
@@ -771,7 +764,7 @@
 //////////////////
 
 
-//R91 assault rifle						Keywords: 5.56mm, Automatic, 20/30 rounds
+//R91 assault rifle							Keywords: 5.56mm, Automatic, 20 (10-50) round magazine
 /obj/item/gun/ballistic/automatic/assault_rifle
 	name = "r91 assault rifle"
 	desc = "A standard R91 assault rifle, out of use around the time of the Great War."
@@ -780,6 +773,7 @@
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
 	fire_delay = 4
 	spread = 7
+	recoil = 0.1
 	can_attachments = TRUE
 	can_bayonet = TRUE
 	bayonet_state = "rifles"
@@ -793,16 +787,18 @@
 	fire_sound = 'sound/f13weapons/varmint_rifle.ogg'
 
 
-//Infiltrator							Keywords: 5.56mm, Automatic, 20/30 rounds, Suppressed
+//Infiltrator								Keywords: 5.56mm, Automatic, 20 (10-50) round magazine, Suppressed. Special modifiers: damage -2, spread -2
 /obj/item/gun/ballistic/automatic/assault_rifle/infiltrator
 	name = "infiltrator"
 	desc = "A customized R91 assault rifle, with an integrated suppressor, cut down stock and polymer furniture."
 	icon_state = "infiltrator"
 	item_state = "fnfal"
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
+	extra_damage = -2
 	spread = 5
 	fire_delay = 3.5
 	burst_shot_delay = 2
+	recoil = 0.1
 	can_suppress = FALSE
 	can_unsuppress = FALSE
 	suppressed = 1
@@ -814,7 +810,7 @@
 	fire_sound = 'sound/weapons/Gunshot_large_silenced.ogg'
 
 
-//Type 93 Chinese rifle					Keywords: 5.56mm, Automatic, 20/30 rounds
+//Type 93 Chinese rifle						Keywords: 5.56mm, Automatic, 20 (10-50) round magazine
 /obj/item/gun/ballistic/automatic/type93
 	name = "type 93 assault rifle"
 	desc = "The Type 93 Chinese assault rifle was designed and manufactured by a Chinese industrial conglomerate for the People's Liberation Army during the Resource Wars, for the purpose of equipping the Chinese infiltrators and American fifth-columnists. Chambered in 5.56x45."
@@ -824,6 +820,7 @@
 	fire_delay = 4
 	spread = 10
 	extra_damage = 1
+	recoil = 0.1
 	can_suppress = TRUE
 	suppressor_state = "rifle_suppressor"
 	suppressor_x_offset = 27
@@ -842,7 +839,7 @@
 	extra_damage = -3
 	can_suppress = FALSE
 
-//Bozar									Keywords: 5.56mm, Automatic, 20/30 rounds, Suppressed 
+//Bozar										Keywords: 5.56mm, Automatic, 20 (10-50) round magazine
 /obj/item/gun/ballistic/automatic/bozar
 	name = "Bozar"
 	desc = "The ultimate refinement of the sniper's art, the Bozar is a scoped, accurate, light machine gun that will make nice big holes in your enemy. Uses 5.56."
@@ -854,6 +851,7 @@
 	burst_shot_delay = 1
 	fire_delay = 3
 	spread = 4
+	recoil = 0.1
 	can_attachments = FALSE
 	zoomable = TRUE
 	zoom_amt = 10
@@ -863,7 +861,7 @@
 	fire_sound = 'sound/f13weapons/bozar_fire.ogg'
 
 
-//CAR-15								Keywords: 5.56mm, Automatic, 20/30 rounds
+//CAR-15									Keywords: 5.56mm, Automatic, 20 (10-50) round magazine, Flashlight
 /obj/item/gun/ballistic/automatic/assault_carbine
 	name = "CAR-15 carbine"
 	desc = "A CAR-15 assault carbine, designated as the 'R8' in the U.S. Army. A variant of the R84 with increased rate of fire and a matte black exterior."
@@ -871,9 +869,10 @@
 	item_state = "assault_carbine"
 	slot_flags = 0
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
-	fire_delay = 3
-	burst_shot_delay = 1
+	fire_delay = 3.5
+	burst_shot_delay = 2
 	spread = 10
+	recoil = 0.1
 	can_attachments = TRUE
 	can_scope = TRUE
 	scope_state = "scope_short"
@@ -883,11 +882,15 @@
 	suppressor_state = "rifle_suppressor"
 	suppressor_x_offset = 26
 	suppressor_y_offset = 28
+	can_flashlight = TRUE
+	gunlight_state = "flightangle"
+	flight_x_offset = 21
+	flight_y_offset = 21
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 	fire_sound = 'sound/f13weapons/assault_carbine.ogg'
 
 
-//FN-FAL								Keywords: 7.62mm, Automatic, 10/20 rounds
+//FN-FAL									Keywords: 7.62mm, Automatic, 10/20 round magazine
 /obj/item/gun/ballistic/automatic/fnfal
 	name = "FN FAL"
 	desc = "This rifle has been more widely used by armed forces than any other rifle in history. It's a reliable assault weapon for any terrain or tactical situation."
@@ -898,6 +901,7 @@
 	mag_type = /obj/item/ammo_box/magazine/m762
 	spread = 12
 	fire_delay = 4
+	recoil = 0.25
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 	fire_sound = 'sound/f13weapons/assaultrifle_fire.ogg'
 
@@ -908,7 +912,7 @@
 ////////////////
 
 
-//R84 Light machinegun					Keywords: 5.56mm, Automatic, 60 rounds.  Special modifiers: damage decrease with burst size for balance reasons
+//R84 Light machinegun						Keywords: NCR, 5.56mm, Automatic, 60 rounds. Special modifiers: damage decrease bullethose
 /obj/item/gun/ballistic/automatic/r84
 	name = "R84 LMG"
 	desc = "A light machinegun using 60 round belts fed from an ammobox, its one of the few heavy weapons designs NCR has produced."
@@ -931,21 +935,21 @@
 			burst_size = 2
 			spread = 12
 			extra_damage = -3
-			recoil = 0.5
+			recoil = 0.25
 			to_chat(user, "<span class='notice'>You switch to burst fire.</span>")
 		if(1)
 			select = 0
 			burst_size = 5
 			spread = 16
 			extra_damage = -6
-			recoil = 1
+			recoil = 0.75
 			to_chat(user, "<span class='notice'>You switch to full auto.</span>")
 	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
 	update_icon()
 	return
 
 
-//LSW squad support weapon. 5.56.
+//LSW squad support weapon					Keywords: 5.56mm, Automatic, 20 (10-50) round magazine. Special modifiers: damage decrease bullethose
 /obj/item/gun/ballistic/automatic/lsw
 	name = "LSW (Light Support Weapon)"
 	desc = "This squad-level support weapon has a bullpup design. The bullpup design makes it difficult to use while lying down. Because of this it was remanded to National Guard units. It, however, earned a reputation as a reliable weapon that packs a lot of punch for its size."
@@ -962,10 +966,32 @@
 	zoom_out_amt = 13
 	can_attachments = TRUE
 	can_scope = FALSE
+	actions_types = list(/datum/action/item_action/toggle_firemode)
+	fire_sound = 'sound/f13weapons/assaultrifle_fire.ogg'
+
+/obj/item/gun/ballistic/automatic/lsw/burst_select()
+	var/mob/living/carbon/human/user = usr
+	switch(select)
+		if(0)
+			select += 1
+			burst_size = 2
+			spread = 8
+			extra_damage = -3
+			recoil = 0.25
+			to_chat(user, "<span class='notice'>You switch to burst fire.</span>")
+		if(1)
+			select = 0
+			burst_size = 4
+			spread = 12
+			extra_damage = -4
+			recoil = 0.5
+			to_chat(user, "<span class='notice'>You switch to full auto.</span>")
+	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
+	update_icon()
+	return
 
 
-
-//M1919 Machinegun. 7.62.
+//M1919 Machinegun							Keywords: LEGION, 7.62mm, Automatic, 80 round belt. Special modifiers: damage decrease bullethose
 /obj/item/gun/ballistic/automatic/m1919
 	name = "Browning M1919"
 	desc = "An old pre-war machine gun used in service by the US Military around the time of the war. Rechambered in 7.62x51."
@@ -974,7 +1000,6 @@
 	slot_flags = 0
 	slowdown = 2
 	mag_type = /obj/item/ammo_box/magazine/mm762
-	fire_sound = 'sound/f13weapons/assaultrifle_fire.ogg'
 	burst_size = 1
 	burst_shot_delay = 1.5
 	fire_delay = 3
@@ -983,6 +1008,7 @@
 	can_attachments = FALSE
 	var/cover_open = FALSE
 	actions_types = list(/datum/action/item_action/toggle_firemode)
+	fire_sound = 'sound/f13weapons/assaultrifle_fire.ogg'
 
 /obj/item/gun/ballistic/automatic/m1919/update_icon()
 	icon_state = "M38[cover_open ? "open" : "closed"][magazine ? CEILING(get_ammo(0)/20, 1)*20 : "-empty"]"
@@ -1065,6 +1091,23 @@
 ////////
 
 
+//Auto-pipe rifle. The ultimate in hobo firearms. .357 autofire, inaccurate as hell, slow RoF.
+/obj/item/gun/ballistic/automatic/autopipe
+	name = "Auto-pipe rifle (.357)"
+	desc = "A belt fed pipe rifle held together with duct tape. Highly inaccurate. What could go wrong."
+	icon = 'icons/fallout/objects/guns/ballistic.dmi'
+	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'
+	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
+	icon_state = "autopipe"
+	item_state = "autopipe"
+	mag_type = /obj/item/ammo_box/magazine/autopipe
+	burst_size = 4
+	fire_delay = 26
+	burst_shot_delay = 5
+	spread = 24
+	fire_sound = 'sound/weapons/Gunshot.ogg'
+
+
 //M72 Gauss rifle
 /obj/item/gun/ballistic/automatic/m72
 	name = "\improper M72 gauss rifle"
@@ -1089,8 +1132,8 @@
 	icon_state = "xl70e3"
 	item_state = "xl70e3"
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
-	fire_delay = 1
-	burst_shot_delay = 1
+	fire_delay = 2
+	burst_shot_delay = 2
 	spawnwithmagazine = TRUE
 	spread = 4
 	can_attachments = TRUE
@@ -1105,13 +1148,13 @@
 	icon_state = "g11"
 	item_state = "g11"
 	mag_type = /obj/item/ammo_box/magazine/m473
-	fire_delay = 2
-	burst_shot_delay = 1.0
+	fire_delay = 2.5
+	burst_shot_delay = 1.5
 	can_attachments = TRUE
 	can_automatic = TRUE
 	semi_auto = TRUE
 	can_scope = FALSE
-	spread = 10
+	spread = 9
 	zoomable = TRUE
 	zoom_amt = 10
 	zoom_out_amt = 13
@@ -1121,8 +1164,8 @@
 	icon_state = "g11e"
 	item_state = "g11e"
 	fire_delay = 2.0
-	burst_shot_delay = 1
-	spread = 5
+	burst_shot_delay = 1.25
+	spread = 7
 
 
 

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -18,6 +18,7 @@
 	fire_delay = 4
 	select = FALSE
 	automatic_burst_overlay = FALSE
+	can_automatic = FALSE
 	semi_auto = TRUE
 	can_suppress = TRUE
 	equipsound = 'sound/f13weapons/equipsounds/pistolequip.ogg'
@@ -40,7 +41,7 @@
 ///////////
 
 
-//.22 Sport			Keywords: .22, Semi-auto, Suppressed
+//.22 Sport						Keywords: .22, Semi-auto, 16 round magazine, Suppressed
 /obj/item/gun/ballistic/automatic/pistol/pistol22
 	name = ".22 pistol"
 	desc = "The silenced .22 pistol is a sporting handgun with an integrated silencer."
@@ -53,7 +54,7 @@
 	fire_sound = 'sound/f13weapons/22pistol.ogg'
 
 
-//N99  10mm			Keywords: 10mm, Semi-auto, 12/24 rounds
+//N99  10mm						Keywords: 10mm, Semi-auto, 12/24 round magazine
 /obj/item/gun/ballistic/automatic/pistol/n99
 	name = "10mm pistol"
 	desc = "A pre-war large-framed, gas-operated advanced 10mm pistol."
@@ -66,7 +67,7 @@
 	suppressor_y_offset = 15
 	fire_sound = 'sound/f13weapons/10mm_fire_02.ogg'
 
-//the Executive		Keywords: Unique, 10mm, Automatic, 12/24 rounds. Special modifiers: damage +4
+//the Executive					Keywords: Unique, 10mm, Automatic, 12/24 round magazine. Special modifiers: damage +4
 /obj/item/gun/ballistic/automatic/pistol/n99/executive
 	name = "the Executive"
 	desc = "A modified N99 pistol with an accurate two-round-burst and a blue Vault-Tec finish, a status symbol for some Overseers."
@@ -77,7 +78,7 @@
 	can_automatic = FALSE
 
 
-//Type 17			Keywords: 10mm, Semi-auto, 12/24 rounds. Special modifiers: damage +1
+//Type 17						Keywords: 10mm, Semi-auto, 12/24 round magazine. Special modifiers: damage +1
 /obj/item/gun/ballistic/automatic/pistol/type17
 	name = "Type 17"
 	desc = "Chinese military sidearm at the time of the Great War. The ones around are old and worn, but somewhat popular due to the long barrel and rechambered in 10mm after the original ammo ran dry decades ago."
@@ -90,20 +91,20 @@
 	fire_sound = 'sound/f13weapons/10mm_fire_02.ogg'
 
 
-//Browning Hi-power		Keywords: 9mm, Semi-auto, 10 rounds
+//Browning Hi-power				Keywords: 9mm, Semi-auto, 10 round magazine
 /obj/item/gun/ballistic/automatic/pistol/ninemil
 	name = "Browning Hi-power"
 	desc = "A mass produced pre-war Browning Hi-power 9mm pistol."
 	icon_state = "ninemil"
 	mag_type = /obj/item/ammo_box/magazine/m9mm
-	fire_delay = 4
+	fire_delay = 3.5
 	can_attachments = TRUE
 	suppressor_state = "pistol_suppressor"
 	suppressor_x_offset = 30
 	suppressor_y_offset = 19
 	fire_sound = 'sound/f13weapons/ninemil.ogg'
 
-//Maria				Keywords: Unique, 9mm, Semi-auto, 10 rounds. Special modifiers: fire delay -1, damage +10, penetration +0.2
+//Maria							Keywords: Unique, 9mm, Semi-auto, 10 round magazine. Special modifiers: fire delay -1, damage +10, penetration +0.2
 /obj/item/gun/ballistic/automatic/pistol/ninemil/maria
 	name = "Maria"
 	desc = "An ornately-decorated pre-war Browning Hi-power 9mm pistol with pearl grips and a polished nickel finish. The firing mechanism has been upgraded, so for anyone on the receiving end, it must seem like an eighteen-karat run of bad luck."
@@ -113,7 +114,7 @@
 	extra_penetration = 0.2
 
 
-//Sig Sauer P220	Keywords: 9mm, Semi-auto, 10 rounds
+//Sig Sauer P220				Keywords: 9mm, Semi-auto, 10 round magazine
 /obj/item/gun/ballistic/automatic/pistol/sig
 	name = "Sig P220"
 	desc = "The P220 Sig Sauer. A Swiss designed pistol that is compact and has a good rate of fire."
@@ -128,12 +129,13 @@
 	fire_sound = 'sound/f13weapons/9mm.ogg'
 
 
-//Beretta M9FS		Keywords: 9mm, Semi-auto, 15 rounds. Special modifiers: spread -1
+//Beretta M9FS					Keywords: 9mm, Semi-auto, 15 round magazine. Special modifiers: spread -1
 /obj/item/gun/ballistic/automatic/pistol/beretta
 	name = "Beretta M9FS"
 	desc = "One of the more common 9mm pistols, the Beretta is popular due to its reliability, 15 round magazine and good looks."
 	icon_state = "beretta"
 	mag_type = /obj/item/ammo_box/magazine/m9mmds
+	fire_delay = 3.7
 	spread = 1
 	can_attachments = TRUE
 	can_suppress = "pistol_suppressor"
@@ -141,7 +143,7 @@
 	suppressor_y_offset = 20
 	fire_sound = 'sound/f13weapons/9mm.ogg'
 
-//Beretta M93R		Keywords: 9mm, Automatic, 15 rounds
+//Beretta M93R					Keywords: 9mm, Automatic, 15 round magazine
 /obj/item/gun/ballistic/automatic/pistol/beretta/automatic
 	name = "Beretta M93R"
 	desc = "A rare select fire variant of the M93R."
@@ -149,13 +151,36 @@
 	burst_size = 2
 	burst_shot_delay = 2.5
 	spread = 8
+	recoil = 0.1
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 	automatic_burst_overlay = TRUE
 	can_attachments = FALSE
 	semi_auto = FALSE
+	actions_types = list(/datum/action/item_action/toggle_firemode)
+
+/obj/item/gun/ballistic/automatic/pistol/beretta/automatic/burst_select()
+	var/mob/living/carbon/human/user = usr
+	switch(select)
+		if(0)
+			select += 1
+			burst_size = 2
+			spread = 9
+			recoil = 0.1
+			weapon_weight = WEAPON_HEAVY
+			to_chat(user, "<span class='notice'>You switch to automatic fire.</span>")
+		if(1)
+			select = 0
+			burst_size = 1
+			spread = 2
+			recoil = 0
+			weapon_weight = WEAPON_MEDIUM
+			to_chat(user, "<span class='notice'>You switch to semi-auto.</span>")
+	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
+	update_icon()
+	return
 
 
-//M1911				Keywords: .45 ACP, Semi-auto, 8 rounds. Special modifiers: damage +1
+//M1911							Keywords: .45 ACP, Semi-auto, 8 round magazine. Special modifiers: damage +1
 /obj/item/gun/ballistic/automatic/pistol/m1911
 	name = "M1911"
 	desc = "A classic .45 handgun with a small magazine capacity."
@@ -170,14 +195,14 @@
 	suppressor_y_offset = 21
 	fire_sound = 'sound/f13weapons/45revolver.ogg'
 
-//M1911	Custom		Keywords: .45 ACP, Semi-auto, 8 rounds. Special modifiers: damage +1
+//M1911	Custom					Keywords: .45 ACP, Semi-auto, 8 round magazine. Special modifiers: damage +1
 /obj/item/gun/ballistic/automatic/pistol/m1911/custom
 	name = "M1911 Custom"
 	desc = "A well-maintained stainless-steel frame 1911, with genuine wooden grips."
 	icon_state = "m1911_custom"
 	fire_delay = 3
 
-//M1911	compac		Keywords: .45 ACP, Semi-auto, Short barrel, 8 rounds. Special modifiers: damage +1
+//M1911	compact					Keywords: .45 ACP, Semi-auto, Short barrel, 8 round magazine. Special modifiers: damage +1
 /obj/item/gun/ballistic/automatic/pistol/m1911/compact
 	name = "M1911 compact"
 	desc = "The compact version of the classic .45 handgun."
@@ -192,13 +217,13 @@
 	spawnwithmagazine = FALSE
 
 
-//Mk. 23			Keywords: .45 ACP, Semi-auto, Long barrel (lasersight), 12 rounds
+//Mk. 23						Keywords: .45 ACP, Semi-auto, Long barrel (lasersight), 12 round magazine, Flashlight
 /obj/item/gun/ballistic/automatic/pistol/mk23
 	name = "Mk. 23"
 	desc = "A very tactical pistol chambered in .45 ACP with a built in laser sight and attachment point for a seclite."
 	icon_state = "mk23"
 	mag_type = /obj/item/ammo_box/magazine/m45exp
-	fire_delay = 3
+	fire_delay = 3.5
 	extra_damage = 2
 	spread = 1
 	can_flashlight = TRUE
@@ -211,7 +236,7 @@
 	fire_sound = 'sound/f13weapons/45revolver.ogg'
 
 
-//Desert Eagle		Keywords: .44 Magnum, Semi-auto, Long barrel, 8 rounds, Heavy. Special modifiers: bullet speed +300 and damage +1
+//Desert Eagle					Keywords: .44 Magnum, Semi-auto, Long barrel, 8 round magazine, Heavy. Special modifiers: bullet speed +300, damage +1
 /obj/item/gun/ballistic/automatic/pistol/deagle
 	name = "Desert Eagle"
 	desc = "A robust .44 magnum semi-automatic handgun."
@@ -228,24 +253,24 @@
 	fire_sound = 'sound/f13weapons/44mag.ogg'
 
 
-//Automag			Keywords: .44 Magnum, Semi-auto, Long barrel, 7 rounds, Heavy. Special modifiers: bullet speed +300
+//Automag						Keywords: .44 Magnum, Semi-auto, Long barrel, 7 rounds, Heavy. Special modifiers: bullet speed +300
 /obj/item/gun/ballistic/automatic/pistol/automag
 	name = "Automag"
 	desc = "A long-barreled .44 magnum semi-automatic handgun."
 	icon_state = "automag"
 	item_state = "deagle"
-//	mag_type = /obj/item/ammo_box/magazine/automag
+	mag_type = /obj/item/ammo_box/magazine/automag
 	weapon_weight = WEAPON_MEDIUM 
 	extra_damage = 2
 	extra_speed = 300
-	fire_delay = 3.5
+	fire_delay = 3.7
 	recoil = 0.1
 	can_suppress = FALSE
 	automatic_burst_overlay = FALSE
 	fire_sound = 'sound/f13weapons/44mag.ogg'
 
 
-//14mm Pistol		Keywords: 14mm, Semi-auto, 7 rounds, Heavy
+//14mm Pistol					Keywords: 14mm, Semi-auto, 7 rounds, Heavy
 /obj/item/gun/ballistic/automatic/pistol/pistol14
 	name = "14mm pistol"
 	desc = "A Swiss SIG-Sauer 14mm handgun, powerful but a little inaccurate"
@@ -257,7 +282,7 @@
 	can_suppress = FALSE
 	fire_sound = 'sound/f13weapons/magnum_fire.ogg'
 
-//14mm compact		Keywords: 14mm, Semi-auto, Short barrel, 7 rounds, Heavy
+//14mm compact					Keywords: 14mm, Semi-auto, Short barrel, 7 rounds, Heavy
 /obj/item/gun/ballistic/automatic/pistol/pistol14/compact
 	name = "compact 14mm pistol"
 	desc = "A Swiss SIG-Sauer 14mm handgun, this one is a compact model for concealed carry."
@@ -266,7 +291,7 @@
 	extra_damage = -2
 	spread = 5
 
-//Little Devil		Keywords: Unique, 14mm, Semi-auto, Short barrel, 7 Rounds, Heavy. Special modifiers: damage +4, penetration +0.05, spread -3
+//Little Devil					Keywords: Unique, 14mm, Semi-auto, Short barrel, 7 Rounds, Heavy. Special modifiers: damage +4, penetration +0.05, spread -3
 /obj/item/gun/ballistic/automatic/pistol/pistol14/lildevil
 	name= "Little Devil 14mm pistol"
 	desc = "A Swiss SIG-Sauer 14mm handgun, this one is a finely tuned custom firearm from the Gunrunners."

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -67,19 +67,20 @@ BULK
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 
-PARTS
+TRAITS
 
 	PISTOL GRIP/FOLDED STOCK MALUS
 	For rifles, not pistols obviously
-	recoil = +0.5 //Standard malus for pistol grip
-	spread = +2 //Standard malus for pistol grip
+	recoil = 0.5
+	spread = +2 (not for shotguns)
+	w_class = WEIGHT_CLASS_NORMAL
 
 	SAWN OFF
 	recoil = 1
 	spread = 10
 	weapon_weight = WEAPON_LIGHT
 
-	LONG BARREL
+	LONG BARREL/LASERSIGHT
 	extra_damage = +2
 	spread = -1
 
@@ -94,6 +95,12 @@ PARTS
 	AMMO RECOIL BASE VALUES
 	.50  recoil = 1
 	.45/70  recoil = 0.25
+
+	2-ROUND BURTS
+	recoil = 0.1
+
+	3-ROUND BURST
+	recoil = 0.25
 
 
 FORCE 	Delicate, clumsy or small gun force 10
@@ -115,6 +122,7 @@ ATTACHMENTS
 	AUTO SEAR
 	Enables fire select automatic
 	burst_size + 1
+	recoil = +´0.1
 	spread + 6 (to bring it into the automatic template range)
 */
 

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -5,14 +5,16 @@
 //////////////////////
 /*
 FMJ (full metal jacket)		=	Baseline
-AP (armor piercing)			=	-10% damage. AP increased by 0.2. Wound bonus -50%
-JHP (jacketed hollow point)	=	+10% damage. AP reduced by 0.2. Wound bonus + 50%
+AP (armor piercing)			=	-20% damage. AP increased by 0.2. Wound bonus -50%
+JHP (jacketed hollow point)	=	+15% damage. AP reduced by 0.2 (not below zero). Wound bonus + 50%
 SWC (semi wadcutter)		=	AP reduced by 0.1. Wound bonus +50%
 P+ (overpressure)			=	extra speed 500. AP + 01. Wound bonus -25%
 Match						=	extra speed 200. AP +0.05. Wound bonus -10%
 Civilian round				=	-10% damage. AP reduced by 50% 
 */
 
+// Explanation: Two major ammo stats, AP and Damage. Bullets placed in classes. Light rounds for example balanced with each other, one more AP, one more Damage.
+// Balance between classes mostly done on the gun end, bigger rounds typically fire slower and have more recoil. They are not supposed to be totally equal either.
 
 ////////////////////
 // .22 LONG RIFLE //
@@ -26,8 +28,8 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 /obj/item/projectile/bullet/c22/hp
 	name = ".22lr hollow point bullet"
-	damage = 22
-	armour_penetration = -0.14
+	damage = 23
+	armour_penetration = 0
 	wound_bonus = -9
 	bare_wound_bonus = 9
 
@@ -45,7 +47,7 @@ Civilian round				=	-10% damage. AP reduced by 50%
 /obj/item/projectile/bullet/c38
 	name = ".38 bullet"
 	damage = 30
-	armour_penetration = 0.04
+	armour_penetration = 0
 	wound_bonus = 10
 
 
@@ -55,13 +57,13 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 /obj/item/projectile/bullet/c9mm
 	name = "9mm FMJ bullet"
-	damage = 28
+	damage = 27
 	armour_penetration = 0.05
 	wound_bonus = 15
 
 /obj/item/projectile/bullet/c9mm/ap
 	name = "9mm AP bullet"
-	damage = 25
+	damage = 22
 	armour_penetration = 0.25
 	wound_bonus = 8
 	bare_wound_bonus = -8
@@ -69,13 +71,13 @@ Civilian round				=	-10% damage. AP reduced by 50%
 /obj/item/projectile/bullet/c9mm/jhp
 	name = "9mm JHP bullet"
 	damage = 31
-	armour_penetration = -0.15
+	armour_penetration = 0
 	wound_bonus = -23
 	bare_wound_bonus = 23
 
 /obj/item/projectile/bullet/c9mm/op
 	name = "9mm +P bullet"
-	damage = 28
+	damage = 27
 	armour_penetration = 0.15
 	wound_bonus = 11
 	bare_wound_bonus = -11
@@ -91,13 +93,13 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 /obj/item/projectile/bullet/c10mm
 	name = "10mm FMJ bullet"
-	damage = 30
+	damage = 29
 	armour_penetration = 0.12
 	wound_bonus = 18
 
 /obj/item/projectile/bullet/c10mm/ap
 	name = "10mm AP bullet"
-	damage = 27
+	damage = 23
 	armour_penetration = 0.32
 	wound_bonus = 9
 	bare_wound_bonus = -9
@@ -105,7 +107,7 @@ Civilian round				=	-10% damage. AP reduced by 50%
 /obj/item/projectile/bullet/c10mm/hp
 	name = "10mm JHP bullet"
 	damage = 33
-	armour_penetration = -0.08
+	armour_penetration = 0
 	wound_bonus = -27
 	bare_wound_bonus = 27
 
@@ -116,20 +118,20 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 /obj/item/projectile/bullet/c45
 	name = ".45 FMJ bullet"
-	damage = 33
+	damage = 32
 	armour_penetration = 0.1
 	wound_bonus = 20
 
 /obj/item/projectile/bullet/c45/jhp
 	name = ".45 JHP bullet"
-	damage = 36
-	armour_penetration = -0.1
+	damage = 37
+	armour_penetration = 0
 	wound_bonus = -30
 	bare_wound_bonus = 30
 
 /obj/item/projectile/bullet/c45/op
 	name = ".45 +P bullet"
-	damage = 33
+	damage = 32
 	armour_penetration = 0.2
 	wound_bonus = 15
 	bare_wound_bonus = -15
@@ -142,21 +144,21 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 /obj/item/projectile/bullet/a357
 	name = ".357 FMJ bullet"
-	damage = 37
+	damage = 36
 	armour_penetration = 0.15
 	wound_bonus = 14
 	bare_wound_bonus = -14
 
 /obj/item/projectile/bullet/a357/jhp
 	name = ".357 JHP bullet"
-	damage = 41
-	armour_penetration = -0.05
+	damage = 42
+	armour_penetration = 0
 	wound_bonus = -21
 	bare_wound_bonus = 21
 
 /obj/item/projectile/bullet/a357/jfp
 	name = ".357 JFP bullet"
-	damage = 39
+	damage = 38
 	armour_penetration = 0.1
 	wound_bonus = 18
 	bare_wound_bonus = 18
@@ -168,21 +170,21 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 /obj/item/projectile/bullet/m44
 	name = ".44 FMJ bullet"
-	damage = 40
+	damage = 39
 	armour_penetration = 0.2
 	wound_bonus = 20
 	bare_wound_bonus = -20
 
 /obj/item/projectile/bullet/m44/jhp
 	name = ".44 JHP bullet"
-	damage = 44
+	damage = 45
 	armour_penetration = 0
 	wound_bonus = -30
 	bare_wound_bonus = 30
 
 /obj/item/projectile/bullet/m44/swc
 	name = ".44 SWC bullet"
-	damage = 40
+	damage = 39
 	armour_penetration = 0.1
 	wound_bonus = 30
 	bare_wound_bonus = 30
@@ -193,7 +195,7 @@ Civilian round				=	-10% damage. AP reduced by 50%
 //45 Long Colt. Bouncy ammo but less damage then the Sequoia. It's in one of the Vet Ranger kits
 /obj/item/projectile/bullet/a45lc
 	name = ".45 LC bullet"
-	damage = 44 //Right inbetween 44 and 45-70. Gun this is used in has a fire delay of 8, doing the math I'm pretty sure a regular M29 has a higher DPS then dual wielding these unless you bounce shots
+	damage = 43 //Right inbetween 44 and 45-70. Gun this is used in has a fire delay of 8, doing the math I'm pretty sure a regular M29 has a higher DPS then dual wielding these unless you bounce shots
 	armour_penetration = 0.25 //Again, right inbetween 44 and 45-70.
 	wound_bonus = 20
 	bare_wound_bonus = -20
@@ -210,7 +212,7 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 /obj/item/projectile/bullet/c4570
 	name = ".45-70 FMJ bullet"
-	damage = 48
+	damage = 46
 	armour_penetration = 0.3
 	wound_bonus = 24
 	bare_wound_bonus = -24
@@ -224,7 +226,7 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 /obj/item/projectile/bullet/c4570/swc
 	name = ".45-70 SWC bullet"
-	damage = 48
+	damage = 49
 	armour_penetration = 0.2
 	wound_bonus = 36
 	bare_wound_bonus = 36
@@ -244,16 +246,16 @@ Civilian round				=	-10% damage. AP reduced by 50%
 // 14 MM //
 ///////////				-Huge pistol round, damage focus
 
-/obj/item/projectile/bullet/a127mm
+/obj/item/projectile/bullet/14mm
 	name = "14mm FMJ bullet"
-	damage = 56
+	damage = 50
 	armour_penetration = 0.25
 	wound_bonus = 28
 	bare_wound_bonus = -28
 
-/obj/item/projectile/bullet/a127mm/jhp
+/obj/item/projectile/bullet/14mm/jhp
 	name = "14mm JHP bullet"
-	damage = 62
+	damage = 57
 	armour_penetration = 0.05
 	wound_bonus = -42
 	bare_wound_bonus = 42
@@ -266,13 +268,13 @@ Civilian round				=	-10% damage. AP reduced by 50%
 /obj/item/projectile/bullet/needle
 	name = "needle"
 	icon_state = "cbbolt"
-	damage = 35
+	damage = 34
 	armour_penetration = 0.6
 	var/piercing = FALSE
 
 /obj/item/projectile/bullet/needle/ap
 	name = "armour piercing needle"
-	damage = 32
+	damage = 31
 	armour_penetration = 0.8
 	wound_bonus = 0
 	bare_wound_bonus = 0
@@ -280,7 +282,7 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 /obj/item/projectile/bullet/needle/ultra
 	name = "ultracite needle"
-	damage = 39
+	damage = 38
 	armour_penetration = 0.4
 	piercing = TRUE
 

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -246,14 +246,14 @@ Civilian round				=	-10% damage. AP reduced by 50%
 // 14 MM //
 ///////////				-Huge pistol round, damage focus
 
-/obj/item/projectile/bullet/14mm
+/obj/item/projectile/bullet/mm14
 	name = "14mm FMJ bullet"
 	damage = 50
 	armour_penetration = 0.25
 	wound_bonus = 28
 	bare_wound_bonus = -28
 
-/obj/item/projectile/bullet/14mm/jhp
+/obj/item/projectile/bullet/mm14/jhp
 	name = "14mm JHP bullet"
 	damage = 57
 	armour_penetration = 0.05

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -5,14 +5,16 @@
 //////////////////////
 /*
 FMJ (full metal jacket)		=	Baseline
-AP (armor piercing)			=	-10% damage. AP increased by 0.2. Wound bonus -50%
-JHP (jacketed hollow point)	=	+10% damage. AP reduced by 0.2. Wound bonus + 50%
+AP (armor piercing)			=	-20% damage. AP increased by 0.2. Wound bonus -50%
+JHP (jacketed hollow point)	=	+15% damage. AP reduced by 0.2 (not below zero). Wound bonus + 50%
 SWC (semi wadcutter)		=	AP reduced by 0.1. Wound bonus +50%
 P+ (overpressure)			=	extra speed 500. AP + 01. Wound bonus -25%
 Match						=	extra speed 200. AP +0.05. Wound bonus -10%
 Civilian round				=	-10% damage. AP reduced by 50% 
 */
 
+// Explanation: Two major ammo stats, AP and Damage. Bullets placed in classes. Light rounds for example balanced with each other, one more AP, one more Damage.
+// Balance between classes mostly done on the gun end, bigger rounds typically fire slower and have more recoil. They are not supposed to be totally equal either.
 
 ////////////////////
 // 5.56 MM & .223 //
@@ -20,37 +22,37 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 /obj/item/projectile/bullet/a556
 	name = "5.56 FMJ bullet"
-	damage = 35
-	armour_penetration = 0.25
+	damage = 34
+	armour_penetration = 0.2
 	wound_bonus = 18
 	bare_wound_bonus = -18
 
 /obj/item/projectile/bullet/a556/ap
 	name = "5.56 AP bullet"
-	damage = 31
-	armour_penetration = 0.45
+	damage = 27
+	armour_penetration = 0.4
 	wound_bonus = 9
 	bare_wound_bonus = -9
 
 /obj/item/projectile/bullet/a556/jhp
 	name = "5.56 JHP bullet"
-	damage = 39
-	armour_penetration = 0.05
+	damage = 40
+	armour_penetration = 0
 	wound_bonus = -25
 	bare_wound_bonus = 25
 
 /obj/item/projectile/bullet/a556/match
 	name = "5.56 match bullet"
-	damage = 35
-	armour_penetration = 0.3
+	damage = 34
+	armour_penetration = 0.25
 	wound_bonus = 16
 	bare_wound_bonus = -16
 	var/extra_speed = 200
 
 /obj/item/projectile/bullet/a556/sport
 	name = ".223 FMJ bullet"
-	damage = 32
-	armour_penetration = 0.12
+	damage = 31
+	armour_penetration = 0.1
 	wound_bonus = 18
 	bare_wound_bonus = -18
 
@@ -63,33 +65,33 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 ////////////////////
 // 7.62 MM & .308 //
-////////////////////		- heavy rifle round, powerful but high recoil and less rof in the guns that can use it. .308 civilian version for hunting.
+////////////////////			- heavy rifle round, powerful but high recoil and less rof in the guns that can use it. .308 civilian version for hunting.
 
 /obj/item/projectile/bullet/a762
 	name = "7.62 FMJ bullet"
-	damage = 42
-	armour_penetration = 0.3
+	damage = 40
+	armour_penetration = 0.25
 	wound_bonus = 20
 	bare_wound_bonus = -20
 
 /obj/item/projectile/bullet/a762/ap
 	name = "7.62 AP bullet"
-	damage = 38
-	armour_penetration = 0.5
+	damage = 32
+	armour_penetration = 0.45
 	wound_bonus = 10
 	bare_wound_bonus = -10
 
 /obj/item/projectile/bullet/a762/jhp
 	name = "7.62 JHP bullet"
-	damage = 47
+	damage = 46
 	armour_penetration = 0.1
 	wound_bonus = -30
 	bare_wound_bonus = 30
 
 /obj/item/projectile/bullet/a762/match
 	name = "7.62 match bullet"
-	damage = 42
-	armour_penetration = 0.35
+	damage = 40
+	armour_penetration = 0.3
 	wound_bonus = 18
 	bare_wound_bonus = -18
 	var/extra_speed = 200
@@ -97,7 +99,7 @@ Civilian round				=	-10% damage. AP reduced by 50%
 //.308 Winchester
 /obj/item/projectile/bullet/a762/sport 
 	name = ".308 bullet"
-	damage = 38
+	damage = 36
 	armour_penetration = 0.15
 	wound_bonus = 20
 	bare_wound_bonus = -20
@@ -113,7 +115,7 @@ Civilian round				=	-10% damage. AP reduced by 50%
 /obj/item/projectile/bullet/a50MG
 	damage = 55
 	armour_penetration = 0.85
-	pixels_per_second = 5000
+	pixels_per_second = 4000
 
 /obj/item/projectile/bullet/a50MG/incendiary
 	damage = 40
@@ -169,6 +171,6 @@ Civilian round				=	-10% damage. AP reduced by 50%
 /////////////////////////			- Gauss rifle
 
 /obj/item/projectile/bullet/c2mm
-	damage = 55
+	damage = 45
 	armour_penetration = 0.85
 	pixels_per_second = TILES_TO_PIXELS(100)

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -319,7 +319,6 @@
 					/obj/item/clothing/head/soft/black = 4,
 					/obj/item/clothing/shoes/sneakers/black = 4,
 					/obj/item/reagent_containers/rag = 4,
-					/obj/item/storage/fancy/ammobox/beanbag = 1,
 					/obj/item/clothing/suit/armor/vest/alt = 1,
 					/obj/item/circuitboard/machine/dish_drive = 1,
 					/obj/item/clothing/glasses/sunglasses/reagent = 1,

--- a/testing.dmm
+++ b/testing.dmm
@@ -1345,7 +1345,7 @@
 "Kc" = (/obj/effect/decal/fakelattice{density = 0; pixel_x = 17},/turf/closed/mineral/random/low_chance,/area/space)
 "Kd" = (/obj/structure/bodycontainer/morgue,/turf/open/floor/f13{icon_state = "darkrusty"},/area/space)
 "Kf" = (/obj/structure/barricade/wooden,/turf/open/water,/area/space)
-"Kg" = (/obj/structure/table/wood,/obj/item/storage/fancy/ammobox/beanbag,/obj/item/storage/fancy/ammobox/beanbag,/obj/item/storage/fancy/ammobox/beanbag,/obj/item/storage/fancy/ammobox/lethalshot,/obj/item/storage/fancy/ammobox/lethalshot,/obj/item/storage/fancy/ammobox/lethalshot,/obj/effect/decal/cleanable/dirt,/turf/open/floor/f13/wood,/area/space)
+"Kg" = (/obj/structure/table/wood,/obj/item/ammo_box/shotgun/bean,/obj/item/ammo_box/shotgun/bean,/obj/item/ammo_box/shotgun/bean,/obj/item/ammo_box/shotgun/buck,/obj/item/ammo_box/shotgun/buck,/obj/item/ammo_box/shotgun/buck,/obj/effect/decal/cleanable/dirt,/turf/open/floor/f13/wood,/area/space)
 "Kh" = (/obj/structure/flora/grass/wasteland{icon_state = "tall_grass_2"; pixel_x = -6},/turf/open/indestructible/ground/inside/dirt,/area/space)
 "Ki" = (/obj/structure/closet/crate/bin,/obj/effect/decal/cleanable/dirt,/turf/open/floor/f13{icon_state = "bluedirtychess2"},/area/space)
 "Kl" = (/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,/area/space)


### PR DESCRIPTION
## About The Pull Request

Adjusts auto templates based on gameplay from the last couple days, most noticeable Car-15 hadn't been adjusted. Gets a 
flashlight though for its troubles.
Ammo templates adjusted, basically -1 damage for light and above rounds, the heaviest pistol and rifles lowered a little more, base AP values adjusted a little. The formula for AP and JHP adjusted to make AP not superior against lightly armored targets and make JHP a little more viable, no more negative AP which messes up the formula.
Adds a little recoil to the template for burst fire to make it feel different from plinking with a 22. 
Pistols are no longer auto fire moddable and will remain so until someone sits and makes their code match the SMG templates.
For obvious balance reasons, the days of dual wielding autofire pistols destroying everything was not good design or very fun for anyone not the shooter.

Also fixes a bunch of the legacy fancy shotgun boxes being around, needs another pass but most in loadouts fixed now. Its a duplicate of the right shotgun box with incorrect code so needs replacing.
Fixes odd pathing for 14mm pistol ammo.
Adjusts a couple pistols to reflect their ammo size (basically  slightly faster RoF in general for 9mm over 10mm as intended.)
Add Legion before the camp follower title.


## Changelog
:cl:
tweak: Adjustment bullet and auto templates.
/:cl:
