### PR TITLE
Removes bluespace tomatoes and bananas.

### DIFF
--- a/code/modules/cargo/bounties/botany.dm
+++ b/code/modules/cargo/bounties/botany.dm
@@ -31,7 +31,6 @@
 /datum/bounty/item/botany/banana
 	name = "Bananas"
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown/banana)
-	exclude_types = list(/obj/item/reagent_containers/food/snacks/grown/banana/bluespace)
 	foodtype = "banana split"
 
 /datum/bounty/item/botany/coconuts
@@ -93,13 +92,13 @@
 	name = "Novaflowers"
 	wanted_types = list(/obj/item/grown/novaflower)
 	multiplier = 2
-
+/*
 /datum/bounty/item/botany/banana_bluespace
 	name = "Bluespace Bananas"
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown/banana/bluespace)
 	multiplier = 2
 	foodtype = "banana split"
-
+*/
 /datum/bounty/item/botany/beans_koi
 	name = "Koi Beans"
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown/koibeans)
@@ -189,11 +188,12 @@
 	multiplier = 4
 	foodtype = "dessert"
 
+/* removed because lrp, cope
 /datum/bounty/item/botany/tomato_bluespace
 	name = "Bluespace Tomatoes"
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown/tomato/blue/bluespace)
 	multiplier = 4
-
+*/
 /datum/bounty/item/botany/cannabis
 	name = "Cannabis Leaves"
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown/cannabis)

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -65,6 +65,7 @@
 	playsound(loc, 'sound/misc/slip.ogg', 50, 1, -1)
 	return (BRUTELOSS)
 
+/*
 // Bluespace Banana
 /obj/item/seeds/banana/bluespace
 	name = "pack of bluespace banana seeds"
@@ -95,7 +96,7 @@
 	name = "bluespace banana peel"
 	desc = "A peel from a bluespace banana."
 	icon_state = "banana_peel_blue"
-
+*/
 //Banana Spider.
 /obj/item/seeds/banana/exotic_banana
 	name = "pack of exotic banana seeds"

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -61,7 +61,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/tomato/blue
 	yield = 2
 	icon_grow = "bluetomato-grow"
-	mutatelist = list(/obj/item/seeds/tomato/blue/bluespace)
+	mutatelist = list()
 	genes = list(/datum/plant_gene/trait/slip, /datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list(/datum/reagent/lube = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 20
@@ -75,6 +75,7 @@
 	filling_color = "#0000FF"
 	distill_reagent = /datum/reagent/consumable/laughter
 
+/* removed because lrp, cope
 // Bluespace Tomato
 /obj/item/seeds/tomato/blue/bluespace
 	name = "pack of bluespace tomato seeds"
@@ -96,6 +97,7 @@
 	icon_state = "bluespacetomato"
 	distill_reagent = null
 	wine_power = 80
+*/
 
 // Killer Tomato
 /obj/item/seeds/tomato/killer


### PR DESCRIPTION
## About The Pull Request

Actually just disables the code for them.

## Why It's Good For The Game

Highly abuseable and not lore friendly, I've seen a video of someone using them to teleport right inside the BoS base.

## Changelog
:cl:
tweak: disabled the bananas and tomatoes
/:cl:
