### PR TITLE
Adds more Ore Redemption Machines around the map

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -2773,15 +2773,6 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
-"bvA" = (
-/obj/machinery/conveyor/auto{
-	dir = 4
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
 "bvO" = (
 /obj/item/ammo_casing/c10mm/ap,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4772,9 +4763,6 @@
 /area/f13/building)
 "cEJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/mine/stun,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -18193,10 +18181,15 @@
 /turf/open/floor/carpet/green,
 /area/f13/ncr)
 "jkA" = (
-/obj/machinery/mineral/processing_unit_console{
-	machinedir = 1
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/closed/wall/r_wall/rust,
+/obj/structure/spider/stickyweb,
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
 /area/f13/building)
 "jkB" = (
 /obj/structure/chair/comfy{
@@ -20015,6 +20008,7 @@
 /area/f13/caves)
 "kez" = (
 /obj/item/storage/toolbox/electrical,
+/obj/structure/rack,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -23455,8 +23449,8 @@
 /area/f13/wasteland)
 "mbl" = (
 /obj/structure/rack,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/metal,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -27905,15 +27899,6 @@
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
-"oDv" = (
-/obj/machinery/conveyor/auto{
-	dir = 6
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
 "oDC" = (
 /obj/structure/chair{
 	dir = 1
@@ -28395,10 +28380,7 @@
 	},
 /area/f13/wasteland)
 "oRu" = (
-/obj/machinery/mineral/processing_unit{
-	input_dir = 8;
-	output_dir = 4
-	},
+/obj/structure/ore_box,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -30417,7 +30399,10 @@
 	},
 /area/f13/building)
 "pPX" = (
-/obj/machinery/mineral/unloading_machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/mineral/ore_redemption,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -33640,12 +33625,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building)
-"rzz" = (
-/obj/machinery/mineral/stacking_unit_console{
-	machinedir = 5
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/building)
 "rzE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/barricade/wooden,
@@ -36636,16 +36615,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"thv" = (
-/obj/machinery/mineral/stacking_machine{
-	input_dir = 1;
-	output_dir = 2
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
 "thG" = (
 /obj/structure/fence{
 	dir = 4
@@ -42734,14 +42703,6 @@
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"woN" = (
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/auto,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
 "woS" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -52663,7 +52624,7 @@ koD
 gcK
 ktB
 dCV
-mZD
+oRu
 rXj
 oeW
 kez
@@ -52921,8 +52882,8 @@ gcK
 ktB
 dCV
 pPX
-dCV
-lTw
+mZD
+mZD
 mZD
 dCV
 rXj
@@ -53177,8 +53138,8 @@ koD
 gcK
 ktB
 dCV
-bvA
-mNT
+oRu
+mZD
 rXj
 rXj
 hkA
@@ -53435,7 +53396,7 @@ gcK
 ktB
 dCV
 oRu
-jkA
+mZD
 mZD
 rXj
 hkA
@@ -53691,9 +53652,9 @@ koD
 gcK
 ktB
 dCV
-bvA
-mNT
-rzz
+jkA
+mZD
+mZD
 cEJ
 dCV
 rXj
@@ -53948,9 +53909,9 @@ koD
 gcK
 ktB
 dCV
-oDv
-thv
-woN
+rXj
+rXj
+mZD
 oIm
 dCV
 rXj

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -6254,6 +6254,13 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"fwv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "fwR" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -27740,6 +27747,10 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"vOx" = (
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "vPB" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt{
@@ -32063,7 +32074,7 @@ fLU
 fAR
 vaH
 fLU
-mIp
+fwv
 qju
 odO
 qju
@@ -48701,8 +48712,8 @@ eoy
 uoO
 eoy
 sgo
-lYM
 dxj
+lYM
 eoy
 nBk
 nBk
@@ -49471,8 +49482,8 @@ gpM
 uoO
 uoO
 eoy
-eoy
-eoy
+xVz
+rZw
 eoy
 eoy
 nBk
@@ -49727,9 +49738,9 @@ sNX
 gpM
 uoO
 uoO
-uoO
-uoO
-uoO
+xVz
+uiV
+xVz
 uoO
 eoy
 nBk
@@ -49985,8 +49996,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+xVz
+xVz
 uoO
 eoy
 nBk
@@ -84059,7 +84070,7 @@ uoO
 uoO
 nBk
 wHB
-sHo
+lnr
 lsP
 gGG
 hQE
@@ -87134,7 +87145,7 @@ uoO
 xyk
 rvI
 rrZ
-rrZ
+vOx
 upC
 xyk
 uoO


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds two ORMs to the mining bunker, one to the raider bunker under the NCR, and one to the supermutant town under the Legion.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
ORMs are incredibly useful for the competent engineer, makes it easier to get without having to metarush every round. The easiest ones to get are still in risky locations for factions to be early in the round.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: four ORMs to the map
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
