### PR TITLE
Various oversights/bugs + slug adjust

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -12,7 +12,7 @@
 		else
 			to_chat(user, "<span class='notice'>You discreetly slip [I] into [parent].</span>")
 
-/datum/component/storage/concrete/pockets
+/datum/component/storage/concrete/pockets/huge
 	max_w_class = WEIGHT_CLASS_NORMAL
 
 /datum/component/storage/concrete/pockets/small

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -609,7 +609,7 @@ Records disabled until a use for them is found
 					dat += "<b>Penis Shape:</b> <a style='display:block;width:120px' href='?_src_=prefs;preference=cock_shape;task=input'>[features["cock_shape"]][tauric_shape ? " (Taur)" : ""]</a>" */
 					dat += "<b>Penis Length:</b> <a style='display:block;width:120px' href='?_src_=prefs;preference=cock_length;task=input'>[features["cock_length"]] inch(es)</a>"
 //					dat += "<b>Penis Visibility:</b><a style='display:block;width:100px' href='?_src_=prefs;preference=cock_visibility;task=input'>[features["cock_visibility"]]</a>"
-//					dat += "<b>Has Testicles:</b><a style='display:block;width:50px' href='?_src_=prefs;preference=has_balls'>[features["has_balls"] == TRUE ? "Yes" : "No"]</a>"
+					dat += "<b>Has Testicles:</b><a style='display:block;width:50px' href='?_src_=prefs;preference=has_balls'>[features["has_balls"] == TRUE ? "Yes" : "No"]</a>"
 //					if(features["has_balls"])
 //						if(!pref_species.use_skintones)
 //							dat += "<b>Testicles Color:</b></a><BR>"
@@ -657,10 +657,10 @@ Records disabled until a use for them is found
 //			dat += "<b>PDA Style:</b> <a href='?_src_=prefs;task=input;preference=pda_style'>[pda_style]</a><br>"
 //			dat += "<b>PDA Reskin:</b> <a href='?_src_=prefs;task=input;preference=pda_skin'>[pda_skin]</a><br>"
 			dat += "<br>"
-			dat += "<b>Ghost Ears:</b> <a href='?_src_=prefs;preference=ghost_ears'>[(chat_toggles & CHAT_GHOSTEARS) ? "Nearest Creatures" : "All Speech"]</a><br>"
+			dat += "<b>Ghost Ears:</b> <a href='?_src_=prefs;preference=ghost_ears'>[(chat_toggles & CHAT_GHOSTEARS) ?  "All Speech":"Nearest Creatures"]</a><br>"
 			dat += "<b>Ghost Radio:</b> <a href='?_src_=prefs;preference=ghost_radio'>[(chat_toggles & CHAT_GHOSTRADIO) ? "All Messages":"No Messages"]</a><br>"
-			dat += "<b>Ghost Sight:</b> <a href='?_src_=prefs;preference=ghost_sight'>[(chat_toggles & CHAT_GHOSTSIGHT) ? "Nearest Creatures" : "All Emotes"]</a><br>"
-			dat += "<b>Ghost Whispers:</b> <a href='?_src_=prefs;preference=ghost_whispers'>[(chat_toggles & CHAT_GHOSTWHISPER) ? "Nearest Creatures" : "All Speech"]</a><br>"
+			dat += "<b>Ghost Sight:</b> <a href='?_src_=prefs;preference=ghost_sight'>[(chat_toggles & CHAT_GHOSTSIGHT) ? "All Emotes":"Nearest Creatures" ]</a><br>"
+			dat += "<b>Ghost Whispers:</b> <a href='?_src_=prefs;preference=ghost_whispers'>[(chat_toggles & CHAT_GHOSTWHISPER) ? "All Speech":"Nearest Creatures"]</a><br>"
 			dat += "<b>Ghost PDA:</b> <a href='?_src_=prefs;preference=ghost_pda'>[(chat_toggles & CHAT_GHOSTPDA) ? "All Messages" : "Nearest Creatures"]</a><br>"
 //			dat += "<b>Window Flashing:</b> <a href='?_src_=prefs;preference=winflash'>[(windowflashing) ? "Enabled":"Disabled"]</a><br>"
 			dat += "<br>"

