### PR TITLE
makes EMPs actually slowdown powerarmor

### DIFF
--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -316,16 +316,21 @@
 		return
 	if(emped == 0)
 		if(ismob(loc))
+			var/mob/living/L = loc
 			to_chat(loc, "<span class='warning'>Warning: electromagnetic surge detected in armor. Rerouting power to emergency systems.</span>")
 			slowdown += 1.2
 			armor = armor.modifyRating(linemelee = -100, linebullet = -100, linelaser = -100)
 			emped = 1
+			if(istype(L))
+				L.update_equipment_speed_mods()
 			spawn(50) //5 seconds of being slow and weak
 				to_chat(loc, "<span class='warning'>Armor power reroute successful. All systems operational.</span>")
 				slowdown -= 1.2
 				armor = armor.modifyRating(linemelee = 100, linebullet = 100, linelaser = 100)
 				emped = 0
-
+				if(istype(L))
+					L.update_equipment_speed_mods()
+					
 /obj/item/clothing/suit/armor/f13/power_armor/run_block(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
 	. = ..()
 	if(damage >= src.dmg_block_threshold && check_armor_penetration(object) >= 0)


### PR DESCRIPTION
This bug has been in the game for, and I checked, 1 year, 3 months, 4 days. 
The main effect of EMPs on power armor is supposed to be that it slows you down. That doesn't happen, it only marginally reduces your armor

In that time NOBODY. NOBODY AT ALL NOTICED THAT EMPS BASICALLY DONT AFFECT POWER ARMOR

THE MAIN COUNTER TO POWER ARMOR EFFECTIVELY DOESNT WORK

NO ONE FIXED THIS FOR OVER A _YEAR_

😡 