### PR TITLE
Slot reduction factions

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -407,8 +407,8 @@ Paladin
 	title = "Paladin"
 	flag = F13PALADIN
 	faction = "BOS"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 1
+	spawn_positions = 1
 	description = "You answer directly to the Senior Paladin. You are this Chapter's main line of defense and offense; highly trained in combat and weaponry though with little practical field experience, you are eager to prove your worth to the Brotherhood. Your primary duties are defense and surface operations. You may also be assigned a trainee Initiate."
 	forbids = "The Brotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals, and cruel torture or experiments on the minds or bodies of prisoners."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
@@ -619,8 +619,8 @@ datum/job/bos/f13seniorknight
 	title = "Senior Knight"
 	flag = F13SENIORKNIGHT
 	faction = "BOS"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 1
+	spawn_positions = 1
 	description = "You report directly to the Head Knight. You are the Brotherhood Senior Knight. Having served the Knight Caste for some time now, you are versatile and experienced in both basic combat and repairs, and also a primary maintainer of the Bunker's facilities. As your seniormost Knight, you may be assigned initiates or Junior Knights to mentor."
 	forbids = "The Brotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals, and cruel torture or experiments on the minds or bodies of prisoners."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -461,8 +461,8 @@ commented out pending rework*/
 	title = "Veteran Legionnaire"
 	flag = F13VETLEGIONARY
 	faction = "Legion"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 3
+	spawn_positions = 3
 	description = "A hardened warrior, obeying the orders from the Decanus and Centurion is second nature, as is fighting the profligates. If no officers are present, make sure the younger warriors act like proper Legionaires."
 	supervisors = "the Decani and Centurion"
 	display_order = JOB_DISPLAY_ORDER_VETLEGIONARY
@@ -596,8 +596,8 @@ commented out pending rework*/
 	title = "Recruit Legionnaire"
 	flag = F13RECRUITLEG
 	faction = "Legion"
-	total_positions = 6
-	spawn_positions = 6
+	total_positions = 5
+	spawn_positions = 5
 	description = "You have recently come of age or been inducted into Caesar's Legion. You have absolutely no training, and are expected to follow every whim of the Decanii and your Centurion. Respect the soldiers of higher rank."
 	supervisors = "the Decani and Centurion."
 	display_order = JOB_DISPLAY_ORDER_RECRUITLEG
@@ -771,16 +771,16 @@ commented out pending rework*/
 		/obj/item/book/granter/trait/techno=1)
 
 
-// AUXILIA - Females with specialist training. Cause men dont do womens work in Legion and vice versa. Cant have it both ways. Healing is womens work, basta.
+// AUXILIA - Civilians with special training.
 // Medicus only one with MID surgery, Treasurer get tinkering, both get Mars & Low Surgery.
 
 /datum/job/CaesarsLegion/auxilia
-	title = "Household Slave"
+	title = "Legion Auxilia"
 	flag = F13AUXILIA
 	faction = "Legion"
 	total_positions = 2
 	spawn_positions = 2
-	description = "You are a slave that has been recognized as being talented and trustworthy, given special medical training or entrusted with the camp funds and maintaining weapons. As part of the Centurions household you are expected to help the camp even if given no orders."
+	description = "A non-combat position in the Legion for free citizens who perform tasks that need special training, such as surgery."
 	supervisors = "the Centurion"
 	display_order = JOB_DISPLAY_ORDER_AUXILIA
 	outfit = /datum/outfit/job/CaesarsLegion/auxilia
@@ -791,6 +791,7 @@ commented out pending rework*/
 	/datum/outfit/loadout/auxmedicus // Do surgery, medical tasks.
 	)
 
+/*
 /datum/outfit/job/CaesarsLegion/auxilia/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)
@@ -803,11 +804,12 @@ commented out pending rework*/
 			var/obj/item/card/id/dogtag/L = H.wear_id
 			L.registered_name = H.name
 			L.update_label()
+*/
 
 /datum/outfit/job/CaesarsLegion/auxilia
-	name = 			"Household Slave"
+	name = 			"Auxilia"
 	jobtype = 		/datum/job/CaesarsLegion/auxilia
-	id =			/obj/item/card/id/legionbrand
+	id =			/obj/item/card/id/dogtag/legauxilia
 	head =			/obj/item/clothing/head/f13/legion/auxilia
 	uniform = 		/obj/item/clothing/under/f13/legauxiliaf
 	shoes = 		/obj/item/clothing/shoes/roman
@@ -861,8 +863,8 @@ commented out pending rework*/
 	title = "Legion Slave"
 	flag = F13LEGIONSLAVE
 	faction = "Legion"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 3
+	spawn_positions = 3
 	description = "A slave that survives the breaking camps is given a Legion appropriate name (latin-tribal inspired) and bull tattoo. Be obedient, respectful, stay inside the camp. Work the farm, mine, make food, clean and help injured men. Do NOT escape on your own, up to you how to handle it if forcibly freed by outside forces."
 	supervisors = "Officers and slavemaster first, then auxilia and warriors."
 	display_order = JOB_DISPLAY_ORDER_LEGIONSLAVE

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -311,12 +311,11 @@ Logistics Officer
 
 /*
 Sergeant First Class
-*/
 
 /datum/job/ncr/f13firstsergeant
 	title = "NCR Sergeant First Class" 
 	flag = F13FIRSTSERGEANT
-	total_positions = 0 //basically doesn't get used, remove the bloat roles. I wont delete this but it should be either reworked or commented out.
+	total_positions = 0
 	spawn_positions = 0
 	description = "You are the most senior NCO in Camp Miller. You act as an senior enlisted advisor to the Lieutenant as well as act as in the third in Command. You have the authority to recommend promotions and as well as managing the enlisted personnel"
 	supervisors = "Lieutenant and above"
