### PR TITLE
Tribal Powercreep

### DIFF
--- a/code/game/objects/items/melee/f13twohanded.dm
+++ b/code/game/objects/items/melee/f13twohanded.dm
@@ -114,7 +114,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
 	name = "improvised metal glaive"
 	desc = "A improvised metal glaive that can be wielded."
-	force = 15
+	force = 10
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
 //	force_unwielded = 25
@@ -122,7 +122,8 @@
 	throwforce = 25
 	throw_speed = 4
 	embedding = list("embed_chance" = 0)
-	armour_penetration = 0
+	armour_penetration = 0.1
+	max_reach = 2
 //	custom_materials = list(MAT_METAL=1150, MAT_GLASS=2075)
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "impaled", "jabbed", "torn", "gored")
@@ -140,7 +141,7 @@
 	AddComponent(/datum/component/butchering, 100, 70) //decent in a pinch, but pretty bad.
 //	AddComponent(/datum/component/jousting)
 	AddElement(/datum/element/sword_point)
-	AddComponent(/datum/component/two_handed, force_unwielded=8, force_wielded=30, icon_wielded="[icon_prefix]1")
+	AddComponent(/datum/component/two_handed, force_unwielded=10, force_wielded=25, icon_wielded="[icon_prefix]1")
 
 /obj/item/twohanded/spear/rightclick_attack_self(mob/user)
 	if(explosive)
@@ -250,7 +251,7 @@
 	throwforce = 25
 	throw_speed = 4
 	embedding = list("embedded_impact_pain_multiplier" = 3)
-	armour_penetration = 0.24				//Enhanced armor piercing
+	armour_penetration = 0.25				//Enhanced armor piercing
 	max_reach = 2
 	custom_materials = null
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -260,20 +261,20 @@
 
 /obj/item/twohanded/spear/bonespear/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded=15, force_wielded=40, icon_wielded="[icon_prefix]1")
+	AddComponent(/datum/component/two_handed, force_unwielded=15, force_wielded=30, icon_wielded="[icon_prefix]1")
 
 /obj/item/twohanded/spear/bonespear/deathclaw
 	name = "deathclaw spear"
 	desc = "A finely crafted spear with a shaft wrapped in deathclaw leather. It is tipped with a claw from a beast that must have been terrifying in size."
 	force = 20
-	armour_penetration = 0.4
+	armour_penetration = 0.30
 	max_reach = 2
 	icon_state = "clawspear0"
 	icon_prefix = "clawspear"
 
 /obj/item/twohanded/spear/bonespear/deathclaw/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded = 20, force_wielded = 50)
+	AddComponent(/datum/component/two_handed, force_unwielded = 20, force_wielded = 45)
 
 //Ultracite
 /obj/item/twohanded/spear/ultra

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -661,7 +661,7 @@
 	icon_state = "tribecombatarmor"
 	item_state = "tribecombatarmor"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
-	armor = list("tier" = 5, "energy" = 40, "bomb" = 50, "bio" = 60, "rad" = 10, "fire" = 60, "acid" = 20)
+	armor = list("tier" = 5, "energy" = 40, "bomb" = 35, "bio" = 60, "rad" = 10, "fire" = 60, "acid" = 20)
 	allowed = list(/obj/item/gun, /obj/item/kitchen, /obj/item/twohanded, /obj/item/claymore, /obj/item/twohanded/spear, /obj/item/melee/smith, /obj/item/melee/smith/twohand)
 
 /obj/item/clothing/suit/armor/f13/tribe_armor
@@ -709,7 +709,9 @@
 	desc = "(VI) A set of power armor, now reborn in the paints of the Wayfarers, it serves its new owners as an idol to Kwer, as well as being a piece of heavy covering, with removed parts to allow for quick nimble speed, its hardly what it used to be long ago."
 	icon_state = "tribal_power_armor"
 	item_state = "tribal_power_armor"
-	armor = list("tier" = 7, "energy" = 35, "bomb" = 40, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0)
+	armor = list("tier" = 7, "energy" = 50, "bomb" = 40, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0)
+	allowed = list(/obj/item/gun, /obj/item/kitchen, /obj/item/twohanded, /obj/item/claymore, /obj/item/twohanded/spear, /obj/item/melee/smith, /obj/item/melee/smith/twohand
+	)
 
 //Followers
 

--- a/code/modules/jobs/job_types/tribals.dm
+++ b/code/modules/jobs/job_types/tribals.dm
@@ -39,8 +39,6 @@ Tribal Chief
 /datum/job/tribal
 	exp_type = EXP_TYPE_TRIBAL
 
-	mind_traits = list(TRAIT_TRIBAL)
-
 /datum/job/tribal/f13chief
 	title = "Chief"
 	flag = F13CHIEF
@@ -75,7 +73,7 @@ Tribal Chief
 	neck =			/obj/item/clothing/neck/cloak/chiefcloak
 	id = 			/obj/item/card/id/tribetattoo
 	suit =			/obj/item/clothing/suit/hooded/cloak/hhunter
