### PR TITLE
No more combat resting; FEV updates; Enclave LT helmet buff.

### DIFF
--- a/code/__DEFINES/mobs/slowdowns.dm
+++ b/code/__DEFINES/mobs/slowdowns.dm
@@ -5,8 +5,8 @@
 /// How much someone is slowed by piggybacking a human
 #define PIGGYBACK_CARRY_SLOWDOWN 0
 /// slowdown when in softcrit. Note that crawling slowdown will also apply at the same time!
-#define SOFTCRIT_ADD_SLOWDOWN 2
+#define SOFTCRIT_ADD_SLOWDOWN 1.2
 /// slowdown when crawling
-#define CRAWLING_ADD_SLOWDOWN 4
+#define CRAWLING_ADD_SLOWDOWN 7
 /// slowdown while scoped in
 #define SCOPED_IN_ADD_SLOWDOWN 4

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -307,7 +307,7 @@
 	var/list/le_list = list(\
 		/mob/living/simple_animal/hostile/centaur/strong = 8, \
 		/mob/living/simple_animal/hostile/abomination/weak = 7, \
-		/mob/living/simple_animal/hostile/ghoul/glowing = 4, \
+		/mob/living/simple_animal/hostile/ghoul/glowing/strong = 4, \
 		/mob/living/simple_animal/hostile/supermutant/playable = 2, \
 		/mob/living/carbon/human/species/ghoul = 1)
 	new_form = pickweight(le_list)

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -316,10 +316,9 @@
 	. = ..()
 
 /datum/disease/transformation/mutant/stage_act()
-	. = ..()
-	if(!.)
-		return
+	..()
 
+	affected_mob.adjustCloneLoss(-4,0) // Don't die while you are mutating.
 	switch(stage)
 		if(2)
 			if (prob(8))

--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -209,12 +209,11 @@
 	armor = list("tier" = 4)
 
 /obj/item/clothing/head/helmet/f13/helmet/enclave/officer
-	name = "officer hat"
-	desc = "(V) Wheeled hat with kevlar cap under."
+	name = "enclave officer hat"
+	desc = "(VII) Wheeled hat with a cap made of light-weight alloys beneath."
 	icon_state = "hat_enclave_officer"
 	item_state = "hat_enclave_officer"
-	armor = list("tier" = 5)
-
+	armor = list("tier" = 7, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30) // On par with BoS Knight
 
 //////////
 //LEGION//

--- a/code/modules/mob/living/simple_animal/hostile/f13/centaur.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/centaur.dm
@@ -49,7 +49,8 @@
 	icon_state = "toxin"
 
 /mob/living/simple_animal/hostile/centaur/strong // Mostly for FEV mutation
-	melee_damage_lower = 25
-	melee_damage_upper = 25
-	maxHealth = 200
-	health = 200
+	maxHealth = 400
+	health = 400
+	melee_damage_lower = 35
+	melee_damage_upper = 35
+	armour_penetration = 0.1

--- a/code/modules/mob/living/simple_animal/hostile/f13/fallout_NPC.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/fallout_NPC.dm
@@ -697,6 +697,7 @@
 	harm_intent_damage = 8
 	melee_damage_lower = 75
 	melee_damage_upper = 75
+	armour_penetration = 0.1
 	attack_verb_simple = "eviscerates"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	speed = -0.5
@@ -732,11 +733,11 @@
 
 /mob/living/simple_animal/hostile/abomination/weak // For FEV mutation.
 	environment_smash = ENVIRONMENT_SMASH_STRUCTURES // So you don't break walls
-	maxHealth = 300
-	health = 300
+	maxHealth = 500
+	health = 500
 	harm_intent_damage = 8
-	melee_damage_lower = 35
-	melee_damage_upper = 35
+	melee_damage_lower = 45
+	melee_damage_upper = 45
 	speed = 2
 
 /mob/living/simple_animal/hostile/abomhorror

--- a/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
@@ -137,6 +137,14 @@
 		var/mob/living/carbon/human/H = target
 		H.apply_effect(20, EFFECT_IRRADIATE, 0)
 
+/mob/living/simple_animal/hostile/ghoul/glowing/strong // FEV mutation
+	maxHealth = 320
+	health = 320
+	speed = 1.4 // Nyooom
+	melee_damage_lower = 35
+	melee_damage_upper = 35
+	armour_penetration = 0.1
+
 /mob/living/simple_animal/hostile/ghoul/soldier
 	name = "ghoul soldier"
 	desc = "Have you ever seen a living ghoul before?<br>Ghouls are necrotic post-humans - decrepit, rotting, zombie-like mutants."

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -696,8 +696,9 @@
 			return FALSE
 	else
 		var/mob/living/L = target
-		if(!direct_target && !L.density)
-			return FALSE
+		if(!direct_target)
+			if(!CHECK_BITFIELD(L.mobility_flags, MOBILITY_USE | MOBILITY_STAND | MOBILITY_MOVE) || !(L.stat == CONSCIOUS))		//If they're able to 1. stand or 2. use items or 3. move, AND they are not softcrit,  they are not stunned enough to dodge projectiles passing over.
+				return FALSE
 	return TRUE
 
 //Spread is FORCED!

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -57,7 +57,6 @@
 	return ..()
 
 /datum/reagent/toxin/FEV_solution/overdose_process(mob/living/carbon/C)
-	C.adjustCloneLoss(-4,0) // Don't die while you are mutating.
 	C.ForceContractDisease(new /datum/disease/transformation/mutant(), FALSE, TRUE)
 
 /datum/reagent/toxin/mutagen


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR does the following:

- People that are resting, but are conscious and NOT in crit(both soft- and hardcrit) will be hit by the bullets even if not directly clicked.
- Resting slowdown increased from 4 to 7. Crit slowdown DEcreased from 2 to 1.2 to be less frustrating.
- FEV mobs now have a tiny bit higher stats to be a viable option against some factions/players and not a free kill to literally anyone.
- Enclave LT's hat now has the same armor values as this of a BoS Knight.
 
## Why It's Good For The Game

- Removes the entire stupid meta of lying down to win the fights. Seriously, every single battle was/is a shitfest with everyone crawling to win.
- Same reason as above, crawling shouldn't win you a game.
- Being turnt into an abomination, usually forcefully, already wasn't the best fate, but when you realize that you are literally made of paper and die in 5 seconds your round is even less fun. This makes FEV mutants a viable option to use against some players, usually slow ones as most humans can still simply outrun the mutants.
- LT's armor was already at 200 armor, don't see why the head should be less protected.

## Changelog
:cl:
add: Combat resting is no longer an option. Unless you are in crit/unconscious - you'll be hit by any bullets that are shot in your direction.
tweak: FEV mutants are now stronger.
tweak: Crawling speed is now much slower.
balance: Enclave Lieutenant's helmet is now tier 7 (200 armor).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
