### PR TITLE
Quick fix spawn location Legion and Lance for Legion recruit

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -637,11 +637,11 @@ obj/effect/landmark/start/f13/ncrlogisticsofficer
 	icon_state = "Legionary"
 
 /obj/effect/landmark/start/f13/auxilia
-	name = "Household Slave"
+	name = "Legion Auxilia"
 	icon_state = "Wastelander"
 
 /obj/effect/landmark/start/f13/campfollower
-	name = "Camp Duty"
+	name = "Legion Camp Duty"
 	icon_state = "Legionary"
 
 /obj/effect/landmark/start/f13/slave

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -623,7 +623,7 @@ commented out pending rework*/
 
 /datum/outfit/loadout/recruittribal
 	name =			"Tribal Recruit"
-	suit_store = 	/obj/item/twohanded/baseball/spiked
+	suit_store = 	/obj/item/twohanded/spear/lance
 	backpack_contents = list(
 					/obj/item/ammo_box/a357=1,
 					/obj/item/gun/ballistic/revolver/colt357=1)


### PR DESCRIPTION
## About The Pull Request

Fixes the issue reported with spawn locations for legion civilians.
Gives the recruit back the lance for good instead of a baseball bat. It just fits better for a tribal recruit, and should be his forever.