-	suit_store =	/obj/item/melee/transforming/cleaving_saw
+	suit_store =	/obj/item/twohanded/spear/bonespear/deathclaw
 	backpack_contents = list(
 		/obj/item/restraints/legcuffs/bola=1,
 		/obj/item/reagent_containers/pill/patch/healingpowder=2,
@@ -247,8 +245,8 @@ Villager
 	flag = F13VILLAGER
 	department_flag = TRIBAL
 	faction = "Village"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 3
+	spawn_positions = 3
 	supervisors = "Tribal Chief, Shaman and Headhunter"
 	description = "A proud member of the Wayfarer tribe, you do what needs to be done to ensure the survival of yourself and your people while following the laws of the tribe. While it is common to venture out into the wasteland, do not thread far or without informing your kin."
 	selection_color = "#006666"
@@ -325,8 +323,8 @@ Hunter
 	flag = F13HUNTER
 	department_flag = TRIBAL
 	faction = "Village"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "The chief and Head Hunter."
 	enforces = "The ways of the Machine spirits."
 	forbids = "Abusing technology and using Pre-War weapons."
@@ -383,7 +381,7 @@ Hunter
 		/obj/item/twohanded/spear/bonespear/deathclaw=1,
 		/obj/item/kitchen/knife/combat/bone=1,
 		/obj/item/binoculars=1,
-		/obj/item/restraints/legcuffs/bola/tactical=2,
+		/obj/item/restraints/legcuffs/bola/tactical=1,
 		/obj/item/reagent_containers/pill/patch/healingpowder=1
 	)
 
@@ -395,8 +393,8 @@ Spirit-Pledged
 	flag = F13SPIRITPLEDGED
 	department_flag = TRIBAL
 	faction = "Village"
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "All other tribals."
 	description = "An outsider to the tribe, you have been welcomed to learn their ways and grow closer to their culture and lifestyle, do NOT run off alone into the wasteland without the supervision of another higher ranking tribal."
 	selection_color = "#006666"
@@ -424,7 +422,7 @@ Guardian
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "All leadership, but the Chief is priority"
-	description = "A hand chosen Hunter with much promise, you are one of the village Guardians. An elite Hunter given the duty to protect the leaders of the tribe, and the village. Your duty is to ensure your kin are safe at all costs, as well as follow any orders from your superiors and enforce the law of the tribe."
+	description = "A hand chosen Hunter with much promise, you are one of the village Guardians. An elite Hunter given the duty to protect the village, your duty is to ensure your kin are safe at all costs, as well as follow any orders from your superiors and enforce the law of the tribe. Do not leave the village unless circumstances allow it."
 	selection_color = "#006666"
 	exp_requirements = 900
 
@@ -433,17 +431,24 @@ Guardian
 	access = list(ACCESS_TRIBE)
 	minimal_access = list(ACCESS_TRIBE)
 
+/datum/outfit/job/tribal/f13guardian/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	ADD_TRAIT(H, TRAIT_LIFEGIVER, src)
+	ADD_TRAIT(H, TRAIT_BIG_LEAGUES, src)
+
 /datum/outfit/job/tribal/f13guardian
 	name = "Guardian"
 	jobtype = /datum/job/tribal/f13guardian
 	uniform = 	/obj/item/clothing/under/f13/wayfarer/hunter
 	gloves = 	/obj/item/clothing/gloves/f13/handwraps
 	shoes = 	/obj/item/clothing/shoes/sandal
-	suit = 		/obj/item/clothing/suit/hooded/cloak/hhunter
+	suit = 		/obj/item/clothing/suit/armor/f13/tribe_heavy_armor
 	suit_store = /obj/item/twohanded/spear/bonespear/deathclaw
 	id = 		/obj/item/card/id/tribetattoo
 	backpack_contents = list(
-		/obj/item/reagent_containers/pill/patch/healpoultice=2,
+		/obj/item/reagent_containers/pill/patch/healingpowder=2,
 		/obj/item/stack/medical/gauze=1,
 		/obj/item/flashlight/flare/torch=1,
-		/obj/item/restraints/legcuffs/bola/tactical=2)
+		/obj/item/restraints/legcuffs/bola/tactical=1)


### PR DESCRIPTION
Powercreep

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### Reduces tribal numbers

(SAME) Chief 1 > 1
(SAME) Shaman 1 > 1
(SAME) Head Hunter 1 > 1
(SAME) Druid 2 > 2
**(NERF) Hunter 4 > 2**
(SAME) Guardian 2 > 2
**(NERF) Villager 4 > 3**
**(NERF) Pledge 3 > 2**

Reduces numbers of tribal population from 18 to 14

### Loadout changes

**(NERF) Reduces the number of all reinforced bolas by 2 to 1**
**(NERF) Guardian poultice is now regular powder**
**(NERF) Guardians spawn with Heavy Tribal armor instead of Razorclaw cloak**
(CHANGE) Chief spawns with Dclaw spear and no more Cleaving Saw

### Reduces and adjusts damage on spear weapons, 

**(NERF) Dclaw spear (20, 50) 0.4 AP > (20,45) 0.3 AP**
(BUFF) Impro glaive (8,30) 0 AP > (10,25) 0.1 AP (Reach is back)
(TWEAK) Bone spear (Same damage) 0.24 AP > 0.25 AP

## Why It's Good For The Game

Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep Powercreep 

Much weaker now, if it sucks ill tweak numbers again.

## Changelog
:cl:
tweak: powercreep
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
