### PR TITLE
NCR helmet fix

### DIFF
--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -577,10 +577,10 @@
 
 /obj/item/clothing/head/f13/ncr_cap
 	name = "NCR garrison cap"
-	desc = "(I) A simple cloth garrison cap to be worn when a helmet isn't necessary."
+	desc = "(II) A simple cloth garrison cap to be worn when a helmet isn't necessary."
 	icon_state = "ncr_cap"
 	item_state = "ncr_cap"
-	armor = list("tier" = 1, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	armor = list("tier" = 2, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/head/f13/ncr_campaign
 	name = "NCR campaign hat"
@@ -591,17 +591,17 @@
 
 /obj/item/clothing/head/beret/ncr_dresscap
 	name = "NCR peaked cap"
-	desc = "(II) A tan peaked cap with silver pin, designated for enlisted NCRA personnel."
+	desc = "(III) A tan peaked cap with silver pin, designated for enlisted NCRA personnel."
 	icon_state = "ncr_dresscap"
 	item_state = "ncr_dresscap"
-	armor = list("tier" = 2, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	armor = list("tier" = 3, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 
 /obj/item/clothing/head/beret/ncr_codresscap
 	name = "NCR peaked cap"
-	desc = "(II) A tan peaked cap with golden pin, designated for commissioned NCRA personnel."
+	desc = "(III) A tan peaked cap with golden pin, designated for commissioned NCRA personnel."
 	icon_state = "ncr_codresscap"
 	item_state = "ncr_codresscap"
-	armor = list("tier" = 2, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	armor = list("tier" = 3, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 
 //NCR Ranger
 

--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -426,10 +426,10 @@
 
 /obj/item/clothing/head/f13/ncr
 	name = "NCR steelpot helmet"
-	desc = "(II) A standard issue NCR steel helmet. Looks like you can write on it and strap a few items on the helmet band."
+	desc = "(III) A standard issue NCR steel helmet. Looks like you can write on it and strap a few items on the helmet band."
 	icon_state = "ncr_steelpot"
 	item_state = "ncr_steelpot"
-	armor = list("tier" = 2, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	armor = list("tier" = 3, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 	strip_delay = 50
 	obj_flags = UNIQUE_RENAME
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/tiny
@@ -440,7 +440,7 @@
 
 /obj/item/clothing/head/f13/ncr/steelpot_goggles
 	name = "NCR storm steelpot helmet"
-	desc = "(II) A standard issue NCR steel helmet, issued with an additional pair of storm goggles for weather resistance."
+	desc = "(III) A standard issue NCR steel helmet, issued with an additional pair of storm goggles for weather resistance."
 	icon_state = "steelpot_goggles"
 	item_state = "steelpot_goggles"
 	alt_toggle_message = "You push the goggles down "
@@ -475,49 +475,49 @@
 
 /obj/item/clothing/head/f13/ncr/steelpot_med
 	name = "NCR medic steelpot helmet"
-	desc = "(II) A standard issue NCR steel helmet with the addition of decalling signifying a medic."
+	desc = "(III) A standard issue NCR steel helmet with the addition of decalling signifying a medic."
 	icon_state = "steelpot_med"
 	item_state = "steelpot_med"
 
 /obj/item/clothing/head/f13/ncr/steelpot_mp
 	name = "NCR military police steelpot helmet"
-	desc = "(II) A standard issue NCR steel helmet emblazoned with the initials of the military police."
+	desc = "(III) A standard issue NCR steel helmet emblazoned with the initials of the military police."
 	icon_state = "steelpot_mp"
 	item_state = "steelpot_mp"
 
 /obj/item/clothing/head/f13/ncr/steelpot_gambler
 	name = "NCR gambler steelpot helmet"
-	desc = "(II) A standard issue NCR steel helmet. Stashed in the strap are decks of cards, dominoes and cigarettes for personal use."
+	desc = "(III) A standard issue NCR steel helmet. Stashed in the strap are decks of cards, dominoes and cigarettes for personal use."
 	icon_state = "steelpot_gambler"
 	item_state = "steelpot_gambler"
 
 /obj/item/clothing/head/f13/ncr/steelpot_bandolier
 	name = "NCR bandolier steelpot helmet"
-	desc = "(II) A standard issue NCR steel helmet. This one has clearly seen heavy use, as well as having additional bullets tucked into the strap."
+	desc = "(III) A standard issue NCR steel helmet. This one has clearly seen heavy use, as well as having additional bullets tucked into the strap."
 	icon_state = "steelpot_bandolier"
 	item_state = "steelpot_bandolier"
 
 /obj/item/clothing/head/f13/ncr/steelpot_patriot
 	name = "NCR patriot steelpot helmet"
-	desc = "(II) A standard issue NCR steel helmet. This one has been patriotically customised to feature the NCR's flag prominently across its front."
+	desc = "(III) A standard issue NCR steel helmet. This one has been patriotically customised to feature the NCR's flag prominently across its front."
 	icon_state = "steelpot_patriot"
 	item_state = "steelpot_patriot"
 
 /obj/item/clothing/head/f13/ncr_flapcap
 	name = "NCR field cap"
-	desc = "(II) A special issue canvas NCR field cap with cotton neckflap, for sun protection in arid climates."
+	desc = "(III) A special issue canvas NCR field cap with cotton neckflap, for sun protection in arid climates."
 	icon_state = "ncr_flapcap"
 	item_state = "ncr_flapcap"
-	armor = list("tier" = 5, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	armor = list("tier" = 3, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 	icon_state = "ncr_flapcap"
 	item_state = "ncr_flapcap"
 
 /obj/item/clothing/head/f13/ncr_slouch
 	name = "NCR slouch hat"
-	desc = "(II) An irregular issue NCR sun hat, the left side of the brim is pinned to the crown for ease with shouldering rifles."
+	desc = "(III) An irregular issue NCR sun hat, the left side of the brim is pinned to the crown for ease with shouldering rifles."
 	icon_state = "ncr_slouch"
 	item_state = "ncr_slouch"
-	armor = list("tier" = 5, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	armor = list("tier" = 3, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 
 /obj/item/clothing/head/beret/ncr
 	name = "NCR officer beret"

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -352,11 +352,11 @@
 //NCR
 /obj/item/clothing/suit/armor/f13/ncrarmor
 	name = "NCR patrol vest"
-	desc = "(II) A standard issue NCR Infantry vest."
+	desc = "(III) A standard issue NCR Infantry vest."
 	icon_state = "ncr_infantry_vest"
 	item_state = "ncr_infantry_vest"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
-	armor = list("tier" = 2, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	armor = list("tier" = 3, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/ncrarmor/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Upgrading trooper armors makes little sense when the helmet will always be stuck at tier two. This change will most likely be required for all faction armors. I also removed the "hidden" tier five NCR helmet what was pickable for every NCR role. It was marked as tier two despite having the armor values of a T5

## Why It's Good For The Game
Because secret hidden OP DR armors is bad :) And it's also nice when you actually get rewarded for plating your armor.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
Adjusted the trooper armor to be closer to Legion recruit armor. I made it tier three to make up for the 0.15 speed. Some may claim that it makes my first change obscelete, and I'd agree. But due to the current state of NCR armor in general it'd seem like an odd choice to buff the trooper helmet to T4, so it'll stay in tier three. (I hate platings :) )

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