--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -433,7 +433,7 @@
 	armor = list("tier" = 2, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 	strip_delay = 50
 	obj_flags = UNIQUE_RENAME
-	pocket_storage_component_path = /datum/component/storage/concrete/pockets
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets/tiny
 
 /obj/item/clothing/head/f13/ncr/Initialize()
 	. = ..()

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -931,7 +931,7 @@ Raider
 	name = "Bounty Hunter"
 	head = /obj/item/clothing/suit/armor/f13/combat/mk2/dark
 	suit = /obj/item/clothing/head/helmet/f13/combat/mk2/dark
-	r_hand = /obj/item/gun/ballistic/automatic/g11/upgraded
+	r_hand = /obj/item/gun/ballistic/automatic/g11
 	backpack_contents = list(
 							/obj/item/ammo_box/magazine/m473=2
 							)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1,3 +1,135 @@
+/*
+IN THIS DOCUMENT: Universal Gun system rules/keywords. Universal gun template and procs/vars.
+
+/////////////////////////////////////
+//UNIVERSAL GUN KEYWORDS AND SYSTEM//
+/////////////////////////////////////
+
+GENERAL
+
+	Bonuses should not go far from this framework, for non-unique stuff plus minus one or two is enough to give a good spread, considering its compounded by tinkering and attachments and ammo.
+	A reduction of 1 in burst shot delay gives a lot more effect than adding 1 damage.
+
+KEYWORDS
+
+	SINGLE ACTION REVOLVER
+	fire_delay = 7
+	spread = 1
+
+	DOUBLE ACTION REVOLVER
+	fire_delay = 6	
+	spread = 2
+
+	SEMI-AUTOMATIC PISTOL
+	fire_delay = 3-5	
+	spread = 3
+
+	SEMI-AUTOMATIC RIFLE
+	fire_delay = 3-6
+	spread = 1-2
+
+	AUTOMATIC SMG
+	fire_delay = 3-6
+	burst_shot_delay = 2.75
+	spread = 8-14
+
+	AUTOMATIC RIFLE
+	fire_delay = 3-7
+	burst_shot_delay = 3
+	spread = 7-12
+
+	REPEATER	
+	fire_delay = 8
+	spread = 1	
+
+	DOUBLE BARREL
+	fire_delay = 1
+	extra damage = 1
+
+	PUMP-ACTION
+	fire_delay = 7
+	extra damage = 1
+	spread = 1
+	(requires manual action to cycle)
+
+	BOLT-ACTION
+	fire_delay = 10-15
+	extra damage = 6
+	extra_speed = 800
+	(requires manual action to cycle)
+
+	PISTOL GRIP/FOLDED STOCK MALUS (For rifles, not pistols obviously)
+	recoil = 0.5
+	spread = +2 (not for shotguns)
+	w_class = WEIGHT_CLASS_NORMAL
+
+	SAWN OFF
+	recoil = 1
+	spread = 10
+	weapon_weight = WEAPON_LIGHT
+
+	LONG BARREL/LASERSIGHT
+	extra_damage = +2
+	spread = -1
+
+	SHORT BARREL
+	extra_damage = -2
+	spread = +3
+
+	HEAVY
+	recoil = 0.1
+	weapon_weight = WEAPON_MEDIUM at least (no dual wield)
+
+GENERAL RULES
+
+	SMALL GUNS
+	slowdown = 0.1-0.2
+	w_class = WEIGHT_CLASS_SMALL
+	weapon_weight = WEAPON_LIGHT - MEDIUM		
+
+	MEDIUM GUNS
+	slowdown = 0.3-0.4
+	w_class = WEIGHT_CLASS_NORMAL - BULKY
+	weapon_weight = WEAPON_MEDIUM - HEAVY	
+
+	RIFLES 
+	slowdown = 0.5
+	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_HEAVY
+
+	AMMO RECOIL BASE VALUES
+	.50  recoil = 1
+	.45/70  recoil = 0.25
+
+	2-ROUND BURST
+	recoil = 0.1
+
+	3-ROUND BURST
+	recoil = 0.25
+
+	FORCE
+	Delicate, clumsy or small gun force 10
+	Pistol whip force 12
+	Rifle type force 15
+	Unusually sturdy clublike 20
+
+ATTACHMENTS
+
+	BURST CAM
+	burst_size + 1
+	spread + 5 (recoil)
+	burst_shot_delay + 0.5 (recoil managment)
+
+	RECOIL COMPENSATOR
+	spread above 10 = -4 spread
+	spread under 10 = -2 spread
+
+	AUTO SEAR
+	Enables fire select automatic
+	burst_size + 1
+	recoil = +0.1
+	spread + 6 (to bring it into the automatic template range)
+*/
 
 #define DUALWIELD_PENALTY_EXTRA_MULTIPLIER 1.4
 
@@ -879,3 +1011,245 @@
 	. = recoil
 	if(user && !user.has_gravity())
 		. = recoil*5
+
+///////////////////
+//GUNCODE ARCHIVE//
+///////////////////
+
+/*
+STICK GUN PICKUP WEIRDNESS
+/obj/item/gun/ballistic/automatic/pistol/stickman/pickup(mob/living/user)
+	. = ..()
+	to_chat(user, "<span class='notice'>As you try to pick up [src], it slips out of your grip..</span>")
+	if(prob(50))
+		to_chat(user, "<span class='notice'>..and vanishes from your vision! Where the hell did it go?</span>")
+		qdel(src)
+		user.update_icons()
+	else
+		to_chat(user, "<span class='notice'>..and falls into view. Whew, that was a close one.</span>")
+		user.dropItemToGround(src)
+
+/obj/item/gun/ballistic/automatic/pistol/deagle/update_overlays()
+	. = ..()
+	if(magazine)
+		. += "deagle_magazine"
+
+CITADEL MODULAR PISTOL CODE
+/obj/item/gun/ballistic/automatic/pistol/modular
+	name = "modular pistol"
+	desc = "A small, easily concealable 10mm handgun. Has a threaded barrel for suppressors."
+	icon = 'modular_citadel/icons/obj/guns/cit_guns.dmi'
+	icon_state = "cde"
+	can_unsuppress = TRUE
+	automatic_burst_overlay = FALSE
+	obj_flags = UNIQUE_RENAME
+	unique_reskin = list("Default" = "cde",
+						"N-99" = "n99",
+						"Stealth" = "stealthpistol",
+						"HKVP-78" = "vp78",
+						"Luger" = "p08b",
+						"Mk.58" = "secguncomp",
+						"PX4 Storm" = "px4"
+						)
+
+/obj/item/gun/ballistic/automatic/pistol/modular/update_icon_state()
+	if(current_skin)
+		icon_state = "[unique_reskin[current_skin]][chambered ? "" : "-e"][suppressed ? "-suppressed" : ""]"
+	else
+		icon_state = "[initial(icon_state)][chambered ? "" : "-e"][suppressed ? "-suppressed" : ""]"
+
+/obj/item/gun/ballistic/automatic/pistol/modular/update_overlays()
+	. = ..()
+	if(magazine && suppressed)
+		. += "[unique_reskin[current_skin]]-magazine-sup"	//Yes, this means the default iconstate can't have a magazine overlay
+	else if (magazine)
+		. += "[unique_reskin[current_skin]]-magazine"
+
+
+SOME SORT OF  BOLT ACTION CODE UNUSED
+/obj/item/gun/ballistic/shotgun/boltaction/pump(mob/M)
+	playsound(M, 'sound/weapons/shotgunpump.ogg', 60, 1)
+	if(bolt_open)
+		pump_reload(M)
+	else
+		pump_unload(M)
+	bolt_open = !bolt_open
+	update_icon()	//I.E. fix the desc
+	return 1
+
+/obj/item/gun/ballistic/shotgun/boltaction/pump(mob/M)
+	playsound(M, 'sound/weapons/shotgunpump.ogg', 60, 1)
+	pump_unload(M)
+	pump_reload(M)
+	update_icon()	//I.E. fix the desc
+	return 1
+
+/obj/item/gun/ballistic/shotgun/boltaction/attackby(obj/item/A, mob/user, params)
+	if(!bolt_open)
+		to_chat(user, "<span class='notice'>The bolt is closed!</span>")
+		return
+	. = ..()
+
+/obj/item/gun/ballistic/shotgun/boltaction/examine(mob/user)
+	. = ..()
+	. += "The bolt is [bolt_open ? "open" : "closed"]."
+
+
+CODE FOR RESKIN
+	unique_reskin = list("Tactical" = "cshotgun",
+						"Slick" = "cshotgun_slick"
+						)
+
+
+DUAL TUBE PUMP ACTION (seems redundant with neostead but why not keep it.)
+/obj/item/gun/ballistic/shotgun/automatic/dual_tube/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>Alt-click to pump it.</span>"
+
+/obj/item/gun/ballistic/shotgun/automatic/dual_tube/attack_self(mob/living/user)
+	if(!chambered && magazine.contents.len)
+		pump()
+	else
+		toggle_tube(user)
+
+/obj/item/gun/ballistic/shotgun/automatic/dual_tube/AltClick(mob/living/user)
+	. = ..()
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
+		return
+	pump()
+	return TRUE
+
+
+ATTACHING SLING
+/obj/item/gun/ballistic/shotgun/boltaction/improvised/attackby(obj/item/A, mob/user, params)
+	..()
+	if(istype(A, /obj/item/stack/cable_coil) && !sawn_off)
+		if(A.use_tool(src, user, 0, 10, skill_gain_mult = EASY_USE_TOOL_MULT))
+			slot_flags = ITEM_SLOT_BACK
+			to_chat(user, "<span class='notice'>You tie the lengths of cable to the rifle, making a sling.</span>")
+			slung = TRUE
+			update_icon()
+		else
+			to_chat(user, "<span class='warning'>You need at least ten lengths of cable if you want to make a sling!</span>")
+
+/obj/item/gun/ballistic/shotgun/boltaction/improvised/update_overlays()
+	. = ..()
+	if(slung)
+		. += "[icon_state]sling"
+
+
+HOOK GUN CODE. Bizarre but could be made into something useful.
+/obj/item/gun/ballistic/shotgun/doublebarrel/hook
+	name = "hook modified sawn-off shotgun"
+	desc = "Range isn't an issue when you can bring your victim to you."
+	icon_state = "hookshotgun"
+	item_state = "shotgun"
+	mag_type = /obj/item/ammo_box/magazine/internal/shot/bounty
+	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_MEDIUM
+	force = 16 //it has a hook on it
+	attack_verb = list("slashed", "hooked", "stabbed")
+	hitsound = 'sound/weapons/bladeslice.ogg'
+	//our hook gun!
+	var/obj/item/gun/magic/hook/bounty/hook
+	var/toggled = FALSE
+
+CODE FOR ASSAULT RIFE WITH GRENADE LAUNCHER ATTACHED
+/obj/item/gun/ballistic/automatic/m90
+	name = "\improper M-90gl Carbine"
+	desc = "A three-round burst 5.56 toploading carbine, designated 'M-90gl'. Has an attached underbarrel grenade launcher which can be toggled on and off."
+	icon_state = "m90"
+	item_state = "m90"
+	mag_type = /obj/item/ammo_box/magazine/m556
+	fire_sound = 'sound/weapons/gunshot_smg.ogg'
+	can_suppress = FALSE
+	automatic_burst_overlay = FALSE
+	var/obj/item/gun/ballistic/revolver/grenadelauncher/underbarrel
+
+/obj/item/gun/ballistic/automatic/m90/Initialize()
+	. = ..()
+	underbarrel = new /obj/item/gun/ballistic/revolver/grenadelauncher(src)
+	update_icon()
+
+/obj/item/gun/ballistic/automatic/m90/unrestricted
+	pin = /obj/item/firing_pin
+
+/obj/item/gun/ballistic/automatic/m90/unrestricted/Initialize()
+	. = ..()
+	underbarrel = new /obj/item/gun/ballistic/revolver/grenadelauncher/unrestricted(src)
+	update_icon()
+
+/obj/item/gun/ballistic/automatic/m90/afterattack(atom/target, mob/living/user, flag, params)
+	if(select == 2)
+		underbarrel.afterattack(target, user, flag, params)
+	else
+		. = ..()
+		return
+/obj/item/gun/ballistic/automatic/m90/attackby(obj/item/A, mob/user, params)
+	if(istype(A, /obj/item/ammo_casing))
+		if(istype(A, underbarrel.magazine.ammo_type))
+			underbarrel.attack_self()
+			underbarrel.attackby(A, user, params)
+	else
+		..()
+/obj/item/gun/ballistic/automatic/m90/update_overlays()
+	. = ..()
+	switch(select)
+		if(0)
+			. += "[initial(icon_state)]semi"
+		if(1)
+			. += "[initial(icon_state)]burst"
+		if(2)
+			. += "[initial(icon_state)]gren"
+
+/obj/item/gun/ballistic/automatic/m90/update_icon_state()
+	icon_state = "[initial(icon_state)][magazine ? "" : "-e"]"
+
+/obj/item/gun/ballistic/automatic/m90/burst_select()
+	var/mob/living/carbon/human/user = usr
+	switch(select)
+		if(0)
+			select = 1
+			burst_size = initial(burst_size)
+			to_chat(user, "<span class='notice'>You switch to [burst_size]-rnd burst.</span>")
+		if(1)
+			select = 2
+			to_chat(user, "<span class='notice'>You switch to grenades.</span>")
+		if(2)
+			select = 0
+			burst_size = 1
+			to_chat(user, "<span class='notice'>You switch to semi-auto.</span>")
+	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
+	update_icon()
+	return
+
+
+LONG SCOPE
+	zoomable = TRUE
+	zoom_amt = 10 //Long range, enough to see in front of you, but no tiles behind you.
+	zoom_out_amt = 13
+
+
+MAG ICON CODE
+/obj/item/gun/ballistic/automatic/surplus/update_icon_state()
+	if(magazine)
+		icon_state = "surplus"
+	else
+		icon_state = "surplus-e"
+
+SPREAD UPON BURST TOGGLE
+/obj/item/gun/ballistic/automatic/wt550/enable_burst()
+	. = ..()
+	spread = 15
+
+/obj/item/gun/ballistic/automatic/wt550/disable_burst()
+	. = ..()
+	spread = 0
+
+ICON UPDATE FOR GRADUAL DEPLETION, PLASTIC MAGS ETC
+/obj/item/gun/ballistic/automatic/c20r/update_icon_state()
+	icon_state = "c20r[magazine ? "-[CEILING(get_ammo(0)/4, 1)*4]" : ""][chambered ? "" : "-e"][suppressed ? "-suppressed" : ""]"
+
+/obj/item/gun/ballistic/automatic/wt550/update_icon_state()
+	icon_state = "wt550[magazine ? "-[CEILING(((get_ammo(FALSE) / magazine.max_ammo) * 20) /4, 1)*4]" : "-0"]" //Sprites only support up to 20.
+*/

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1,9 +1,11 @@
-//In this document: SMGs, Carbines, Rifles, Assault rifles, Machineguns and Misc.
+//IN THIS DOCUMENT: Automatic template, SMGs, Carbines, Semi-auto rifles, Assault rifles, Machineguns and Misc.
+// See gun.dm for keywords and the system used for gun balance
 
 
-////////////////////////////////////
-//AUTOMATIC TEMPLATE AND FUNCTIONS//
-////////////////////////////////////
+
+//////////////////////
+//AUTOMATIC TEMPLATE//
+//////////////////////
 
 
 /obj/item/gun/ballistic/automatic
@@ -161,6 +163,7 @@
 	weapon_weight = WEAPON_HEAVY //Automatic fire and onehanded use mix poorly.
 	slowdown = 0.2
 	fire_delay = 4 //most SMGs are pretty rapid fire
+	burst_shot_delay = 3
 	spread = 10
 	force = 12 //Less good for bashing since smaller than rifles
 	actions_types = list(/datum/action/item_action/toggle_firemode)
@@ -203,7 +206,7 @@
 	icon_state = "grease_gun"
 	item_state = "smg9mm"
 	mag_type = /obj/item/ammo_box/magazine/greasegun
-	fire_delay = 5
+	fire_delay = 4
 	burst_shot_delay = 3.25 //Slow rate of fire
 	can_attachments = TRUE
 	suppressor_state = "uzi_suppressor"
@@ -219,15 +222,15 @@
 			select += 1
 			burst_size = 2
 			spread = 10
-			fire_delay = 5
+			fire_delay = 4.5
+			recoil = 0.1
 			weapon_weight = WEAPON_HEAVY
 			to_chat(user, "<span class='notice'>You switch to automatic fire.</span>")
 		if(1)
 			select = 0
 			burst_size = 1
-			fire_delay = 4.5
-			spread = 3
-			recoil = 0.1
+			fire_delay = 4
+			spread = 2
 			weapon_weight = WEAPON_MEDIUM
 			to_chat(user, "<span class='notice'>You switch to semi-auto.</span>")
 	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
@@ -325,7 +328,7 @@
 	item_state = "cg45"
 	mag_type = /obj/item/ammo_box/magazine/cg45
 	w_class = WEIGHT_CLASS_NORMAL
-	fire_delay = 3
+	fire_delay = 3.5
 	spread = 9
 	recoil = 0.1
 	can_attachments = TRUE
@@ -361,7 +364,7 @@
 	item_state = "fnfal"
 	mag_type = /obj/item/ammo_box/magazine/uzim9mm
 	spread = 8
-	fire_delay = 4
+	fire_delay = 3.5
 	burst_shot_delay = 2
 	suppressed = 1
 	recoil = 0.1
@@ -522,9 +525,9 @@
 
 
 
-//////////
-//RIFLES//
-//////////
+////////////////////
+//SEMI-AUTO RIFLES//
+////////////////////
 
 
 //Service rifle								Keywords: NCR, 5.56mm, Semi-auto, 20 (10-50) round magazine
@@ -547,26 +550,13 @@
 	fire_sound = 'sound/f13weapons/varmint_rifle.ogg'
 
 
-//R82 Heavy service rifle					Keywords: NCR, 5.56mm, Semi-auto, 20 (10-50) round magazine
-/obj/item/gun/ballistic/automatic/service/r82
-	name = "R82 heavy service rifle"
-	desc = "The assault rifle variant of the R84, based off the pre-war FN FNC. Issued to high-ranking troopers and specialized units. Chambered in 5.56."
-	icon_state = "R82"
-	item_state = "R84"
-	fire_delay = 4
-	can_suppress = TRUE
-	suppressor_state = "rifle_suppressor"
-	suppressor_x_offset = 27
-	suppressor_y_offset = 28
-
-
 //Scout carbine								Keywords: NCR, 5.56mm, Semi-auto, 20 (10-50) round magazine. Special modifiers: spread -1
 /obj/item/gun/ballistic/automatic/service/carbine
 	name = "scout carbine"
 	desc = "A cut down version of the standard-issue service rifle tapped with mounting holes for a scope. Shorter barrel, lower muzzle velocity."
 	icon_state = "scout_carbine"
 	extra_damage = -2
-	fire_delay = 3.5
+	fire_delay = 4
 	spread = 3
 	can_scope = TRUE
 	scope_state = "scope_short"
@@ -741,7 +731,6 @@
 	desc = "A DKS 501, chambered in .308 Winchester.  With a light polymer body, it's suited for long treks through the desert."
 	icon_state = "sniper_rifle"
 	item_state = "sniper_rifle"
-	w_class = WEIGHT_CLASS_NORMAL
 	mag_type = /obj/item/ammo_box/magazine/w308
 	fire_delay = 10
 	burst_size = 1
@@ -764,6 +753,19 @@
 //////////////////
 
 
+//R82 Heavy service rifle					Keywords: NCR, 5.56mm, Semi-auto, 20 (10-50) round magazine
+/obj/item/gun/ballistic/automatic/service/r82
+	name = "R82 heavy service rifle"
+	desc = "The assault rifle variant of the R84, based off the pre-war FN FNC. Issued to high-ranking troopers and specialized units. Chambered in 5.56."
+	icon_state = "R82"
+	item_state = "R84"
+	fire_delay = 4.2
+	can_suppress = TRUE
+	suppressor_state = "rifle_suppressor"
+	suppressor_x_offset = 27
+	suppressor_y_offset = 28
+
+
 //R91 assault rifle							Keywords: 5.56mm, Automatic, 20 (10-50) round magazine
 /obj/item/gun/ballistic/automatic/assault_rifle
 	name = "r91 assault rifle"
@@ -772,7 +774,7 @@
 	item_state = "fnfal"
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
 	fire_delay = 4
-	spread = 7
+	spread = 8
 	recoil = 0.1
 	can_attachments = TRUE
 	can_bayonet = TRUE
@@ -839,6 +841,7 @@
 	extra_damage = -3
 	can_suppress = FALSE
 
+
 //Bozar										Keywords: 5.56mm, Automatic, 20 (10-50) round magazine
 /obj/item/gun/ballistic/automatic/bozar
 	name = "Bozar"
@@ -870,8 +873,8 @@
 	slot_flags = 0
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
 	fire_delay = 3.5
-	burst_shot_delay = 2
-	spread = 10
+	burst_shot_delay = 2.2
+	spread = 9
 	recoil = 0.1
 	can_attachments = TRUE
 	can_scope = TRUE
@@ -904,6 +907,25 @@
 	recoil = 0.25
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 	fire_sound = 'sound/f13weapons/assaultrifle_fire.ogg'
+
+
+//H&K G11									Keywords: 4.73mm, Automatic, 50 round magazine
+/obj/item/gun/ballistic/automatic/g11
+	name = "g11"
+	desc = "This experimental german gun fires a caseless cartridge consisting of a block of propellant with a bullet buried inside. The weight and space savings allows for a very high magazine capacity. Chambered in 4.73mm."
+	icon_state = "g11"
+	item_state = "g11"
+	mag_type = /obj/item/ammo_box/magazine/m473
+	fire_delay = 2.5
+	burst_shot_delay = 1.5
+	can_attachments = TRUE
+	can_automatic = TRUE
+	semi_auto = TRUE
+	can_scope = FALSE
+	spread = 8
+	zoomable = TRUE
+	zoom_amt = 10
+	zoom_out_amt = 13
 
 
 
@@ -941,7 +963,7 @@
 			select = 0
 			burst_size = 5
 			spread = 16
-			extra_damage = -6
+			extra_damage = -7
 			recoil = 0.75
 			to_chat(user, "<span class='notice'>You switch to full auto.</span>")
 	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
@@ -1091,23 +1113,6 @@
 ////////
 
 
-//Auto-pipe rifle. The ultimate in hobo firearms. .357 autofire, inaccurate as hell, slow RoF.
-/obj/item/gun/ballistic/automatic/autopipe
-	name = "Auto-pipe rifle (.357)"
-	desc = "A belt fed pipe rifle held together with duct tape. Highly inaccurate. What could go wrong."
-	icon = 'icons/fallout/objects/guns/ballistic.dmi'
-	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'
-	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
-	icon_state = "autopipe"
-	item_state = "autopipe"
-	mag_type = /obj/item/ammo_box/magazine/autopipe
-	burst_size = 4
-	fire_delay = 26
-	burst_shot_delay = 5
-	spread = 24
-	fire_sound = 'sound/weapons/Gunshot.ogg'
-
-
 //M72 Gauss rifle
 /obj/item/gun/ballistic/automatic/m72
 	name = "\improper M72 gauss rifle"
@@ -1141,135 +1146,3 @@
 	zoom_amt = 10
 	zoom_out_amt = 13
 	can_scope = FALSE
-
-/obj/item/gun/ballistic/automatic/g11
-	name = "g11"
-	desc = "This gun revolutionized assault weapon design. The weapon fires a caseless cartridge consisting of a block of propellant with a bullet buried inside. The resultant weight and space savings allow this weapon to have a very high magazine capacity. Chambered in 4.73mm."
-	icon_state = "g11"
-	item_state = "g11"
-	mag_type = /obj/item/ammo_box/magazine/m473
-	fire_delay = 2.5
-	burst_shot_delay = 1.5
-	can_attachments = TRUE
-	can_automatic = TRUE
-	semi_auto = TRUE
-	can_scope = FALSE
-	spread = 9
-	zoomable = TRUE
-	zoom_amt = 10
-	zoom_out_amt = 13
-
-/obj/item/gun/ballistic/automatic/g11/upgraded
-	name = "g11e"
-	icon_state = "g11e"
-	item_state = "g11e"
-	fire_delay = 2.0
-	burst_shot_delay = 1.25
-	spread = 7
-
-
-
-/////////////////
-//CODE SNIPPETS//
-/////////////////
-
-/*
-CODE FOR ASSAULT RIFE WITH GRENADE LAUNCHER ATTACHED
-/obj/item/gun/ballistic/automatic/m90
-	name = "\improper M-90gl Carbine"
-	desc = "A three-round burst 5.56 toploading carbine, designated 'M-90gl'. Has an attached underbarrel grenade launcher which can be toggled on and off."
-	icon_state = "m90"
-	item_state = "m90"
-	mag_type = /obj/item/ammo_box/magazine/m556
-	fire_sound = 'sound/weapons/gunshot_smg.ogg'
-	can_suppress = FALSE
-	automatic_burst_overlay = FALSE
-	var/obj/item/gun/ballistic/revolver/grenadelauncher/underbarrel
-
-/obj/item/gun/ballistic/automatic/m90/Initialize()
-	. = ..()
-	underbarrel = new /obj/item/gun/ballistic/revolver/grenadelauncher(src)
-	update_icon()
-
-/obj/item/gun/ballistic/automatic/m90/unrestricted
-	pin = /obj/item/firing_pin
-
-/obj/item/gun/ballistic/automatic/m90/unrestricted/Initialize()
-	. = ..()
-	underbarrel = new /obj/item/gun/ballistic/revolver/grenadelauncher/unrestricted(src)
-	update_icon()
-
-/obj/item/gun/ballistic/automatic/m90/afterattack(atom/target, mob/living/user, flag, params)
-	if(select == 2)
-		underbarrel.afterattack(target, user, flag, params)
-	else
-		. = ..()
-		return
-/obj/item/gun/ballistic/automatic/m90/attackby(obj/item/A, mob/user, params)
-	if(istype(A, /obj/item/ammo_casing))
-		if(istype(A, underbarrel.magazine.ammo_type))
-			underbarrel.attack_self()
-			underbarrel.attackby(A, user, params)
-	else
-		..()
-/obj/item/gun/ballistic/automatic/m90/update_overlays()
-	. = ..()
-	switch(select)
-		if(0)
-			. += "[initial(icon_state)]semi"
-		if(1)
-			. += "[initial(icon_state)]burst"
-		if(2)
-			. += "[initial(icon_state)]gren"
-
-/obj/item/gun/ballistic/automatic/m90/update_icon_state()
-	icon_state = "[initial(icon_state)][magazine ? "" : "-e"]"
-
-/obj/item/gun/ballistic/automatic/m90/burst_select()
-	var/mob/living/carbon/human/user = usr
-	switch(select)
-		if(0)
-			select = 1
-			burst_size = initial(burst_size)
-			to_chat(user, "<span class='notice'>You switch to [burst_size]-rnd burst.</span>")
-		if(1)
-			select = 2
-			to_chat(user, "<span class='notice'>You switch to grenades.</span>")
-		if(2)
-			select = 0
-			burst_size = 1
-			to_chat(user, "<span class='notice'>You switch to semi-auto.</span>")
-	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
-	update_icon()
-	return
-
-
-LONG SCOPE
-	zoomable = TRUE
-	zoom_amt = 10 //Long range, enough to see in front of you, but no tiles behind you.
-	zoom_out_amt = 13
-
-
-MAG ICON CODE
-/obj/item/gun/ballistic/automatic/surplus/update_icon_state()
-	if(magazine)
-		icon_state = "surplus"
-	else
-		icon_state = "surplus-e"
-
-SPREAD UPON BURST TOGGLE
-/obj/item/gun/ballistic/automatic/wt550/enable_burst()
-	. = ..()
-	spread = 15
-
-/obj/item/gun/ballistic/automatic/wt550/disable_burst()
-	. = ..()
-	spread = 0
-
-ICON UPDATE FOR GRADUAL DEPLETION, PLASTIC MAGS ETC
-/obj/item/gun/ballistic/automatic/c20r/update_icon_state()
-	icon_state = "c20r[magazine ? "-[CEILING(get_ammo(0)/4, 1)*4]" : ""][chambered ? "" : "-e"][suppressed ? "-suppressed" : ""]"
-
-/obj/item/gun/ballistic/automatic/wt550/update_icon_state()
-	icon_state = "wt550[magazine ? "-[CEILING(((get_ammo(FALSE) / magazine.max_ammo) * 20) /4, 1)*4]" : "-0"]" //Sprites only support up to 20.
-*/

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -1,4 +1,12 @@
-// IN THIS DOCUMENT :  Semi-automatic pistols
+//IN THIS DOCUMENT: Pistol template, Light pistols, Heavy pistols
+// See gun.dm for keywords and the system used for gun balance
+
+
+
+///////////////////
+//PISTOL TEMPLATE//
+///////////////////
+
 
 /obj/item/gun/ballistic/automatic/pistol
 	slowdown = 0.1
@@ -36,9 +44,9 @@
 
 
 
-///////////
-//PISTOLS//
-///////////
+/////////////////
+//LIGHT PISTOLS//
+/////////////////
 
 
 //.22 Sport						Keywords: .22, Semi-auto, 16 round magazine, Suppressed
@@ -236,6 +244,12 @@
 	fire_sound = 'sound/f13weapons/45revolver.ogg'
 
 
+
+/////////////////
+//HEAVY PISTOLS//
+/////////////////
+
+
 //Desert Eagle					Keywords: .44 Magnum, Semi-auto, Long barrel, 8 round magazine, Heavy. Special modifiers: bullet speed +300, damage +1
 /obj/item/gun/ballistic/automatic/pistol/deagle
 	name = "Desert Eagle"
@@ -300,58 +314,3 @@
 	extra_damage = 2
 	extra_penetration = 0.05
 	fire_delay = 4
-
-
-
-/////////////////
-//CODE SNIPPETS//
-/////////////////
-/*
-Code for weird stick gun pickup
-/obj/item/gun/ballistic/automatic/pistol/stickman/pickup(mob/living/user)
-	. = ..()
-	to_chat(user, "<span class='notice'>As you try to pick up [src], it slips out of your grip..</span>")
-	if(prob(50))
-		to_chat(user, "<span class='notice'>..and vanishes from your vision! Where the hell did it go?</span>")
-		qdel(src)
-		user.update_icons()
-	else
-		to_chat(user, "<span class='notice'>..and falls into view. Whew, that was a close one.</span>")
-		user.dropItemToGround(src)
-
-/obj/item/gun/ballistic/automatic/pistol/deagle/update_overlays()
-	. = ..()
-	if(magazine)
-		. += "deagle_magazine"
-
-Citadel modular pistol code
-/obj/item/gun/ballistic/automatic/pistol/modular
-	name = "modular pistol"
-	desc = "A small, easily concealable 10mm handgun. Has a threaded barrel for suppressors."
-	icon = 'modular_citadel/icons/obj/guns/cit_guns.dmi'
-	icon_state = "cde"
-	can_unsuppress = TRUE
-	automatic_burst_overlay = FALSE
-	obj_flags = UNIQUE_RENAME
-	unique_reskin = list("Default" = "cde",
-						"N-99" = "n99",
-						"Stealth" = "stealthpistol",
-						"HKVP-78" = "vp78",
-						"Luger" = "p08b",
-						"Mk.58" = "secguncomp",
-						"PX4 Storm" = "px4"
-						)
-
-/obj/item/gun/ballistic/automatic/pistol/modular/update_icon_state()
-	if(current_skin)
-		icon_state = "[unique_reskin[current_skin]][chambered ? "" : "-e"][suppressed ? "-suppressed" : ""]"
-	else
-		icon_state = "[initial(icon_state)][chambered ? "" : "-e"][suppressed ? "-suppressed" : ""]"
-
-/obj/item/gun/ballistic/automatic/pistol/modular/update_overlays()
-	. = ..()
-	if(magazine && suppressed)
-		. += "[unique_reskin[current_skin]]-magazine-sup"	//Yes, this means the default iconstate can't have a magazine overlay
-	else if (magazine)
-		. += "[unique_reskin[current_skin]]-magazine"
-*/

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -1,3 +1,7 @@
+// In this document: Revolvers, Needlers, Weird revolvers
+// See gun.dm for keywords and the system used for gun balance
+
+
 /obj/item/gun/ballistic/revolver
 	slowdown = 0.1
 	name = "revolver template"
@@ -423,35 +427,6 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/revneedler
 	fire_sound = 'sound/weapons/gunshot_silenced.ogg'
 	w_class = WEIGHT_CLASS_SMALL
-
-
-//Hobo guns
-
-/obj/item/gun/ballistic/revolver/zipgun
-	name = "zipgun (9mm)"
-	desc = "A crudely-made 9mm pistol. You're not sure this thing is reliable."
-	icon_state = "zipgun"
-	item_state = "gun"
-	fire_sound = 'sound/weapons/Gunshot.ogg'
-	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/improvised9mm
-	spread = 20
-
-/obj/item/gun/ballistic/revolver/pipe_rifle
-	name = "pepperbox gun (10mm)"
-	desc = "Take six pipes. Tie them together. Add planks, 10mm ammo and prayers."
-	icon_state = "pepperbox"
-	item_state = "improvgun"
-	fire_sound = 'sound/weapons/Gunshot.ogg'
-	extra_damage = 1
-	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/improvised10mm
-	w_class = WEIGHT_CLASS_BULKY
-	weapon_weight = WEAPON_HEAVY
-	spread = 15
-
-/obj/item/gun/ballistic/revolver/pipe_rifle/attackby(obj/item/A, mob/user, params)
-	..()
-	if(A.tool_behaviour == TOOL_SAW || istype(A, /obj/item/gun/energy/plasmacutter))
-		sawoff(user)
 
 
 // LEGACY STUFF

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -1,131 +1,15 @@
-//In this document. Lever action rifles, Bolt action rifles
-
-//////////////////////////////////////////
-//UNIVERSAL GUN CATEGORIES AND MODIFIERS//
-//////////////////////////////////////////
-/*
-GENERAL
-
-	Bonuses should not go far from this framework, for non-unique stuff plus minus one or two is enough to give a good spread, considering its compounded by tinkering and attachments and ammo.
-	A reduction of 1 in burst shot delay gives a lot more effect than adding 1 damage.
-
-MECHANISMS
-
-	SINGLE ACTION REVOLVER
-	fire_delay = 7
-	spread = 1
-
-	DOUBLE ACTION REVOLVER
-	fire_delay = 6	
-	spread = 2
-
-	SEMI-AUTOMATIC PISTOL
-	fire_delay = 3-5	
-	spread = 3
-
-	SEMI-AUTOMATIC RIFLE
-	fire_delay = 3-6
-	spread = 1-2
-
-	AUTOMATIC
-	fire_delay = 3-7
-	burst_shot_delay = 2.5
-	spread = 7-14
-
-	REPEATER	
-	fire_delay = 8
-	spread = 1	
-
-	DOUBLE BARREL
-	fire_delay = 1
-
-	PUMP-ACTION
-	fire_delay = 7
-	extra damage = 1
-	spread = 0 (shotguns need 0 spread unless sawn off since it scatters the individual pellets. Slugs have gotten a 2 spread increase instead, so all good.)
-	(requires manual action to cycle)
-
-	BOLT-ACTION
-	fire_delay = 10-15
-	extra damage = 5
-	extra_speed = 500
-	(requires manual action to cycle)
-
-BULK
-	SMALL GUNS
-	slowdown = 0.1-0.2
-	w_class = WEIGHT_CLASS_SMALL
-	weapon_weight = WEAPON_LIGHT - MEDIUM		
-
-	MEDIUM GUNS
-	slowdown = 0.3-0.4
-	w_class = WEIGHT_CLASS_NORMAL - BULKY
-	weapon_weight = WEAPON_MEDIUM - HEAVY	
-
-	RIFLES 
-	slowdown = 0.5
-	w_class = WEIGHT_CLASS_BULKY
-	weapon_weight = WEAPON_HEAVY
-
-PARTS
-
-	PISTOL GRIP/FOLDED STOCK MALUS
-	For rifles, not pistols obviously
-	recoil = +0.5
-	spread = +2 unless shotgun
-
-	SAWN OFF
-	recoil = 1
-	spread = 10
-	weapon_weight = WEAPON_LIGHT
-
-	LONG BARREL
-	extra_damage = +2
-	spread = -1
-
-	SHORT BARREL
-	extra_damage = -2
-	spread = +3
-
-	HEAVY
-	recoil = 0.1
-	No dual wield
-
-	AMMO RECOIL BASE VALUES
-	.50  recoil = 1
-	.45/70  recoil = 0.25
+//IN THIS DOCUMENT: Rifle template, Lever-action rifles, Bolt-action rifles, Magazine-fed bolt-action rifles
+// See gun.dm for keywords and the system used for gun balance
 
 
-FORCE 	Delicate, clumsy or small gun force 10
-		Pistol whip force 12
-		Rifle type force 15
-		Unusually sturdy clublike 20
 
-ATTACHMENTS
-
-	BURST CAM
-	burst_size + 1
-	spread + 5 (recoil)
-	burst_shot_delay + 0.5 (recoil managment)
-
-	RECOIL COMPENSATOR
-	spread above 10 = -4 spread
-	spread under 10 = -2 spread
-
-	AUTO SEAR
-	Enables fire select automatic
-	burst_size + 1
-	spread + 6 (to bring it into the automatic template range)
-*/
+////////////////////
+// RIFLE TEMPLATE //
+////////////////////
 
 
-////////////
-// RIFLES //
-////////////
-
-// Rifle template
 /obj/item/gun/ballistic/rifle
-	slowdown = 0.5 
+
 	name = "rifle template"
 	desc = "Should not exist"
 	icon = 'icons/fallout/objects/guns/ballistic.dmi'
@@ -137,6 +21,7 @@ ATTACHMENTS
 	weapon_weight = WEAPON_HEAVY
 	slot_flags = ITEM_SLOT_BACK
 	can_automatic = FALSE
+	slowdown = 0.5 
 	fire_delay = 8
 	spread = 1
 	force = 15 //Decent clubs generally speaking
@@ -210,10 +95,6 @@ ATTACHMENTS
 /obj/item/gun/ballistic/rifle/repeater
 	name = "repeater template"
 	desc = "should not exist"
-	w_class = WEIGHT_CLASS_BULKY
-	weapon_weight = WEAPON_HEAVY
-	fire_delay = 8 //Standard repeater mechanism delay 
-	can_automatic = FALSE
 	can_scope = TRUE
 	scope_state = "scope_long"
 	scope_x_offset = 5
@@ -274,8 +155,8 @@ ATTACHMENTS
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/hunting
 	sawn_desc = "A hunting rifle, crudely shortened with a saw. It's far from accurate, but the short barrel makes it quite portable."
 	fire_delay = 10
-	extra_damage = 5
-	extra_speed = 500
+	extra_damage = 6
+	extra_speed = 800
 	spread = 0
 	force = 18
 	can_scope = TRUE
@@ -300,9 +181,9 @@ ATTACHMENTS
 	desc = "A militarized hunting rifle rechambered to 7.62. This one has had the barrel floated with shims to increase accuracy. In use by 1st Recon and designated marksman throughout the NCR."
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/hunting/remington
 	fire_delay = 12
-	extra_damage = 6
+	extra_damage = 7
 	extra_penetration = 0.05
-	extra_speed = 500 
+	extra_speed = 800 
 	force = 18
 	untinkerable = TRUE
 
@@ -346,8 +227,8 @@ ATTACHMENTS
 	icon_state = "mosin"
 	item_state = "308"
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction
-	extra_damage = 4
-	extra_speed = 400
+	extra_damage = 5
+	extra_speed = 600
 	fire_delay = 12
 	force = 18
 	can_scope = TRUE
@@ -371,7 +252,7 @@ ATTACHMENTS
 /obj/item/gun/ballistic/rifle/mag
 	name = "magazine fed bolt-action rifle template"
 	desc = "should not exist."
-	extra_speed = 500
+	extra_speed = 800
 
 /obj/item/gun/ballistic/rifle/mag/examine(mob/user)
 	. = ..()
@@ -415,8 +296,8 @@ ATTACHMENTS
 	init_mag_type = /obj/item/ammo_box/magazine/m556/rifle/small
 	fire_delay = 9
 	spread = 0
-	extra_damage = 4
-	extra_speed = 400
+	extra_damage = 5
+	extra_speed = 700
 	can_bayonet = FALSE
 	scope_state = "scope_short"
 	scope_x_offset = 4
@@ -428,16 +309,16 @@ ATTACHMENTS
 	fire_sound = 'sound/f13weapons/varmint_rifle.ogg'
 
 
-//Commando carbine							Keywords: BOS, .45 ACP, Bolt-action, 12 round magazine, Long barrel, Suppressed
+//Commando carbine							Keywords: BOS, .45 ACP, Bolt-action, 12 round magazine, Long barrel, Suppressed, Reduces spread
 /obj/item/gun/ballistic/rifle/mag/commando
 	name = "commando carbine"
 	desc = "An integrally suppressed bolt action carbine, the few existing examples of this rare gun are mostly in Brotherhood hands. Uses .45 socom magazines."
 	icon_state = "commando"
 	item_state = "varmintrifle"
 	mag_type = /obj/item/ammo_box/magazine/m45exp
-	extra_damage = 7
+	extra_damage = 8
 	fire_delay = 8
-	spread = 1
+	spread = 0
 	can_unsuppress = FALSE
 	suppressed = 1
 	scope_state = "scope_medium"
@@ -452,7 +333,7 @@ ATTACHMENTS
 	desc = "A modified varmint rifle with better stopping power, a scope, and suppressor. Oh, don't forget the sick paint job."
 	icon_state = "ratslayer"
 	item_state = "ratslayer"
-	extra_damage = 8
+	extra_damage = 9
 	extra_penetration = 0.1
 	zoomable = TRUE
 	zoom_amt = 10
@@ -482,113 +363,3 @@ ATTACHMENTS
 	zoom_out_amt = 13
 	fire_sound = 'sound/f13weapons/antimaterielfire.ogg'
 	pump_sound = 'sound/f13weapons/antimaterielreload.ogg'
-
-
-/////////////
-//HOBO GUNS//
-/////////////
-
-
-//Laser musket
-/obj/item/gun/ballistic/rifle/lasmusket
-	name = "Laser Musket"
-	desc = "In the wasteland, one must make do. And making do is what the creator of this weapon does. Made from metal scraps, electronic parts. an old rifle stock and a bottle full of dreams, the Laser Musket is sure to stop anything in their tracks and make those raiders think twice."
-	icon = 'icons/fallout/objects/guns/energy.dmi'
-	icon_state = "lasmusket"
-	item_state = "lasmusket"
-	mag_type = /obj/item/ammo_box/magazine/internal/shot/lasmusket
-	fire_delay = 15
-	isenergy = TRUE
-	var/bolt_open = FALSE
-	can_bayonet = TRUE
-	knife_x_offset = 22
-	knife_y_offset = 20
-	bayonet_state = "bayonet"
-	can_scope = TRUE
-	scope_state = "scope_long"
-	scope_x_offset = 11
-	scope_y_offset = 14
-	fire_sound = 'sound/f13weapons/lasmusket_fire.ogg'
-	pump_sound = 'sound/f13weapons/lasmusket_crank.ogg'
-	equipsound = 'sound/f13weapons/equipsounds/aep7equip.ogg'
-
-
-//Plasma musket.
-/obj/item/gun/ballistic/rifle/plasmacaster
-	name = "Plasma Musket"
-	desc = "The cooling looks dubious and is that a empty can of beans used as a safety valve? Pray the plasma goes towards the enemy and not your face when you pull the trigger."
-	icon = 'icons/fallout/objects/guns/energy.dmi'
-	icon_state = "plasmamusket"
-	item_state = "plasmamusket"
-	mag_type = /obj/item/ammo_box/magazine/internal/plasmacaster
-	fire_delay = 20
-	var/bolt_open = FALSE
-	isenergy = TRUE
-	can_scope = TRUE
-	scope_state = "scope_medium"
-	scope_x_offset = 9
-	scope_y_offset = 20
-	fire_sound = 'sound/f13weapons/lasmusket_fire.ogg'
-	pump_sound = 'sound/f13weapons/lasmusket_crank.ogg'
-	equipsound = 'sound/f13weapons/equipsounds/aep7equip.ogg'
-
-
-//Slamfire shotgun.
-/obj/item/gun/ballistic/revolver/single_shotgun
-	name = "Slamfire shotgun"
-	desc = "A pipe, some wood and a screwdriver is all you need to fire a shotgun shell apparantly."
-	icon = 'icons/fallout/objects/guns/ballistic.dmi'
-	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'
-	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
-	icon_state = "shotgunimprov"
-	item_state = "improvgun"
-	force = 20 //Good club
-	mag_type = /obj/item/ammo_box/magazine/internal/shot/improvised
-	sawn_desc = "At this point, you're basically holding an individual shotgun shell as it goes off."
-	fire_sound = 'sound/f13weapons/caravan_shotgun.ogg'
-
-/obj/item/gun/ballistic/revolver/single_shotgun/attackby(obj/item/A, mob/user, params)
-	..()
-	if(istype(A, /obj/item/circular_saw) || istype(A, /obj/item/gun/energy/plasmacutter))
-		sawoff(user)
-	if(istype(A, /obj/item/melee/transforming/energy))
-		var/obj/item/melee/transforming/energy/W = A
-		if(W.active)
-			sawoff(user)
-
-
-
-/////////////////
-//CODE SNIPPETS//
-/////////////////
-
-
-/*
-SOME SORT OF  BOLT ACTION CODE UNUSED
-/obj/item/gun/ballistic/shotgun/boltaction/pump(mob/M)
-	playsound(M, 'sound/weapons/shotgunpump.ogg', 60, 1)
-	if(bolt_open)
-		pump_reload(M)
-	else
-		pump_unload(M)
-	bolt_open = !bolt_open
-	update_icon()	//I.E. fix the desc
-	return 1
-
-/obj/item/gun/ballistic/shotgun/boltaction/pump(mob/M)
-	playsound(M, 'sound/weapons/shotgunpump.ogg', 60, 1)
-	pump_unload(M)
-	pump_reload(M)
-	update_icon()	//I.E. fix the desc
-	return 1
-
-/obj/item/gun/ballistic/shotgun/boltaction/attackby(obj/item/A, mob/user, params)
-	if(!bolt_open)
-		to_chat(user, "<span class='notice'>The bolt is closed!</span>")
-		return
-	. = ..()
-
-/obj/item/gun/ballistic/shotgun/boltaction/examine(mob/user)
-	. = ..()
-	. += "The bolt is [bolt_open ? "open" : "closed"]."
-*/

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -1,132 +1,13 @@
-//In this document. Double barrel shotguns, Pump-action shotguns, Semi-auto shotgun, Bolt action rifles
-
-//////////////////////////////////////////
-//UNIVERSAL GUN CATEGORIES AND MODIFIERS//
-//////////////////////////////////////////
-/*
-GENERAL
-
-	Bonuses should not go far from this framework, for non-unique stuff plus minus one or two is enough to give a good spread, considering its compounded by tinkering and attachments and ammo.
-	A reduction of 1 in burst shot delay gives a lot more effect than adding 1 damage.
-
-MECHANISMS
-
-	SINGLE ACTION REVOLVER
-	fire_delay = 7
-	spread = 1
-
-	DOUBLE ACTION REVOLVER
-	fire_delay = 6	
-	spread = 2
-
-	SEMI-AUTOMATIC PISTOL
-	fire_delay = 3-5	
-	spread = 3
-
-	SEMI-AUTOMATIC RIFLE
-	fire_delay = 3-6
-	spread = 1-2
-
-	AUTOMATIC
-	fire_delay = 3-7
-	burst_shot_delay = 2.5
-	spread = 7-14
-
-	REPEATER	
-	fire_delay = 8
-	spread = 1	
-
-	DOUBLE BARREL
-	fire_delay = 1
-
-	PUMP-ACTION
-	fire_delay = 7
-	extra damage = 1
-	spread = 0 (shotguns need 0 spread unless sawn off since it scatters the individual pellets. Slugs have gotten a 2 spread increase instead, so all good.)
-	(requires manual action to cycle)
-
-	BOLT-ACTION
-	fire_delay = 10-15
-	extra damage = 5
-	extra_speed = 500
-	(requires manual action to cycle)
-
-BULK
-	SMALL GUNS
-	slowdown = 0.1-0.2
-	w_class = WEIGHT_CLASS_SMALL
-	weapon_weight = WEAPON_LIGHT - MEDIUM		
-
-	MEDIUM GUNS
-	slowdown = 0.3-0.4
-	w_class = WEIGHT_CLASS_NORMAL - BULKY
-	weapon_weight = WEAPON_MEDIUM - HEAVY	
-
-	RIFLES 
-	slowdown = 0.5
-	w_class = WEIGHT_CLASS_BULKY
-	weapon_weight = WEAPON_HEAVY
-
-TRAITS
-
-	PISTOL GRIP/FOLDED STOCK MALUS
-	For rifles, not pistols obviously
-	recoil = 0.5
-	spread = +2 (not for shotguns)
-	w_class = WEIGHT_CLASS_NORMAL
-
-	SAWN OFF
-	recoil = 1
-	spread = 10
-	weapon_weight = WEAPON_LIGHT
-
-	LONG BARREL/LASERSIGHT
-	extra_damage = +2
-	spread = -1
-
-	SHORT BARREL
-	extra_damage = -2
-	spread = +3
-
-	HEAVY
-	recoil = 0.1
-	No dual wield
-
-	AMMO RECOIL BASE VALUES
-	.50  recoil = 1
-	.45/70  recoil = 0.25
-
-	2-ROUND BURTS
-	recoil = 0.1
-
-	3-ROUND BURST
-	recoil = 0.25
+//IN THIS DOCUMENT: Shotgun template, Double barrel shotguns, Pump-action shotguns, Semi-auto shotgun
+// See gun.dm for keywords and the system used for gun balance
 
 
-FORCE 	Delicate, clumsy or small gun force 10
-		Pistol whip force 12
-		Rifle type force 15
-		Unusually sturdy clublike 20
 
-ATTACHMENTS
+//////////////////////
+// SHOTGUN TEMPLATE //
+//////////////////////
 
-	BURST CAM
-	burst_size + 1
-	spread + 5 (recoil)
-	burst_shot_delay + 0.5 (recoil managment)
 
-	RECOIL COMPENSATOR
-	spread above 10 = -4 spread
-	spread under 10 = -2 spread
-
-	AUTO SEAR
-	Enables fire select automatic
-	burst_size + 1
-	recoil = +´0.1
-	spread + 6 (to bring it into the automatic template range)
-*/
-
-//Shotgun template
 /obj/item/gun/ballistic/shotgun
 	slowdown = 0.4 //Bulky gun slowdown with rebate since generally smaller than assault rifles
 	name = "shotgun template"
@@ -141,7 +22,7 @@ ATTACHMENTS
 	slot_flags = ITEM_SLOT_BACK
 	force = 15 //Decent clubs generally speaking
 	fire_delay = 7 //Typical pump action, pretty fast.
-	spread = 0
+	spread = 1
 	recoil = 0.1
 	flags_1 =  CONDUCT_1
 	mag_type = /obj/item/ammo_box/magazine/internal/shot
@@ -213,10 +94,9 @@ ATTACHMENTS
 ////////////////////////////////////////
 //DOUBLE BARREL & PUMP ACTION SHOTGUNS//
 ////////////////////////////////////////
-//Sawn off gives additional recoil and spread but lowers weight.
 
 
-//Caravan shotgun. Double barrel, saw-off, extra damage.
+//Caravan shotgun. Double barrel, saw-off, Extra damage +2
 /obj/item/gun/ballistic/revolver/caravan_shotgun
 	name = "caravan shotgun"
 	desc = "An common over-under double barreled shotgun."
@@ -229,7 +109,7 @@ ATTACHMENTS
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 1
 	extra_damage = 2
-	force = 20
+	force = 19
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/dual
 	sawn_desc = "Short and concealable, terribly uncomfortable to fire, but worse on the other end."
 	fire_sound = 'sound/f13weapons/caravan_shotgun.ogg'
@@ -252,7 +132,7 @@ ATTACHMENTS
 		icon_state = "[initial(icon_state)]"
 
 
-//Widowmaker. Double barrel, saw-off.
+//Widowmaker. Double barrel, saw-off, Fire delay -1, Extra damage +1
 /obj/item/gun/ballistic/revolver/widowmaker
 	name = "Winchester Widowmaker"
 	desc = "A Winchester Widowmaker double-barreled 12 gauge shotgun, with mahogany furniture"
@@ -264,6 +144,7 @@ ATTACHMENTS
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/dual
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
+	extra_damage = 1
 	fire_delay = 0
 	force = 20
 	sawn_desc = "Someone took the time to chop the last few inches off the barrel and stock of this shotgun. Now, the wide spread of this hand-cannon's short-barreled shots makes it perfect for short-range crowd control."
@@ -287,7 +168,7 @@ ATTACHMENTS
 		icon_state = "[initial(icon_state)]"
 
 
-//Hunting shotgun					Keywords: Shotgun, Pump-action, 4 rounds, Saw-off
+//Hunting shotgun					Keywords: Shotgun, Pump-action, 4 rounds, Saw-off, Extra damage +1
 /obj/item/gun/ballistic/shotgun/hunting
 	name = "hunting shotgun"
 	desc = "A traditional hunting shotgun with wood furniture and a four-shell capacity underneath."
@@ -362,14 +243,14 @@ ATTACHMENTS
 	icon_state = "[current_skin ? unique_reskin[current_skin] : "shotgunpolice"][stock ? "" : "fold"]"
 
 
-//Trench shotgun					Keywords: Shotgun, Pump-action, 5 rounds, Bayonet, Extra firemode, Extra damage +3
+//Trench shotgun					Keywords: Shotgun, Pump-action, 5 rounds, Bayonet, Extra firemode, Extra damage +2
 /obj/item/gun/ballistic/shotgun/trench
 	name = "trench shotgun"
 	desc = "A military shotgun designed for close-quarters fighting, equipped with a bayonet lug."
 	icon_state = "trench"
 	item_state = "shotguntrench"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/trench
-	extra_damage = 3
+	extra_damage = 2
 	var/select = 0
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 	can_bayonet = TRUE
@@ -396,27 +277,26 @@ ATTACHMENTS
 			burst_size = 1
 			fire_delay = 5
 			burst_shot_delay = 4
-			extra_damage = 1
+			extra_damage = 0
 			to_chat(user, "<span class='notice'>You prepare to slamfire the shotgun for a rapid burst of shots.</span>")
 		if(1)
 			select = 0
 			burst_size = 1
-			spread = 0
-			extra_damage = 3
+			spread = 1
+			extra_damage = 2
 			to_chat(user, "<span class='notice'>You go back to firing the shotgun one round at a time.</span>")
+
 
 
 ///////////////////////////
 //SEMI-AUTOMATIC SHOTGUNS//
 ///////////////////////////
 
-
 //Semi-auto shotgun template
 /obj/item/gun/ballistic/shotgun/automatic/combat
 	name = "semi-auto shotgun template"
 	fire_delay = 6
 	recoil = 0.1
-	spread = 0
 
 /obj/item/gun/ballistic/shotgun/automatic/shoot_live_shot(mob/living/user, pointblank = FALSE, mob/pbtarget, message = 1, stam_cost = 0)
 	..()
@@ -427,7 +307,6 @@ ATTACHMENTS
 		icon_state = "[initial(icon_state)]-e"
 	else
 		icon_state = "[initial(icon_state)]"
-
 
 //Browning Auto-5					Keywords: Shotgun, Semi-auto, 4 rounds internal
 /obj/item/gun/ballistic/shotgun/automatic/combat/auto5
@@ -516,128 +395,11 @@ ATTACHMENTS
 	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
 	icon_state = "shotgunriot"
 	item_state = "shotgunriot" 
+	w_class = WEIGHT_CLASS_BULKY
 	mag_type = /obj/item/ammo_box/magazine/d12g
 	fire_delay = 6
 	burst_size = 1
 	recoil = 0.5
-	spread = 0
 	automatic_burst_overlay = FALSE
 	semi_auto = TRUE
 	fire_sound = 'sound/f13weapons/riot_shotgun.ogg'
-
-
-
-/////////////
-//HOBO GUNS//
-/////////////
-
-
-
-//Slamfire shotgun.
-/obj/item/gun/ballistic/revolver/single_shotgun
-	name = "Slamfire shotgun"
-	desc = "A pipe, some wood and a screwdriver is all you need to fire a shotgun shell apparantly."
-	icon = 'icons/fallout/objects/guns/ballistic.dmi'
-	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'
-	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
-	icon_state = "shotgunimprov"
-	item_state = "improvgun"
-	force = 20 //Good club
-	mag_type = /obj/item/ammo_box/magazine/internal/shot/improvised
-	sawn_desc = "At this point, you're basically holding an individual shotgun shell as it goes off."
-	fire_sound = 'sound/f13weapons/caravan_shotgun.ogg'
-
-/obj/item/gun/ballistic/revolver/single_shotgun/attackby(obj/item/A, mob/user, params)
-	..()
-	if(istype(A, /obj/item/circular_saw) || istype(A, /obj/item/gun/energy/plasmacutter))
-		sawoff(user)
-	if(istype(A, /obj/item/melee/transforming/energy))
-		var/obj/item/melee/transforming/energy/W = A
-		if(W.active)
-			sawoff(user)
-
-
-
-/////////////////
-//CODE SNIPPETS//
-/////////////////
-
-
-/*
-CODE FOR RESKIN
-	unique_reskin = list("Tactical" = "cshotgun",
-						"Slick" = "cshotgun_slick"
-						)
-
-
-DUAL TUBE PUMP ACTION (seems redundant with neostead but why not keep it.)
-/obj/item/gun/ballistic/shotgun/automatic/dual_tube/examine(mob/user)
-	. = ..()
-	. += "<span class='notice'>Alt-click to pump it.</span>"
-
-
-/obj/item/gun/ballistic/shotgun/automatic/dual_tube/attack_self(mob/living/user)
-	if(!chambered && magazine.contents.len)
-		pump()
-	else
-		toggle_tube(user)
-
-/obj/item/gun/ballistic/shotgun/automatic/dual_tube/AltClick(mob/living/user)
-	. = ..()
-	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
-		return
-	pump()
-	return TRUE
-
-
-ATTACHING SLING
-/obj/item/gun/ballistic/shotgun/boltaction/improvised/attackby(obj/item/A, mob/user, params)
-	..()
-	if(istype(A, /obj/item/stack/cable_coil) && !sawn_off)
-		if(A.use_tool(src, user, 0, 10, skill_gain_mult = EASY_USE_TOOL_MULT))
-			slot_flags = ITEM_SLOT_BACK
-			to_chat(user, "<span class='notice'>You tie the lengths of cable to the rifle, making a sling.</span>")
-			slung = TRUE
-			update_icon()
-		else
-			to_chat(user, "<span class='warning'>You need at least ten lengths of cable if you want to make a sling!</span>")
-
-/obj/item/gun/ballistic/shotgun/boltaction/improvised/update_overlays()
-	. = ..()
-	if(slung)
-		. += "[icon_state]sling"
-
-HOOK GUN CODE. Bizarre but could be made into something useful.
-/obj/item/gun/ballistic/shotgun/doublebarrel/hook
-	name = "hook modified sawn-off shotgun"
-	desc = "Range isn't an issue when you can bring your victim to you."
-	icon_state = "hookshotgun"
-	item_state = "shotgun"
-	mag_type = /obj/item/ammo_box/magazine/internal/shot/bounty
-	w_class = WEIGHT_CLASS_BULKY
-	weapon_weight = WEAPON_MEDIUM
-	force = 16 //it has a hook on it
-	attack_verb = list("slashed", "hooked", "stabbed")
-	hitsound = 'sound/weapons/bladeslice.ogg'
-	//our hook gun!
-	var/obj/item/gun/magic/hook/bounty/hook
-	var/toggled = FALSE
-
-Not currently implemented due to balance issues
-/obj/item/gun/ballistic/automatic/shotgun/pancor
-	name = "Pancor Jackhammer"
-	desc = "A select fire automatic shotgun, the pinnacle of turning things into swiss cheese."
-	icon_state = "pancor"
-	item_state = "cshotgun1"
-	fire_sound = 'sound/f13weapons/repeater_fire.ogg'
-	burst_size = 3
-
-/obj/item/gun/ballistic/automatic/shotgun/caws
-	name = "H&K CAWS"
-	desc = "A select fire automatic shotgun, a modern variant of the Pancor Jackhammer."
-	icon_state = "caws"
-	item_state = "cshotgun1"
-	fire_sound = 'sound/f13weapons/repeater_fire.ogg'
-	burst_size = 2
-	fire_delay = 4
-*/

--- a/code/modules/projectiles/guns/hoboguns.dm
+++ b/code/modules/projectiles/guns/hoboguns.dm
@@ -1,0 +1,125 @@
+// IN THIS DOCUMENT: Improvised/home made guns
+// See gun.dm for keywords and the system used for gun balance
+
+/obj/item/gun/ballistic/hobo
+	desc = "hobo gun template"
+	name = "should not exist"
+	icon_state = "pistol"
+	w_class = WEIGHT_CLASS_NORMAL
+
+
+/////////////
+//HOBO GUNS//
+/////////////
+
+
+/obj/item/gun/ballistic/revolver/zipgun
+	name = "zipgun (9mm)"
+	desc = "A crudely-made 9mm pistol. You're not sure this thing is reliable."
+	icon_state = "zipgun"
+	item_state = "gun"
+	fire_sound = 'sound/weapons/Gunshot.ogg'
+	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/improvised9mm
+	spread = 20
+
+/obj/item/gun/ballistic/revolver/pipe_rifle
+	name = "pepperbox gun (10mm)"
+	desc = "Take six pipes. Tie them together. Add planks, 10mm ammo and prayers."
+	icon_state = "pepperbox"
+	item_state = "improvgun"
+	fire_sound = 'sound/weapons/Gunshot.ogg'
+	extra_damage = 1
+	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/improvised10mm
+	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_HEAVY
+	spread = 15
+
+/obj/item/gun/ballistic/revolver/pipe_rifle/attackby(obj/item/A, mob/user, params)
+	..()
+	if(A.tool_behaviour == TOOL_SAW || istype(A, /obj/item/gun/energy/plasmacutter))
+		sawoff(user)
+
+
+//Slamfire shotgun.
+/obj/item/gun/ballistic/revolver/single_shotgun
+	name = "Slamfire shotgun"
+	desc = "A pipe, some wood and a screwdriver is all you need to fire a shotgun shell apparantly."
+	icon = 'icons/fallout/objects/guns/ballistic.dmi'
+	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'
+	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
+	icon_state = "shotgunimprov"
+	item_state = "improvgun"
+	force = 20 //Good club
+	mag_type = /obj/item/ammo_box/magazine/internal/shot/improvised
+	sawn_desc = "At this point, you're basically holding an individual shotgun shell as it goes off."
+	fire_sound = 'sound/f13weapons/caravan_shotgun.ogg'
+
+/obj/item/gun/ballistic/revolver/single_shotgun/attackby(obj/item/A, mob/user, params)
+	..()
+	if(istype(A, /obj/item/circular_saw) || istype(A, /obj/item/gun/energy/plasmacutter))
+		sawoff(user)
+	if(istype(A, /obj/item/melee/transforming/energy))
+		var/obj/item/melee/transforming/energy/W = A
+		if(W.active)
+			sawoff(user)
+
+
+//Auto-pipe rifle. The ultimate in hobo firearms. .357 autofire, inaccurate as hell, slow RoF.
+/obj/item/gun/ballistic/automatic/autopipe
+	name = "Auto-pipe rifle (.357)"
+	desc = "A belt fed pipe rifle held together with duct tape. Highly inaccurate. What could go wrong."
+	icon = 'icons/fallout/objects/guns/ballistic.dmi'
+	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'
+	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
+	icon_state = "autopipe"
+	item_state = "autopipe"
+	mag_type = /obj/item/ammo_box/magazine/autopipe
+	burst_size = 4
+	fire_delay = 26
+	burst_shot_delay = 5
+	spread = 24
+	fire_sound = 'sound/weapons/Gunshot.ogg'
+
+
+//Laser musket
+/obj/item/gun/ballistic/rifle/lasmusket
+	name = "Laser Musket"
+	desc = "In the wasteland, one must make do. And making do is what the creator of this weapon does. Made from metal scraps, electronic parts. an old rifle stock and a bottle full of dreams, the Laser Musket is sure to stop anything in their tracks and make those raiders think twice."
+	icon = 'icons/fallout/objects/guns/energy.dmi'
+	icon_state = "lasmusket"
+	item_state = "lasmusket"
+	mag_type = /obj/item/ammo_box/magazine/internal/shot/lasmusket
+	fire_delay = 15
+	isenergy = TRUE
+	var/bolt_open = FALSE
+	can_bayonet = TRUE
+	knife_x_offset = 22
+	knife_y_offset = 20
+	bayonet_state = "bayonet"
+	can_scope = TRUE
+	scope_state = "scope_long"
+	scope_x_offset = 11
+	scope_y_offset = 14
+	fire_sound = 'sound/f13weapons/lasmusket_fire.ogg'
+	pump_sound = 'sound/f13weapons/lasmusket_crank.ogg'
+	equipsound = 'sound/f13weapons/equipsounds/aep7equip.ogg'
+
+
+//Plasma musket.
+/obj/item/gun/ballistic/rifle/plasmacaster
+	name = "Plasma Musket"
+	desc = "The cooling looks dubious and is that a empty can of beans used as a safety valve? Pray the plasma goes towards the enemy and not your face when you pull the trigger."
+	icon = 'icons/fallout/objects/guns/energy.dmi'
+	icon_state = "plasmamusket"
+	item_state = "plasmamusket"
+	mag_type = /obj/item/ammo_box/magazine/internal/plasmacaster
+	fire_delay = 20
+	var/bolt_open = FALSE
+	isenergy = TRUE
+	can_scope = TRUE
+	scope_state = "scope_medium"
+	scope_x_offset = 9
+	scope_y_offset = 20
+	fire_sound = 'sound/f13weapons/lasmusket_fire.ogg'
+	pump_sound = 'sound/f13weapons/lasmusket_crank.ogg'
+	equipsound = 'sound/f13weapons/equipsounds/aep7equip.ogg'

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,6 +1,6 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 55
+	damage = 49
 	sharpness = SHARP_POINTY
 	armour_penetration = 0.3
 	wound_bonus = 26
@@ -19,8 +19,8 @@
 
 /obj/item/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
-	damage = 10
-	stamina = 40
+	damage = 15
+	stamina = 60
 	wound_bonus = 20
 	sharpness = SHARP_NONE
 	embedding = null

--- a/fortune13.dme
+++ b/fortune13.dme
@@ -3719,3 +3719,4 @@
 #include "modular_citadel\code\modules\reagents\objects\items.dm"
 // END_INCLUDE
 #include "code\modules\projectiles\guns\ballistic\rifle.dm"
+#include "code\modules\projectiles\guns\hoboguns.dm"


### PR DESCRIPTION
## About The Pull Request

Boring cleanup, only things that will be noticeable really for most is slug/beanbag adjustments and NCR hat un-memed.

Prefs: Incorrect labeling fixed for ghost options. Balls option uncommented since the stated purpose was to disable only buttons with no mechanical function, and the users Sex Joke and Caligo have pointed out they can no longer refill their field flasks now and whatnot, so according to the principles of the pref cleanup its fair to restore it for now.

Sniper rifle DKS had incorrect weight, as did Riot shotgun, fixed
NCR helmet had bugged helmet strap storage due to lazy ass code having several pockets with same path. Fixed, now the helmet strap can hold a Tiny item, like cigarette pack, instead of two UZIs or whatever.
Adjusts slug more, to 49 dam from 55. Still about 25% more powerful than second closest round, the 7,62, should fix some issues with semi auto meta.
Adjusts bean bags to have +50% power, both damage and stamina. Currently its kind of trash, something has to be done about it.

Small adjustments to the gun templates, small rof adjustment autos (uzi and grease gun most affected), increased projectile speed/damage +1 for bolt actions, adjusted bullet hose damage for LMG with -1 etc etc. Not dramatic stuff.
Sorts the gun files so the gun rules are in one place, with references to it in the child files, the code archive moved to the same file instead of spread out, new file to collect the hobo guns in preparation for some sort of overhaul/balance of those poor guys. 

The unnecessary G11 version called upgrade removed, the vigilante gets the normal one instead. Not a fix for the Vig, its 
to keep the weapon system in order, Vig needs its own PR.

## Changelog
:cl:
fix: NCR helmet bag of holding fix. Slug nerf. Bean bag improved. 
/:cl:
