### PR TITLE
Fix for crew manifest Legion roles

### DIFF
--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -213,24 +213,25 @@ GLOBAL_LIST_INIT(den_positions, list(
 ))
 
 GLOBAL_LIST_INIT(legion_command_positions, list(
+	"Legate"
 	"Legion Centurion",
-	"Legion Venator"
+	"Legion Veteran Decanus"
 ))
 
 GLOBAL_LIST_INIT(legion_positions, list(
-	"Legion Veteran Decanus",
-	"Veteran Legionnaire",
-	"Legion Prime Decanus",
-	"Prime Legionnaire",
-	"Legion Recruit Decanus",
-	"Recruit Legionnaire",
-	"Legion Explorer",
-	"Auxilia",
-	"Camp Follower",
-	"Legion Slave",
-	"Legion Vexillarius",
 	"Legion Centurion",
-	"Legion Venator"
+	"Legion Veteran Decanus",
+	"Legion Prime Decanus",
+	"Legion Recruit Decanus",
+	"Legion Vexillarius",
+	"Veteran Legionnaire",
+	"Prime Legionnaire",
+	"Recruit Legionnaire",
+	"Legion Venator",
+	"Legion Explorer",
+	"Legion Auxilia",
+	"Legion Camp Duty",
+	"Legion Slave"
 ))
 
 GLOBAL_LIST_INIT(ncr_rangervet_positions, list(

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -49,8 +49,9 @@ GLOBAL_LIST_INIT(command_positions, list(
 
 	"Enclave Lieutenant",
 
+	"Legate",
 	"Legion Centurion",
-	"Legion Venator",
+	"Legion Veteran Decanus",
 
 	"Overseer",
 	"Chief of Security",
@@ -93,7 +94,7 @@ GLOBAL_LIST_INIT(faction_whitelist_positions, list(
 "Legion Recruit Decanus",
 "Legion Scout",
 "Legion Explorer",
-"Auxilia",
+"Legion Auxilia",
 "Legion Slave",
 
 "Mayor",
@@ -137,7 +138,7 @@ GLOBAL_LIST_INIT(faction_player_positions, list(
 "Legion Recruit Decanus",
 "Legion Scout",
 "Legion Explorer",
-"Auxilia",
+"Legion Auxilia",
 "Legion Slave",
 
 "Deputy",
@@ -213,7 +214,7 @@ GLOBAL_LIST_INIT(den_positions, list(
 ))
 
 GLOBAL_LIST_INIT(legion_command_positions, list(
-	"Legate"
+	"Legate",
 	"Legion Centurion",
 	"Legion Veteran Decanus"
 ))


### PR DESCRIPTION
## About The Pull Request

Couple wonky Legion roles in the manifest, time to fix.
Legate should now show up as command correctly.
Cent and Vet decan too. 
Venator not shown as command, a man without plume is not fit to command, also makes more sense lorewise the vet dec is second in command.
Auxilia and camp duty listed as Legion and not misc.