### PR TITLE
Removes Vigilante

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -868,7 +868,7 @@ Raider
 
 //vigilante
 
-
+/*
 /datum/job/wasteland/f13vigilante
 	title = "Vigilante"
 	flag = F13VIGILANTE
@@ -938,7 +938,7 @@ Raider
 	backpack_contents = list(
 							/obj/item/ammo_box/c4570/explosive=2
 							)
-
+*/
 /datum/job/wasteland/f13adminboos
 	title = "Death"
 	flag = F13ADMINBOOS
@@ -953,7 +953,7 @@ Raider
 
 /datum/outfit/job/wasteland/f13adminboos
 	name = "Death"
-	jobtype = /datum/job/wasteland/f13vigilante
+	jobtype = /datum/job/wasteland/f13wastelander
 	id = /obj/item/card/id/dogtag/vigilante
 	belt = /obj/item/storage/belt/military
 	shoes = /obj/item/clothing/shoes/f13/explorer

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -868,7 +868,7 @@ Raider
 
 //vigilante
 
-/*
+
 /datum/job/wasteland/f13vigilante
 	title = "Vigilante"
 	flag = F13VIGILANTE
@@ -938,7 +938,7 @@ Raider
 	backpack_contents = list(
 							/obj/item/ammo_box/c4570/explosive=2
 							)
-*/
+
 /datum/job/wasteland/f13adminboos
 	title = "Death"
 	flag = F13ADMINBOOS
@@ -953,7 +953,7 @@ Raider
 
 /datum/outfit/job/wasteland/f13adminboos
 	name = "Death"
-	jobtype = /datum/job/wasteland/f13wastelander
+	jobtype = /datum/job/wasteland/f13vigilante
 	id = /obj/item/card/id/dogtag/vigilante
 	belt = /obj/item/storage/belt/military
 	shoes = /obj/item/clothing/shoes/f13/explorer

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -873,8 +873,8 @@ Raider
 	title = "Vigilante"
 	flag = F13VIGILANTE
 	faction = "Wastelander"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You have come a long way to reach this god forsaken place... it is now your job to protect its inhabitants from all sorts of injustice. Your moral codex requires you to help anyone in need and to never harm an innocent. Always try to capture and reeducate criminals instead of killing. Do not get involved in the conflicts between the major factions, that is not your fight."
 	supervisors = "your moral code"
 	selection_color = "#76885f"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Comments out vigilante and changes the adminabuse/deathguy role to use waster as a base.
## Why It's Good For The Game
Vigilante is a bad role. It is played almost exclusively by shitters, whom only play the game to do the bare-minimum required RP, then go off to SLAY like a queen. The very rare "decent" vigilantes are people who either completely abandon their role and purpose for the gear, or simply do not pursue people doing bad things. ALL vigilante players metarush bunkers for better loot.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: vigilante
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
