### PR TITLE
Updates time requirements for Brotherhood of Steel

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -341,7 +341,7 @@ Star Paladin
 	supervisors = "the Head Paladin"
 	selection_color = "#95a5a6"
 
-	exp_requirements = 600
+	exp_requirements = 750
 	exp_type = EXP_TYPE_BROTHERHOOD
 
 	loadout_options = list(
@@ -414,7 +414,7 @@ Paladin
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
 	supervisors = "the Senior Paladin and Head Paladin"
 	selection_color = "#95a5a6"
-	exp_requirements = 300
+	exp_requirements = 450
 
 	loadout_options = list(
 	/datum/outfit/loadout/paladina, //Carbine and aep7
@@ -559,6 +559,8 @@ Scribe
 	supervisors = "the Senior Scribe and Head Scribe"
 	selection_color = "#95a5a6"
 
+	exp_requirements = 300
+
 	loadout_options = list(
 	/datum/outfit/loadout/scribea,
 	/datum/outfit/loadout/scribeb,
@@ -691,6 +693,8 @@ Knight
 	supervisors = "the Senior Knight, and Head Knight"
 	selection_color = "#95a5a6"
 
+	exp_requirements = 300
+
 	loadout_options = list(
 	/datum/outfit/loadout/knighta, //AER9
 	/datum/outfit/loadout/knightb, //lever shotgun and teleshield
@@ -767,6 +771,9 @@ Initiate
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
 	supervisors = "the scribes, knights, or Paladins"
 	selection_color = "#95a5a6"
+
+	exp_type = EXP_TYPE_FALLOUT
+	exp_requirements = 300
 
 	loadout_options = list(
 	/datum/outfit/loadout/initiatek, //AEP7 and Engibelt with combat armor, no helmet


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases time requirements for some roles.
Adds 5 hour time requirement as BoS for Knights and Scribes.
Adds 5 hour time requirement as Living for Initiate.

## Why It's Good For The Game

Right now, one of the most powerful factions has no time requirements for 3 roles. 
This will prevent absolute randoms from picking it instantly and abusing whatever BoS has in their bunker.

## Changelog
:cl:
tweak: BoS time requirements were increased and added for Knights, Scribes and Initiates.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
