### PR TITLE
Some changes for FEV.

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -310,7 +310,7 @@
 		/mob/living/simple_animal/hostile/ghoul = 6, \
 		/mob/living/simple_animal/hostile/ghoul/glowing = 4, \
 		/mob/living/carbon/human/species/ghoul = 1, \
-		/mob/living/simple_animal/hostile/supermutant/playable = 1) // Lucky bastard
+		/mob/living/carbon/human/species/smutant = 1) // Lucky bastard
 	new_form = pickweight(le_list)
 	. = ..()
 

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -291,7 +291,7 @@
 	cure_text = "mutadone."
 	cures = list(/datum/reagent/medicine/mutadone)
 	cure_chance = 1 // Good luck
-	stage_prob = 20
+	stage_prob = 10
 	agent = "FEV-I toxin strain" // The unstable one.
 	desc = "A megavirus, with a protein sheath reinforced by ionized hydrogen. This virus is capable of mutating the affected into something horrifying..."
 	severity = DISEASE_SEVERITY_BIOHAZARD

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -305,13 +305,14 @@
 
 /datum/disease/transformation/mutant/do_disease_transformation(mob/living/affected_mob)
 	var/list/le_list = list(\
-		/mob/living/simple_animal/hostile/centaur = 8, \
+		/mob/living/simple_animal/hostile/centaur/strong = 8, \
 		/mob/living/simple_animal/hostile/abomination/weak = 7, \
-		/mob/living/simple_animal/hostile/ghoul = 6, \
 		/mob/living/simple_animal/hostile/ghoul/glowing = 4, \
-		/mob/living/carbon/human/species/ghoul = 1, \
-		/mob/living/carbon/human/species/smutant = 1) // Lucky bastard
+		/mob/living/simple_animal/hostile/supermutant/playable = 2, \
+		/mob/living/carbon/human/species/ghoul = 1)
 	new_form = pickweight(le_list)
+	if(!ispath(new_form, /mob/living/carbon)) // If you've become simple_mob - you can't go and be all friendly to those around you!
+		to_chat(affected_mob, "<big><span class='warning'><b>You've become something entirely different! You are being controlled only by your hunger and desire to kill!</b></span></big>")
 	. = ..()
 
 /datum/disease/transformation/mutant/stage_act()
@@ -319,23 +320,22 @@
 	if(!.)
 		return
 
-	affected_mob.adjustCloneLoss(-4, FALSE) // To prevent mob from dying before mutating.
 	switch(stage)
 		if(2)
-			if (prob(4))
+			if (prob(8))
 				to_chat(affected_mob, "<span class='danger'>You feel weird...</span>")
 		if(3)
-			if (prob(6))
+			if (prob(12))
 				to_chat(affected_mob, "<span class='danger'>Your skin twitches...</span>")
 				affected_mob.Jitter(3)
 		if(4)
-			if (prob(15))
+			if (prob(20))
 				to_chat(affected_mob, "<span class='danger'>The pain is unbearable!</span>")
 				affected_mob.emote("cry")
-			if (prob(10))
+			if (prob(15))
 				to_chat(affected_mob, "<span class='danger'>Your skin begins to shift, hurting like hell!</span>")
 				affected_mob.emote("scream")
 				affected_mob.Jitter(4)
-			if (prob(5))
+			if (prob(6))
 				to_chat(affected_mob, "<span class='danger'>Your body shuts down for a moment!</span>")
 				affected_mob.Unconscious(10)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1266,3 +1266,6 @@
 
 /mob/living/carbon/human/species/ghoul
 	race = /datum/species/ghoul
+
+/mob/living/carbon/human/species/smutant
+	race = /datum/species/smutant

--- a/code/modules/mob/living/simple_animal/hostile/f13/centaur.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/centaur.dm
@@ -47,3 +47,9 @@
 	name = "spit"
 	damage = 30
 	icon_state = "toxin"
+
+/mob/living/simple_animal/hostile/centaur/strong // Mostly for FEV mutation
+	melee_damage_lower = 25
+	melee_damage_upper = 25
+	maxHealth = 200
+	health = 200

--- a/code/modules/mob/living/simple_animal/hostile/f13/fallout_NPC.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/fallout_NPC.dm
@@ -690,6 +690,7 @@
 	icon_living = "abomination"
 	icon_dead = "abomination_dead"
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
+	environment_smash = ENVIRONMENT_SMASH_RWALLS
 	robust_searching = 1
 	maxHealth = 1000
 	health = 1000