@@ -348,6 +347,7 @@ Sergeant First Class
 		/obj/item/melee/classic_baton/telescopic=1, \
 		/obj/item/ammo_box/magazine/m556/rifle/assault=1, \
 		/obj/item/binoculars=1)
+*/
 
 /*
 Sergeant
@@ -356,8 +356,8 @@ Sergeant
 /datum/job/ncr/f13sergeant
 	title = "NCR Sergeant"
 	flag = F13SERGEANT
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 2
+	spawn_positions = 2
 	description = "You are the direct superior to the enlisted troops, working with the chain of command you echo the orders of your superiors and ensure that the enlisted follow them to the letter. Additionally, you are responsible for the wellbeing of the troops and their ongoing training with the NCR."
 	supervisors = "Sergeant First Class and above"
 	selection_color = "#fff5cc"
@@ -429,8 +429,8 @@ Heavy Trooper
 /datum/job/ncr/f13heavytrooper
 	title = "NCR Heavy Trooper"
 	flag = F13HEAVYTROOPER
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 1
+	spawn_positions = 1
 	description = "You are the most elite of the enlisted, sergeant in rank but forgoing regular command roles to lead in battle only. You are expected to be on the frontlines of every engagement, and to provide firing support for the rank and file. Your power armor lacks the protects the full working sets have, but you have trained with it and can use it in battle well. General Oliver praises you and your other Heavy Troopers, prove to him you're no exception to the rule."
 	supervisors = "Sergeant First Class and above"
 	access = list(ACCESS_NCR, ACCESS_NCR_ARMORY)
@@ -475,8 +475,8 @@ Corporal
 /datum/job/ncr/f13corporal
 	title = "NCR Corporal"
 	flag = F13CORPORAL
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 2
+	spawn_positions = 2
 	description = "You are a junior NCO. You are tasked with organizing the enlisted ranks into fireteams and answer directly to a Sergeant and/or the Sergeant First Class."
 	supervisors = "Sergeant and above"
 	selection_color = "#fff5cc"
@@ -584,8 +584,8 @@ Combat Engineer
 /datum/job/ncr/f13combatengineer
 	title = "NCR Combat Engineer"
 	flag = F13COMBATENGINEER
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 1
+	spawn_positions = 1
 	description = "You are a veteran enlisted with an engineering skill set. You work closely with your squad, taking orders from your officers. You have the authority to command troopers if there are none present."
 	supervisors = "Corporals and above"
 	access = list(ACCESS_NCR, ACCESS_NCR_ARMORY)
@@ -740,8 +740,8 @@ Trooper
 /datum/job/ncr/f13mp
 	title = "NCR Military Police"
 	flag = F13MP
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 1
+	spawn_positions = 1
 	description = "You are tasked with the supervision of the NCRA to maintain internal order and disciplice and to prevent any warcrimes from happening."
 	supervisors = "the Captain"
 	selection_color = "#fff5cc"
@@ -976,7 +976,7 @@ Veteran Ranger
 	title = "NCR Ranger"
 	flag = F13RANGER
 	total_positions = 4
-	spawn_positions = 5
+	spawn_positions = 4
 	description = "As an NCR Ranger, you are the premier special forces unit of the NCR. You are the forward observations and support the Army in it's campaigns, as well as continuing the tradition of stopping slavery in it's tracks."
 	supervisors = "Veteran Ranger"
 	selection_color = "#fff5cc"


### PR DESCRIPTION
## About The Pull Request

The number of slots in the fighting factions has gone out of control. time to prune.
Too many slots = TDM focus increased, combat respawn more likely, snowflake specialists become the norm and not grunts.

What this PR does - reduces slots, after adjustments numbers are below, its progress, not the end goal. Goal is to get it down to total roles around 25 for NCR and Legion including civilians, about a dozen for BoS. but it will require loadout changes etc and takes time to do right.
I strongly advise adopting the rule I have suggested before, 1 new added, 1 old goes away, so if you add a slot you need to remove another, same with factions, until the weeds have been cleared out and the garden is a little less cluttered. Its a rule of thumb that can prevent the bloat from reoccuring, its a natural process that requires a proactive policy to stop.

``` 
Post PR slots
NCR - 29 combat roles

CAPTAIN		1
VET RANGER	1
LIEUTENANT	1
SERGEANT	2
CORPORAL	2
RANGER		4
HEAVY		1
LOGISTICS	1
ENGINEER	1
MO		1
MEDIC		1
TROOPER		8
MP		1
REAR		4


LEGION - 23 combat roles, 5 civilian

CENT		1
VET DEC		1
PRIM DEC	1
REC DEC		1
VENATOR		1
VEX		1
EXPLORER	3
VET		3
PRIME		4
RECRUIT		5
CAMP		2

SLAVE		3
AUX		2

BOS - 10 combat, 4 scribe

HEAD PALADIN	1
HEAD SCRIBE	1
HEAD KNIGHT	1
SENIOR PALADIN	1
PALADIN		1
SENIOR SCRIBE	1
SCRIBE		2
SENIOR KNIGHT	1
KNIGHT		2
INITIATE	3
```

Also changes Household slave to Auxilia, since thats what people call it anyways. Its functionally identical, but at least less excuses to play a faction role as a subversive against the faction.


## Changelog
:cl:
tweak: Slot reductions, NCR, Legion, BoS. Household slave relabeled Auxilia.
/:cl:
