### PR TITLE
Increases airlocks damage deflection

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -34,8 +34,9 @@
 
 #define AIRLOCK_INTEGRITY_N			 300 // Normal airlock integrity
 #define AIRLOCK_INTEGRITY_MULTIPLIER 1.5 // How much reinforced doors health increases
-#define AIRLOCK_DAMAGE_DEFLECTION_N  21  // Normal airlock damage deflection
-#define AIRLOCK_DAMAGE_DEFLECTION_R  30  // Reinforced airlock damage deflection
+#define AIRLOCK_DAMAGE_DEFLECTION_N  27  // Normal airlock damage deflection
+#define AIRLOCK_DAMAGE_DEFLECTION_R  31  // Metal-reinforced airlock damage deflection
+#define AIRLOCK_DAMAGE_DEFLECTION_SR  34  // Plasteel-reinforced airlock damage deflection
 
 #define NOT_ELECTRIFIED 0
 #define ELECTRIFIED_PERMANENT -1
@@ -117,8 +118,10 @@
 	else
 		obj_integrity = normal_integrity
 		max_integrity = normal_integrity
-	if(damage_deflection == AIRLOCK_DAMAGE_DEFLECTION_N && security_level > AIRLOCK_SECURITY_METAL)
+	if(damage_deflection < AIRLOCK_DAMAGE_DEFLECTION_R && security_level == AIRLOCK_SECURITY_METAL)
 		damage_deflection = AIRLOCK_DAMAGE_DEFLECTION_R
+	else if(damage_deflection < AIRLOCK_DAMAGE_DEFLECTION_SR && security_level >= AIRLOCK_SECURITY_PLASTEEL)
+		damage_deflection = AIRLOCK_DAMAGE_DEFLECTION_SR
 	prepare_huds()
 	for(var/datum/atom_hud/data/diagnostic/diag_hud in GLOB.huds)
 		diag_hud.add_to_hud(src)
@@ -845,6 +848,8 @@
 						user.visible_message("<span class='notice'>[user] reinforces \the [src] with metal.</span>",
 											"<span class='notice'>You reinforce \the [src] with metal.</span>")
 						security_level = AIRLOCK_SECURITY_METAL
+						if(damage_deflection < AIRLOCK_DAMAGE_DEFLECTION_R)
+							damage_deflection = AIRLOCK_DAMAGE_DEFLECTION_R
 						update_icon()
 					return
 				else if(istype(C, /obj/item/stack/sheet/plasteel))
@@ -860,7 +865,8 @@
 											"<span class='notice'>You reinforce \the [src] with plasteel.</span>")
 						security_level = AIRLOCK_SECURITY_PLASTEEL
 						modify_max_integrity(normal_integrity * AIRLOCK_INTEGRITY_MULTIPLIER)
-						damage_deflection = AIRLOCK_DAMAGE_DEFLECTION_R
+						if(damage_deflection < AIRLOCK_DAMAGE_DEFLECTION_SR)
+							damage_deflection = AIRLOCK_DAMAGE_DEFLECTION_SR
 						update_icon()
 					return
 			if(AIRLOCK_SECURITY_METAL)

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -388,6 +388,7 @@
 	wiretypepath = /datum/wires/airlock/secure
 	explosion_block = 2
 	normal_integrity = 400 // reverse engieneerd: 400 * 1.5 (sec lvl 6) = 600 = original
+	damage_deflection = 44
 	security_level = 6
 
 //////////////////////////////////
@@ -425,7 +426,7 @@
 	explosion_block = 2
 	normal_integrity = 500
 	security_level = 1
-	damage_deflection = 30
+	damage_deflection = 38
 
 //////////////////////////////////
 /*


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases damage deflection of all airlocks a bit.

## Why It's Good For The Game

Melee weapons on our server are much, much more stronger than vanilla SS13 weapons. Damage deflection values for airlocks were added with one thing in mind: Only(probably) a fire axe and traitor weapons had more than 24 damage.

On our server, however, some random shitty knife has 30 damage and can break airlocks, which is stupid af to me.

Another point of that PR is improving Vault airlocks, so you would probably be completely unable to break it with a melee weapon, unless it's something high-tier, above 44 force.

## Changelog
:cl:
balance: Airlocks are now stronger and won't take damage from weak melee weaponry.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