@@ -697,8 +698,7 @@
 	melee_damage_lower = 75
 	melee_damage_upper = 75
 	attack_verb_simple = "eviscerates"
-	attack_sound = 'sound/weapons/punch1.ogg'
-	attack_verb_simple = "lacerates"
+	attack_sound = 'sound/weapons/bladeslice.ogg'
 	speed = -0.5
 	var/static/list/abom_sounds
 	deathmessage = "wails as its form shudders and violently comes to a stop."
@@ -708,7 +708,7 @@
 	. = ..()
 	if(. && ishuman(target))
 		var/mob/living/carbon/human/H = target
-		var/choice = pick(1, 1, 1, 2, 3)
+		var/choice = pick(1, 1, 2, 2, 3, 4)
 		H.reagents.add_reagent(/datum/reagent/toxin/FEV_solution, choice)
 
 /mob/living/simple_animal/hostile/abomination/Initialize()
@@ -731,11 +731,13 @@
 		playsound(src, chosen_sound, 70, TRUE)
 
 /mob/living/simple_animal/hostile/abomination/weak // For FEV mutation.
+	environment_smash = ENVIRONMENT_SMASH_STRUCTURES // So you don't break walls
 	maxHealth = 300
 	health = 300
 	harm_intent_damage = 8
 	melee_damage_lower = 35
 	melee_damage_upper = 35
+	speed = 2
 
 /mob/living/simple_animal/hostile/abomhorror
 	name = "failed experiment"
@@ -753,7 +755,6 @@
 	melee_damage_upper = 50
 	attack_verb_simple = "eviscerates"
 	attack_sound = 'sound/weapons/punch1.ogg'
-	attack_verb_simple = "lacerates"
 	speed = -0.5
 	var/static/list/abom_sounds
 	deathmessage = "wails as its form shudders and violently comes to a stop."

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -36,7 +36,7 @@
 	description = "An incredibly lethal strain of the Forced Evolutionary Virus. Consume at your own risk."
 	color = "#00FF00"
 	toxpwr = 0
-	overdose_threshold = 20
+	overdose_threshold = 18 // So, someone drinking 20 units will FOR SURE get overdosed
 	taste_description = "horrific agony"
 	taste_mult = 0.9
 
@@ -52,11 +52,12 @@
 	..()
 
 /datum/reagent/toxin/FEV_solution/on_mob_life(mob/living/carbon/C)
-	C.apply_effect(30,EFFECT_IRRADIATE,0)
-	C.adjustCloneLoss(2,0)
+	C.apply_effect(40,EFFECT_IRRADIATE,0)
+	C.adjustCloneLoss(3,0) // ~15 units will get you near crit condition.
 	return ..()
 
 /datum/reagent/toxin/FEV_solution/overdose_process(mob/living/carbon/C)
+	C.adjustCloneLoss(-4,0) // Don't die while you are mutating.
 	C.ForceContractDisease(new /datum/disease/transformation/mutant(), FALSE, TRUE)
 
 /datum/reagent/toxin/mutagen


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- FEV now takes more time to progress.
- FEV now requires less units to overdose.
- FEV now deals more cellular damage without overdose, and more radiation.
- Abomination mob(the one in bunker with FEV) can now break walls.
- Added "strong" centaur subtype to be controlled by those who got mutated by FEV.

## Why It's Good For The Game

FEV right now is hella fast, and usually has barely enough for one person to mutate(unless in foam, in large concentrations). This PR changes it and make FEV a tiny bit more dangerous, but not an instant death after overdose, giving some time to use mutadone to prevent it from happening

Abomination mob isn't supposed to be kited by staying at one specific spot, with this change it will break walls and prevent people from getting easy loot with no losses.

Centaur mob is too weak and dies easily. Giving FEV mutation a bit stronger version would make player experience less frustrating.

## Changelog
:cl:
tweak: FEV virus is now twice as slow in progressing. You will no longer turn into mutant in 5 seconds.
tweak: FEV mutants now have a fluff text when mutating, that states that their memories of previous life are gone. This doesn't happen if they become a carbon mob.
balance: Abomination in bunker with FEV sample can now break walls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
