### PR TITLE
Durability threshold

### DIFF
--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -10,7 +10,7 @@
 	var/tier  //1 to 11. Tier 1 - thin clothing, 2 - thick clothing , 3 - armored jackets, 4 - low quality/light armor, 5 - medium qual armor, 6 - medium high, 7 - high, 8 - exceptional/low qual PA, 9 - t45, 10 - t51, 11 - t60
 	var/linemelee
 	var/linebullet
-	var/linelaser 
+	var/linelaser
 	var/melee
 	var/bullet
 	var/laser
@@ -26,7 +26,7 @@
 	var/tierline = list(25, 50, 75, 100, 125, 150, 200, 250, 300, 350, 400, 500, 600) //new
 
 /datum/armor/New(tier = 0, linemelee = 0, linebullet = 0, linelaser = 0, melee = 0, bullet = 0, laser = 0,  energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0)
-	
+
 	if(tier) //ASSIGNS ARMOR VALUES BASED ON TIER, IT WILL USE ARMOR VALUES INSTEAD OF THE TIER FOR THAT VALUE IF THE ARMOR VALUE IS PRESENT
 		linemelee = linemelee+tierline[tier] //If an armor has a tier value, having a linemelee value will add onto that tier value rather than replace it.
 		linebullet = linebullet+tierline[tier]

--- a/code/modules/crafting/items.dm
+++ b/code/modules/crafting/items.dm
@@ -1178,7 +1178,6 @@
 	A.armor.linelaser += tiermod*2
 	A.name = prefix + A.name
 	A.tinkered += 1
-	A.desc += " Armor: Melee: [A.armor.linemelee], Bullet: [A.armor.linebullet], Laser: [A.armor.linelaser]"
 
 	to_chat(usr, "You tinker with the armor making [W.name]...")
 	qdel(src)
@@ -1220,7 +1219,6 @@
 	H.armor.linelaser += tiermod*2
 	H.name = prefix + H.name
 	H.tinkered += 1
-	H.desc += " Armor: Melee: [H.armor.linemelee], Bullet: [H.armor.linebullet], Laser: [H.armor.linelaser]"
 
 	to_chat(usr, "You tinker with the armor making [W.name]...")
 	qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

All Tier 2+ armor now has a durability threshold. Any damage below the threshold will not damage the durability of the armor.

Additionally, this PR removes obsolete addition to the description after tinkering with armor.

## Why It's Good For The Game

Durability on its own is a questionable mechanic, much more so when your super-powerful PA set gets damaged by a fork.
This makes it so you don't have to run from ants in an attempt to avoid durability damage. Anything that has high armor penetration is still dangerous to it, this PR just makes sources of tiny damage less annoying.

## Changelog
:cl:
add: Added durability thresholds. Any damage below it will not damage the durability of armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
