### PR TITLE
Brings tribal slots back to their pre 'Tribal Powercreep' levels.

### DIFF
--- a/code/modules/jobs/job_types/tribals.dm
+++ b/code/modules/jobs/job_types/tribals.dm
@@ -245,8 +245,8 @@ Villager
 	flag = F13VILLAGER
 	department_flag = TRIBAL
 	faction = "Village"
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 4
+	spawn_positions = 4
 	supervisors = "Tribal Chief, Shaman and Headhunter"
 	description = "A proud member of the Wayfarer tribe, you do what needs to be done to ensure the survival of yourself and your people while following the laws of the tribe. While it is common to venture out into the wasteland, do not thread far or without informing your kin."
 	selection_color = "#006666"
@@ -323,8 +323,8 @@ Hunter
 	flag = F13HUNTER
 	department_flag = TRIBAL
 	faction = "Village"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 4
+	spawn_positions = 4
 	supervisors = "The chief and Head Hunter."
 	enforces = "The ways of the Machine spirits."
 	forbids = "Abusing technology and using Pre-War weapons."
@@ -393,8 +393,8 @@ Spirit-Pledged
 	flag = F13SPIRITPLEDGED
 	department_flag = TRIBAL
 	faction = "Village"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 3
+	spawn_positions = 3
 	supervisors = "All other tribals."
 	description = "An outsider to the tribe, you have been welcomed to learn their ways and grow closer to their culture and lifestyle, do NOT run off alone into the wasteland without the supervision of another higher ranking tribal."
 	selection_color = "#006666"


### PR DESCRIPTION

## About The Pull Request

That PR just snapped a bunch of tribal roles.

## Why It's Good For The Game

Two hunter slots are not enough, three villager slots are not enough, two pledged slots are not enough.

## Changelog
:cl:
tweak: Razed hunter slots from 2 to 4
tweak: Razed villager slots from 3 to 4
tweak: Rased pledged slots from 2 to 3
/:cl:
