### PR TITLE
BoS armor removal and faction uniforms

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -15396,6 +15396,30 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"hSK" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/white/box,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/clothing/under/f13/ncr/ncr_shorts,
+/obj/item/clothing/under/f13/ncr/ncr_shorts,
+/obj/item/clothing/under/f13/ncr/ncr_shorts,
+/obj/item/clothing/under/f13/ncr,
+/obj/item/clothing/under/f13/ncr,
+/obj/item/clothing/under/f13/ncr,
+/obj/item/clothing/under/f13/ncr,
+/obj/item/clothing/under/f13/ncr,
+/obj/item/clothing/shoes/f13/military/ncr,
+/obj/item/clothing/shoes/f13/military/ncr,
+/obj/item/clothing/shoes/f13/military/ncr,
+/obj/item/clothing/shoes/f13/military/ncr,
+/obj/item/clothing/shoes/f13/military/ncr,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/ncr)
 "hSQ" = (
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bucket,
@@ -28768,6 +28792,24 @@
 /obj/item/seeds/cannabis,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"pbM" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/white/box,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/storage/belt/military/NCR_Bandolier,
+/obj/item/storage/belt/military/NCR_Bandolier,
+/obj/item/storage/belt/military/NCR_Bandolier,
+/obj/item/storage/belt/military/NCR_Bandolier,
+/obj/item/storage/belt/military/NCR_Bandolier,
+/obj/item/storage/belt/military/assault/ncr,
+/obj/item/storage/belt/military/assault/ncr,
+/obj/item/storage/belt/military/assault/ncr,
+/obj/item/storage/belt/military/assault/ncr,
+/obj/item/storage/belt/military/assault/ncr,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/ncr)
 "pbS" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/drinks/flask,
@@ -32446,6 +32488,21 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
+/obj/item/clothing/head/f13/ncr,
+/obj/item/clothing/head/f13/ncr,
+/obj/item/clothing/head/f13/ncr,
+/obj/item/clothing/head/f13/ncr,
+/obj/item/clothing/head/f13/ncr,
+/obj/item/clothing/head/f13/ncr/steelpot_goggles,
+/obj/item/clothing/head/f13/ncr/steelpot_goggles,
+/obj/item/clothing/head/f13/ncr/steelpot_goggles,
+/obj/item/clothing/head/f13/ncr/steelpot_goggles,
+/obj/item/clothing/head/f13/ncr/steelpot_goggles,
+/obj/item/clothing/suit/armor/f13/ncrarmor,
+/obj/item/clothing/suit/armor/f13/ncrarmor,
+/obj/item/clothing/suit/armor/f13/ncrarmor,
+/obj/item/clothing/suit/armor/f13/ncrarmor,
+/obj/item/clothing/suit/armor/f13/ncrarmor,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
@@ -36127,6 +36184,26 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"sSm" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/helmet/f13/legion/recruit,
+/obj/item/clothing/head/helmet/f13/legion/recruit,
+/obj/item/clothing/head/helmet/f13/legion/recruit,
+/obj/item/clothing/head/helmet/f13/legion/recruit,
+/obj/item/clothing/head/helmet/f13/legion/recruit,
+/obj/item/clothing/mask/bandana/legion/legrecruit,
+/obj/item/clothing/mask/bandana/legion/legrecruit,
+/obj/item/clothing/mask/bandana/legion/legrecruit,
+/obj/item/clothing/mask/bandana/legion/legrecruit,
+/obj/item/clothing/mask/bandana/legion/legrecruit,
+/obj/item/clothing/suit/armor/f13/legion/recruit,
+/obj/item/clothing/suit/armor/f13/legion/recruit,
+/obj/item/clothing/suit/armor/f13/legion/recruit,
+/obj/item/clothing/suit/armor/f13/legion/recruit,
+/obj/item/clothing/suit/armor/f13/legion/recruit,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "sSr" = (
 /turf/open/floor/wood/f13/old/ruinedstraightnorth,
 /area/f13/wasteland)
@@ -44217,6 +44294,16 @@
 "wXo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
+/obj/item/clothing/gloves/legion,
+/obj/item/clothing/gloves/legion,
+/obj/item/clothing/gloves/legion,
+/obj/item/clothing/gloves/legion,
+/obj/item/clothing/gloves/legion,
+/obj/item/clothing/under/f13/legskirt,
+/obj/item/clothing/under/f13/legskirt,
+/obj/item/clothing/under/f13/legskirt,
+/obj/item/clothing/under/f13/legskirt,
+/obj/item/clothing/under/f13/legskirt,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
@@ -45826,6 +45913,21 @@
 /obj/structure/bed/old,
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"xLu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/clothing/glasses/legiongoggles,
+/obj/item/clothing/glasses/legiongoggles,
+/obj/item/clothing/glasses/legiongoggles,
+/obj/item/clothing/glasses/legiongoggles,
+/obj/item/clothing/glasses/legiongoggles,
+/obj/item/clothing/shoes/f13/military/plated,
+/obj/item/clothing/shoes/f13/military/plated,
+/obj/item/clothing/shoes/f13/military/plated,
+/obj/item/clothing/shoes/f13/military/plated,
+/obj/item/clothing/shoes/f13/military/plated,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "xLK" = (
 /obj/structure/closet/cabinet,
 /mob/living/simple_animal/hostile/ghoul,
@@ -55579,8 +55681,8 @@ jNs
 mfN
 xdt
 qQf
-jxd
-uVw
+hSK
+pbM
 xdt
 idH
 pRS
@@ -108975,9 +109077,9 @@ xNm
 xNm
 uNK
 dpK
-seY
+sSm
 wXo
-bMP
+xLu
 leX
 hom
 ggK

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -1179,16 +1179,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
-"bgZ" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse/white{
-	desc = "It's a strangely clean little white rodent.";
-	name = "Algernon"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/operations)
 "bhe" = (
 /obj/item/stack/rods/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -59697,7 +59687,7 @@ fJt
 yei
 ePe
 qUR
-bgZ
+ePe
 yhh
 ePe
 qUR

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -12493,10 +12493,6 @@
 	name = "Head Knight's PDA"
 	},
 /obj/item/storage/briefcase,
-/obj/item/clothing/suit/armor/vest/capcarapace/syndicate{
-	desc = "A sinister looking vest of advanced armor worn over a black and red fireproof jacket. The gold collar and shoulders denote that this belongs to a high ranking officer of some lost prewar army.";
-	name = "old officer's vest"
-	},
 /obj/item/clothing/head/HoS/beret/syndicate{
 	name = "officer's beret"
 	},
@@ -15305,15 +15301,8 @@
 	pixel_x = 21;
 	pixel_y = 5
 	},
-/obj/item/book/granter/trait/pa_wear{
-	pixel_x = 5;
-	pixel_y = 7
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/book/granter/trait/pa_wear{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood/offices1st)
 "mpE" = (

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -4733,13 +4733,6 @@
 /area/f13/brotherhood/leisure)
 "ejQ" = (
 /obj/structure/closet/secure_closet/personal,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/storage/belt/holster,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/senior,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/senior,
-/obj/item/clothing/gloves/combat,
-/obj/item/clothing/shoes/combat/swat,
-/obj/item/storage/belt/military,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
@@ -12477,11 +12470,6 @@
 /area/f13/tcoms)
 "kbH" = (
 /obj/item/bedsheet/hos,
-/obj/item/toy/figure/warden{
-	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
-	name = "Head Knight Action Figure";
-	toysay = "Victory is our tradition!"
-	},
 /obj/structure/bed,
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
@@ -13376,6 +13364,7 @@
 	pixel_x = -3;
 	pixel_y = 15
 	},
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
 "kOc" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the senior knight armors from the BoS. Also removes the literally renamed syndicate armor from the BoS. Removes their two PA trait books and replaces it with a random_high and a random_medium cash spawner. Deletes the BoS clone of Algernon. 
Also adds in spare low rank uniforms and armor for NCR and Legion so they can actually recruit some people.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Spare high ranking armor is bad. I don't see why they should get PA books for free; just go buy them like everyone else, and regardless, they're just going to be handed out. Now, also, NCR and Legion can actually put people they recruit in their own faction uniform! Incredible.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: my ass
add: changelog doesnt even work ingame this is entirely useless
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
