### PR TITLE
Remove Sneedclave Two

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -9035,12 +9035,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/f13/tcoms)
-"hvr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/handy/assaultron,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "hvw" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -9896,11 +9890,6 @@
 "idK" = (
 /turf/open/floor/plasteel/freezer,
 /area/f13/den)
-"iej" = (
-/obj/machinery/door/airlock/hatch,
-/obj/effect/mine/explosive,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "iep" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -29145,10 +29134,6 @@
 /obj/structure/table/wood/fancy/blackred,
 /turf/open/floor/carpet/black,
 /area/f13/tunnel)
-"xld" = (
-/mob/living/simple_animal/hostile/handy/sentrybot/nsb/riot,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "xlH" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
@@ -62983,7 +62968,7 @@ ouq
 yhT
 yhT
 fJu
-iej
+vFv
 yhT
 yhT
 yhT
@@ -66318,10 +66303,10 @@ hcf
 hcf
 yhT
 vfo
-xld
+xSi
 riZ
 wTH
-wTH
+xSi
 jVT
 osY
 ujY
@@ -66835,7 +66820,7 @@ rnt
 vDC
 vxG
 vRs
-hvr
+pRA
 yhT
 rlz
 ekj

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -96,11 +96,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"aek" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "aes" = (
 /obj/structure/window/reinforced/spawner{
 	color = "#777777";
@@ -204,11 +199,6 @@
 /obj/structure/closet/cabinet,
 /turf/open/floor/carpet/green,
 /area/f13/tunnel)
-"ahV" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "aiQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -474,16 +464,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/tunnel)
-"avY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "awd" = (
 /obj/structure/table/wood/poker,
 /obj/item/dice{
@@ -597,12 +577,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"aAL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/bed/oldalt,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "aAX" = (
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -615,13 +589,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"aBr" = (
-/obj/structure/junk/locker,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
 "aCo" = (
@@ -800,12 +767,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/den)
-"aHf" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "aHj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -849,14 +810,6 @@
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"aLJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/debris/v3{
-	layer = 2
-	},
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "aMg" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
@@ -883,15 +836,6 @@
 /turf/closed/indestructible/vaultdoor{
 	desc = "A wall made out of metal, really fucking tough metal. Someone built this waaaay in advance.";
 	name = "bunker wall"
-	},
-/area/f13/bunker)
-"aPb" = (
-/obj/structure/junk/locker,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "redmark"
 	},
 /area/f13/bunker)
 "aPr" = (
@@ -1009,10 +953,6 @@
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"aXl" = (
-/obj/structure/stairs/west,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "aXJ" = (
 /obj/structure/closet/crate/large,
 /obj/item/circuitboard/machine/protolathe,
@@ -1037,11 +977,6 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
-/area/f13/bunker)
-"aYl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/abomhorror,
-/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "aYI" = (
 /obj/structure/barricade/bars,
@@ -1236,19 +1171,6 @@
 /obj/item/wrench/crude,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
-"bhO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/broken{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "bis" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -1415,11 +1337,6 @@
 /obj/item/claymore/machete/golf,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"boV" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/junk/small/table,
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
 "bpa" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -1933,13 +1850,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/brotherhood/operations)
-"bLa" = (
-/obj/structure/junk/locker,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/bunker)
 "bMe" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/subway,
@@ -1994,13 +1904,6 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
-"bNF" = (
-/obj/machinery/light/small/broken{
-	dir = 8
-	},
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bunker)
 "bOf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2326,10 +2229,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"cfR" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/bunker)
 "cfU" = (
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2366,18 +2265,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"cim" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/broken{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "ciF" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -2646,16 +2533,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"cuT" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/handy/assaultron,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "cvd" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -2835,10 +2712,6 @@
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"cDH" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "cDL" = (
 /obj/item/stack/cable_coil/random/five,
 /obj/effect/decal/cleanable/dirt,
@@ -2933,13 +2806,6 @@
 	},
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
-"cGN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/broken{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "cGZ" = (
 /obj/structure/table/booth,
 /turf/open/indestructible/ground/inside/subway,
@@ -2987,17 +2853,6 @@
 "cIS" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker)
-"cIY" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
 /area/f13/bunker)
 "cKI" = (
 /obj/item/gun/ballistic/automatic/tribalbow{
@@ -3565,13 +3420,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/tunnel)
-"deH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/bunker)
 "deX" = (
 /obj/structure/simple_door/fakeglass,
 /obj/effect/decal/cleanable/dirt,
@@ -3710,13 +3558,6 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/den)
-"doa" = (
-/obj/structure/bed/mattress/pregame,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "doi" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3859,30 +3700,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"dtB" = (
-/obj/structure/barricade/bars,
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "duf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"dum" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/bunker)
 "duv" = (
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3924,17 +3746,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"dwY" = (
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/obj/structure/showcase/horrific_experiment{
-	icon_state = "pod_0_maintenance"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "dxd" = (
 /obj/structure/reagent_dispensers/barrel,
 /turf/open/indestructible/ground/inside/mountain,
@@ -4027,13 +3838,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"dAQ" = (
-/obj/structure/door_assembly/door_assembly_grunge,
-/obj/structure/barricade/wooden/planks,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/bunker)
 "dBb" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/table/wood,
@@ -4227,13 +4031,6 @@
 /obj/structure/bed,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
-"dHQ" = (
-/obj/structure/table,
-/obj/structure/barricade/sandbags,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/bunker)
 "dID" = (
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/gloves/color/white/bos,
@@ -4248,10 +4045,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
-"dIV" = (
-/mob/living/simple_animal/hostile/handy/gutsy,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "dJm" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/subway,
@@ -4407,12 +4200,6 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/bunker)
-"dNW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/clothing/suit/armor/f13/battlecoat/tan/enclave,
-/obj/structure/closet/anchored,
-/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "dOf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4652,12 +4439,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"dYM" = (
-/obj/structure/showcase/horrific_experiment{
-	icon_state = "pod_0"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "dYQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -4857,15 +4638,6 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
-"ejj" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "ejr" = (
 /obj/structure/barricade/wooden,
 /obj/effect/mine/stun,
@@ -4894,12 +4666,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/den)
-"ekj" = (
-/obj/structure/barricade/sandbags,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/bunker)
 "ekl" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom"
@@ -4953,16 +4719,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"emV" = (
-/obj/structure/barricade/bars,
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "enl" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
@@ -5247,12 +5003,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/operations)
-"ezR" = (
-/obj/structure/chair/comfy/black,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "eAa" = (
 /obj/machinery/vending/sovietsoda,
 /turf/open/floor/f13{
@@ -5274,11 +5024,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper/crumpled,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"eAK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "eAQ" = (
 /obj/structure/nest/scorpion,
@@ -5861,15 +5606,6 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/tunnel)
-"eZx" = (
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/item/gun/energy/laser/plasma,
-/obj/effect/decal/remains/human,
-/obj/item/clothing/head/helmet/f13/helmet/enclave/peacekeeper,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "eZU" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/lattice/catwalk,
@@ -5889,16 +5625,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"faC" = (
-/obj/structure/sink/kitchen,
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/bunker)
-"faK" = (
-/obj/structure/showcase/horrific_experiment,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
 /area/f13/bunker)
 "faR" = (
 /obj/structure/simple_door/metal/ventilation,
@@ -6051,12 +5777,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
-"fji" = (
-/mob/living/simple_animal/hostile/abomhorror,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "fjN" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy/assaultron,
@@ -6117,11 +5837,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"flz" = (
-/mob/living/simple_animal/hostile/handy/assaultron,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "flC" = (
 /obj/machinery/door/airlock/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -6333,12 +6048,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/offices1st)
-"fvg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/office,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
 "fvo" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -6350,12 +6059,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"fvw" = (
-/obj/machinery/light/small/broken{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "fws" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/computer/terminal{
@@ -6370,15 +6073,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/tunnel)
-"fwR" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "fwX" = (
 /obj/machinery/workbench/advanced,
 /obj/effect/turf_decal/stripes/box,
@@ -6628,11 +6322,6 @@
 /obj/machinery/microwave/stove,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"fGF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/remains/human,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "fGO" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -6681,12 +6370,6 @@
 /obj/machinery/light,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
-"fJu" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/bunker)
 "fJx" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -6704,24 +6387,6 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
-/area/f13/bunker)
-"fKm" = (
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/obj/structure/junk/machinery,
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/bunker)
-"fKz" = (
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/box,
-/obj/structure/reagent_dispensers/barrel/explosive,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "fKP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6784,15 +6449,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"fMJ" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/bunker)
 "fMR" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -6808,12 +6464,6 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker)
-"fMX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/kitchenspike,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "fNc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6890,21 +6540,6 @@
 /obj/machinery/telecomms/processor/preset_one,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"fPQ" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/bunker)
-"fQo" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/bunker)
 "fQF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/sandbags,
@@ -7020,11 +6655,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"fUO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/office,
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
 "fUR" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -7244,12 +6874,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/offices1st)
-"ggi" = (
-/obj/structure/junk/locker,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/bunker)
 "ggm" = (
 /obj/structure/table{
 	layer = 2.9
@@ -7359,13 +6983,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"gjJ" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "gkm" = (
 /mob/living/simple_animal/hostile/centaur,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -7664,13 +7281,6 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"guj" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
-	},
-/obj/structure/decoration/vent,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "gul" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy/assaultron/nsb,
@@ -7909,17 +7519,6 @@
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
-"gFZ" = (
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "gGG" = (
 /obj/effect/mine/explosive,
 /obj/machinery/light/small,
@@ -8026,10 +7625,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"gNg" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "gNj" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -8122,10 +7717,6 @@
 	dir = 10;
 	icon_state = "redmark"
 	},
-/area/f13/bunker)
-"gQo" = (
-/mob/living/simple_animal/hostile/handy/sentrybot,
-/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "gQI" = (
 /obj/structure/table,
@@ -8223,18 +7814,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/followers)
-"gTk" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "gTv" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 5
@@ -8400,12 +7979,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"gXQ" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/bunker)
 "gYt" = (
 /obj/structure/lattice{
 	density = 1
@@ -8501,24 +8074,11 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/den)
-"hcf" = (
-/obj/structure/barricade/bars,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "hcC" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
-	},
-/area/f13/bunker)
-"hcO" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
 	},
 /area/f13/bunker)
 "hcS" = (
@@ -8728,12 +8288,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"hmn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/built,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "hmL" = (
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8869,10 +8423,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"hqn" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/bunker)
 "hqt" = (
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/snacks/soylentgreen,
@@ -8958,13 +8508,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/followers)
-"hsN" = (
-/obj/machinery/light/small,
-/obj/structure/junk/locker,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/bunker)
 "hsP" = (
 /obj/structure/decoration/vent,
 /obj/effect/decal/cleanable/dirt,
@@ -8972,15 +8515,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"hsR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/broken{
-	dir = 8
-	},
-/obj/structure/junk/locker,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "htu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/bos{
@@ -8995,10 +8529,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"htG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/mineral/random/high_chance,
-/area/f13/caves)
 "htI" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/graveldirt,
@@ -9046,13 +8576,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/followers)
-"hvF" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "hvG" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -9272,24 +8795,10 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
-"hEn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/fridge/standard,
-/obj/machinery/light/small,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "hEp" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"hFb" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "hFM" = (
 /obj/machinery/button/crematorium,
 /obj/structure/table,
@@ -9494,15 +9003,6 @@
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
-"hMJ" = (
-/obj/item/clothing/under/f13/enclave/science,
-/obj/item/clothing/mask/gas/enclave,
-/obj/item/clothing/shoes/f13/enclave/serviceboots,
-/obj/structure/closet/anchored,
-/obj/effect/spawner/lootdrop/f13/armor/tier4,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "hMQ" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13{
@@ -9641,10 +9141,6 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
-/area/f13/bunker)
-"hTg" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "hUn" = (
 /obj/effect/decal/cleanable/generic,
@@ -10036,14 +9532,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"iiK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "iiZ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -10468,21 +9956,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"iBp" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"iCd" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/bunker)
 "iCh" = (
 /obj/effect/landmark/start/f13/headscribe,
 /obj/effect/decal/cleanable/dirt,
@@ -10569,20 +10042,6 @@
 /obj/effect/decal/cleanable/blood/gibs/human,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
-"iGB" = (
-/obj/machinery/light/small/broken{
-	dir = 4
-	},
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"iHW" = (
-/obj/effect/turf_decal/stripes/white/box,
-/obj/structure/wreck/trash/brokenvendor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/bunker)
 "iId" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 5
@@ -10685,13 +10144,6 @@
 	icon_state = "dark"
 	},
 /area/f13/building)
-"iMF" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/bunker)
 "iMP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -10725,10 +10177,6 @@
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel/freezer,
 /area/f13/den)
-"iNP" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "iNY" = (
 /obj/structure/closet/cardboard,
 /turf/open/indestructible/ground/outside/graveldirt,
@@ -11241,15 +10689,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"jfx" = (
-/obj/item/book/granter/trait/chemistry,
-/obj/structure/closet/anchored,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "jfE" = (
 /obj/structure/fence/handrail_end/non_dense{
 	pixel_x = -16;
@@ -11481,12 +10920,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"joH" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/bunker)
 "jpe" = (
 /obj/machinery/light{
 	dir = 4
@@ -11610,18 +11043,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"jud" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/bunker)
 "jug" = (
 /obj/structure/table/wood,
 /obj/item/flashlight,
@@ -11712,14 +11133,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"jwN" = (
-/obj/structure/table/optable,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"jwS" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/bunker)
 "jwZ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -11762,13 +11175,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"jze" = (
-/obj/structure/junk/locker,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "jzg" = (
 /obj/structure/rack,
 /obj/item/stack/crafting/electronicparts/three,
@@ -11848,12 +11254,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/den)
-"jCE" = (
-/mob/living/simple_animal/hostile/handy/gutsy,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/bunker)
 "jCU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -12291,12 +11691,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"jVT" = (
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/bunker)
 "jWa" = (
 /obj/structure/closet/crate{
 	icon_state = "medicalcrate"
@@ -12528,11 +11922,6 @@
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
-"kcE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/kitchenspike,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "kcY" = (
 /obj/structure/barricade/wooden/strong,
 /obj/machinery/door/airlock/abandoned,
@@ -12549,13 +11938,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"kdk" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/bunker)
 "kdH" = (
 /obj/structure/safe/floor,
 /turf/closed/wall/r_wall,
@@ -12708,12 +12090,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"kkd" = (
-/obj/structure/debris/v3{
-	layer = 2
-	},
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/bunker)
 "kkg" = (
 /obj/structure/sign/poster/contraband/donut_corp{
 	pixel_y = 32
@@ -12781,11 +12157,6 @@
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
-/area/f13/bunker)
-"kkK" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/structure/junk/locker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "kkU" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -12877,11 +12248,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"kre" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/remains/human,
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
 "krt" = (
 /obj/structure/barricade/bars,
 /obj/effect/decal/cleanable/dirt,
@@ -13072,11 +12438,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"kBs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/bed/oldalt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "kBx" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -13133,10 +12494,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/f13/den)
-"kDe" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/bunker)
 "kDS" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -13412,12 +12769,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/freezer,
 /area/f13/den)
-"kQc" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/bunker)
 "kQy" = (
 /obj/structure/table{
 	pixel_y = 6
@@ -13479,11 +12830,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"kSx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "kTl" = (
 /obj/structure/decoration/vent/rusty,
 /obj/item/radio,
@@ -13606,10 +12952,6 @@
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
-/area/f13/bunker)
-"laO" = (
-/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "laU" = (
 /obj/machinery/computer/rdconsole{
@@ -13781,16 +13123,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"leT" = (
-/obj/structure/table/optable,
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "lfg" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Brig";
@@ -14151,12 +13483,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"ltr" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "lts" = (
 /obj/structure/table,
 /obj/item/kitchen/knife/butcher,
@@ -14199,25 +13525,11 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
-"lvx" = (
-/obj/structure/reagent_dispensers/barrel/explosive,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "lwc" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"lwq" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
-	},
-/obj/structure/decoration/vent,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "lwz" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14427,12 +13739,6 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/bunker)
-"lGD" = (
-/obj/structure/closet/anchored,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/broken,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "lGH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14695,10 +14001,6 @@
 /obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"lTX" = (
-/obj/structure/bed/old,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "lUm" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/decal/fakelattice,
@@ -15312,13 +14614,6 @@
 /obj/effect/landmark/start/f13/ncrveteranranger,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"msi" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/handy/gutsy,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/bunker)
 "msv" = (
 /obj/structure/table/reinforced,
 /obj/item/twohanded/sledgehammer,
@@ -15389,12 +14684,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mvO" = (
-/obj/machinery/chem_master/advanced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "mwG" = (
 /obj/item/ammo_casing/shotgun/buckshot,
 /obj/structure/wreck/trash/engine,
@@ -15529,14 +14818,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/den)
-"mBL" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/reagent_dispensers/barrel/explosive,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "mBS" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -15674,15 +14955,6 @@
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
-"mHA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "mHK" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -15742,19 +15014,8 @@
 	icon_state = "showroomfloor"
 	},
 /area/f13/bunker)
-"mKt" = (
-/obj/machinery/light/small/broken{
-	dir = 8
-	},
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "mKE" = (
 /mob/living/simple_animal/hostile/handy/gutsy/nsb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"mKH" = (
-/obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "mKY" = (
@@ -15862,10 +15123,6 @@
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
-"mOY" = (
-/obj/structure/junk/locker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "mPa" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -15896,12 +15153,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/f13/bunker)
-"mQd" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "mQj" = (
 /obj/structure/toilet{
 	dir = 1
@@ -15916,13 +15167,6 @@
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"mRk" = (
-/obj/machinery/door/airlock/hatch,
-/obj/structure/barricade/wooden/planks,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/bunker)
 "mRz" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/carpet,
@@ -16433,14 +15677,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"niW" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "njZ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/beakers,
@@ -16471,13 +15707,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"nll" = (
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "nlH" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard{
@@ -16840,12 +16069,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nBe" = (
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "nBh" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/breadslice/plain,
@@ -17164,16 +16387,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"nPE" = (
-/obj/structure/decoration/vent,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "nQe" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -17299,11 +16512,6 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nTc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/bunker)
 "nTr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
@@ -17481,15 +16689,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"nYd" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "nYw" = (
 /obj/machinery/door/airlock/wood{
 	req_access_txt = "121"
@@ -17605,14 +16804,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"ocv" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/built,
-/obj/structure/junk/micro,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/bunker)
 "odj" = (
 /obj/effect/decal/remains,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -17726,15 +16917,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"oeA" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "ofm" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/inside/mountain,
@@ -18084,11 +17266,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"ouq" = (
-/obj/machinery/door/airlock/hatch,
-/obj/structure/barricade/wooden/planks,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "ouz" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -18141,12 +17318,6 @@
 /obj/item/stack/sheet/plasteel/twenty,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
-"owF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "owX" = (
@@ -18616,10 +17787,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"oQp" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker)
 "oQs" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -18653,13 +17820,6 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
-/area/f13/bunker)
-"oRK" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "oRZ" = (
 /obj/structure/table/wood/bar,
@@ -18838,17 +17998,6 @@
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"oWK" = (
-/obj/structure/barricade/bars,
-/obj/structure/barricade/bars,
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "oWM" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -18987,10 +18136,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"pdR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "pem" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/east,
@@ -19131,11 +18276,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"piO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/reagent_dispensers/barrel/explosive,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "piT" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -19244,11 +18384,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"pon" = (
-/obj/structure/table,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "poM" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13{
@@ -19307,12 +18442,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
-"prL" = (
-/obj/structure/table,
-/obj/machinery/light/small,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "prM" = (
 /obj/structure/table/reinforced,
 /obj/item/book/granter/trait/chemistry,
@@ -19565,19 +18694,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"pAR" = (
-/obj/structure/closet/anchored,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/bunker)
-"pAY" = (
-/obj/structure/rack,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "pBe" = (
 /obj/machinery/light/small,
 /mob/living/simple_animal/hostile/deathclaw,
@@ -19732,12 +18848,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"pFY" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "pGw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -20052,11 +19162,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"pRA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "pRM" = (
 /obj/machinery/telecomms/message_server,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -20084,14 +19189,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"pSE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "pTD" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -20371,11 +19468,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"qeW" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "qfu" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -20386,18 +19478,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
-"qfx" = (
-/obj/effect/decal/fakelattice,
-/obj/structure/closet/anchored,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "qfB" = (
 /obj/machinery/door/airlock/wood{
 	name = "Ranger Quarters";
@@ -20474,11 +19554,6 @@
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"qiL" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "qiO" = (
 /obj/item/chair,
 /turf/open/indestructible/ground/inside/subway,
@@ -20612,12 +19687,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"qoW" = (
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/bunker)
 "qpc" = (
 /obj/machinery/sleeper{
 	density = 1;
@@ -20859,12 +19928,6 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"qwG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
 "qwH" = (
@@ -21138,17 +20201,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"qIj" = (
-/obj/structure/debris/v3{
-	layer = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"qIx" = (
-/obj/machinery/light/small,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "qIB" = (
 /obj/structure/lattice{
 	layer = 3
@@ -21355,14 +20407,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/den)
-"qNR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "qOD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/box/bodybags{
@@ -21483,11 +20527,6 @@
 /obj/structure/glowshroom/single,
 /turf/open/water,
 /area/f13/caves)
-"qRy" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "qRM" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/meatsalted,
@@ -21614,17 +20653,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/operations)
-"qVw" = (
-/obj/effect/turf_decal/arrows/white{
-	dir = 8;
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/stripes/white/box,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/bunker)
 "qVC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -21977,11 +21005,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"rin" = (
-/mob/living/simple_animal/hostile/handy/sentrybot/nsb/riot,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "riF" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -21997,11 +21020,6 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/bunker)
-"riZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "rjq" = (
 /obj/structure/toilet{
@@ -22026,10 +21044,6 @@
 /obj/structure/bed,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
-"rjY" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "rkH" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/f13{
@@ -22085,14 +21099,6 @@
 /mob/living/simple_animal/hostile/supermutant/nightkin,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"rlz" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/bunker)
 "rlW" = (
 /obj/structure/reagent_dispensers/barrel/three{
 	pixel_x = -14
@@ -22137,23 +21143,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/tunnel)
-"rnt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"rnw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/junk/small/bed,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "rnI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
@@ -22602,13 +21591,6 @@
 /obj/item/ammo_box/a308,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"rAQ" = (
-/obj/structure/barricade/bars,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "rAW" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/f13{
@@ -22730,12 +21712,6 @@
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
-	},
-/area/f13/bunker)
-"rGo" = (
-/mob/living/simple_animal/hostile/handy/gutsy,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
 "rGw" = (
@@ -22923,16 +21899,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/operations)
-"rLZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "rMk" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -22993,15 +21959,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/den)
-"rOT" = (
-/obj/machinery/light/small/broken,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "rPg" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13{
@@ -23047,10 +22004,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"rPQ" = (
-/mob/living/simple_animal/hostile/handy/assaultron,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "rQm" = (
 /obj/structure/closet/crate/large,
 /obj/item/storage/box/stockparts/basic,
@@ -23210,12 +22163,6 @@
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"rXn" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "rXA" = (
 /obj/structure/timeddoor,
 /obj/structure/timeddoor,
@@ -23329,12 +22276,6 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/water,
 /area/f13/caves)
-"sdX" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "sef" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/flora/rock/jungle,
@@ -23388,13 +22329,6 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
-"sfx" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/bunker)
 "sfy" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical/old,
@@ -23635,22 +22569,6 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
-"snc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/handy/gutsy,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"snf" = (
-/obj/machinery/light/small/broken{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "snP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -23781,13 +22699,6 @@
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
-/area/f13/bunker)
-"syz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "syU" = (
 /obj/structure/dresser,
@@ -23985,14 +22896,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
-"sKR" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/bunker)
 "sLx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -24076,7 +22979,7 @@
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
 	},
-/area/f13/bunker)
+/area/f13/caves)
 "sPK" = (
 /obj/structure/bed/old,
 /turf/open/floor/plasteel/f13{
@@ -24088,11 +22991,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
 /area/f13/den)
-"sPX" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/bunker)
 "sPY" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/structure/spider/stickyweb,
@@ -24330,17 +23228,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
-"tam" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/bunker)
-"tap" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/mineral/random/low_chance,
-/area/f13/bunker)
 "taI" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -24348,11 +23235,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"taP" = (
-/obj/structure/decoration/vent,
-/obj/structure/reagent_dispensers/barrel/explosive,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "tbE" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -24595,15 +23477,6 @@
 	icon_state = "bluefull"
 	},
 /area/f13/bunker)
-"tjG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/broken{
-	dir = 8
-	},
-/obj/effect/decal/fakelattice,
-/obj/structure/reagent_dispensers/barrel/explosive,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "tjI" = (
 /obj/structure/chair/sofa/right,
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
@@ -24734,14 +23607,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"tpW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/bed/old,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
 "tqE" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -24852,10 +23717,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"ttE" = (
-/obj/structure/junk/locker,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "ttW" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -24944,18 +23805,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/den)
-"twb" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "twj" = (
 /obj/item/instrument/saxophone,
 /obj/structure/rack,
@@ -25073,10 +23922,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
-"tDc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/indestructible/rock,
-/area/f13/bunker)
 "tDo" = (
 /obj/structure/table/wood/poker,
 /obj/effect/decal/cleanable/dirt,
@@ -25160,15 +24005,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"tGA" = (
-/obj/structure/barricade/bars,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "tGW" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/den)
@@ -25496,14 +24332,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
 /area/f13/den)
-"tWo" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wreck/trash/machinepile,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
 "tWR" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -25665,11 +24493,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"uaR" = (
-/obj/structure/rack,
-/obj/machinery/light/small/broken,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "ubh" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -25679,18 +24502,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
-	},
-/area/f13/bunker)
-"ubj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
 "ubr" = (
@@ -25752,11 +24563,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
-"ufh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "ufQ" = (
 /obj/structure/decoration/warning,
 /turf/closed/wall/rust,
@@ -25916,18 +24722,6 @@
 	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
-"uog" = (
-/obj/structure/bed/mattress/pregame,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
 "uoq" = (
@@ -26219,12 +25013,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/tunnel)
-"uzy" = (
-/obj/machinery/light/small/broken{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "uAc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26302,12 +25090,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/brotherhood/reactor)
-"uEj" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/bunker)
 "uEm" = (
 /obj/effect/landmark/start/f13/enforcer,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -26349,36 +25131,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"uHH" = (
-/obj/effect/turf_decal/arrows/white{
-	dir = 8;
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/stripes/white/box,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"uHT" = (
-/obj/structure/table,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/bunker)
 "uHU" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"uIk" = (
-/obj/structure/simple_door/metal/barred{
-	req_one_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "uIE" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -26475,13 +25231,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/f13/tcoms)
-"uLI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/debris/v3{
-	layer = 2
-	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/bunker)
 "uLM" = (
 /obj/structure/table,
 /obj/item/clothing/under/f13/enclave_officer,
@@ -26503,18 +25252,6 @@
 	icon_state = "housebase"
 	},
 /area/f13/den)
-"uLX" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
-	},
-/obj/structure/decoration/vent,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "uMA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/f13/rotten,
@@ -26556,10 +25293,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"uOF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
 "uOL" = (
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/gloves/color/white/bos,
@@ -26622,14 +25355,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"uSi" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/bunker)
 "uSI" = (
 /obj/structure/chair/wood,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -26768,15 +25493,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/den)
-"vbu" = (
-/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "vbV" = (
 /obj/structure/handrail/g_central{
 	dir = 4;
@@ -26869,12 +25585,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"vfo" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "vfx" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -26911,13 +25621,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/operations)
-"vfU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/bunker)
 "vfV" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -27112,15 +25815,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"vri" = (
-/obj/structure/simple_door/metal/barred{
-	req_one_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "vrD" = (
 /obj/structure/table/abductor{
 	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
@@ -27183,11 +25877,6 @@
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"vvW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/handy/gutsy,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "vwa" = (
 /obj/structure/chair/wood/modern{
 	dir = 8;
@@ -27195,15 +25884,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"vwg" = (
-/obj/structure/decoration/vent,
-/obj/effect/turf_decal/stripes/white/box,
-/obj/structure/reagent_dispensers/barrel/explosive,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "vwh" = (
 /obj/machinery/light_switch{
 	pixel_x = 27
@@ -27239,14 +25919,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
-"vxG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/office,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "vxK" = (
 /obj/machinery/door/window,
 /obj/effect/decal/cleanable/dirt,
@@ -27260,11 +25932,6 @@
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
-/area/f13/bunker)
-"vyK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wreck/trash/brokenvendor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bunker)
 "vyL" = (
 /obj/structure/statue/uranium/nuke,
@@ -27311,14 +25978,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/den)
-"vCr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/debris/v3{
-	layer = 2
-	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/bunker)
 "vCF" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /obj/effect/decal/waste{
@@ -27386,23 +26045,12 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
-"vFv" = (
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "vFx" = (
 /obj/structure/chair/comfy/brown,
 /obj/item/clothing/head/crown,
 /mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"vGr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
 "vGT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -27538,12 +26186,6 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"vOE" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "vPB" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt{
@@ -27615,11 +26257,6 @@
 /obj/effect/landmark/start/f13/raider,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/den)
-"vRs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "vRw" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -27642,13 +26279,6 @@
 	icon_state = "neutralrusty"
 	},
 /area/f13/den)
-"vSW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "vTm" = (
 /obj/structure/lattice{
 	layer = 2
@@ -27704,13 +26334,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/operations)
-"vWg" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "vWj" = (
 /obj/item/paper/crumpled{
 	info = "By order order of the Boss, the Den has 3 rules. No murdering while you're inside. No stealing while you're inside. Pay a tribute to the boss for providing a safe haven, if you are able to do so.";
@@ -27751,14 +26374,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"vXS" = (
-/obj/effect/turf_decal/stripes/white/box,
-/obj/effect/turf_decal/delivery/white,
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
 	},
 /area/f13/bunker)
 "vXU" = (
@@ -27857,16 +26472,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/reactor)
-"wag" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/structure/closet/anchored,
-/obj/item/clothing/under/f13/enclave/peacekeeper,
-/obj/item/clothing/shoes/f13/enclave/serviceboots,
-/obj/item/clothing/gloves/f13/military,
-/obj/item/clothing/head/helmet/f13/helmet/enclave/peacekeeper,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "waL" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plating/tunnel,
@@ -27888,13 +26493,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"wbu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "wbW" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -27914,15 +26512,6 @@
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"wcQ" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
-	},
-/obj/structure/decoration/vent,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "wdt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -28112,20 +26701,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"wpj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
-"wpO" = (
-/obj/machinery/light/small/broken{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "wqD" = (
 /obj/effect/turf_decal/bot_white,
 /obj/effect/decal/cleanable/dirt,
@@ -28212,21 +26787,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/den)
-"wuT" = (
-/obj/structure/closet/crate{
-	name = "MRE Crate"
-	},
-/obj/effect/spawner/lootdrop/mre,
-/obj/effect/spawner/lootdrop/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/trash/f13/mre,
-/obj/item/trash/f13/mre,
-/obj/item/trash/f13/mre,
-/obj/item/trash/f13/mre,
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/bunker)
 "wvi" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -28268,13 +26828,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"wwE" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker)
 "wwW" = (
 /obj/structure/sink{
 	dir = 4;
@@ -28287,11 +26840,6 @@
 	icon_state = "housebase"
 	},
 /area/f13/den)
-"wxe" = (
-/obj/structure/table,
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "wxL" = (
 /obj/structure/table/wood/fancy/green,
 /turf/open/indestructible/ground/inside/subway,
@@ -28300,10 +26848,6 @@
 /obj/item/clothing/head/hardhat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"wyT" = (
-/obj/structure/wreck/trash/brokenvendor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/bunker)
 "wzw" = (
 /obj/structure/fence/handrail_end/non_dense{
 	pixel_x = -16;
@@ -28323,10 +26867,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
-"wAg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "wAk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
@@ -28470,13 +27010,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"wJo" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/food/snacks/meat/slab/gecko,
-/obj/item/reagent_containers/food/snacks/meat/slab/gecko,
-/obj/item/reagent_containers/food/snacks/meat/slab/gecko,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "wJQ" = (
 /obj/structure/barricade/bars,
 /obj/structure/barricade/bars,
@@ -28537,15 +27070,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"wKS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/broken{
-	dir = 8
-	},
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "wLv" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/reactor)
@@ -28605,14 +27129,6 @@
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/den)
-"wMR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/junk/small/tv,
-/obj/machinery/light/small/broken{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
 "wNk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -28664,10 +27180,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"wRn" = (
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "wRA" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -28679,13 +27191,6 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"wRS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/remains/human,
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/bunker)
 "wSb" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
@@ -28708,11 +27213,6 @@
 /obj/structure/table,
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"wTH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "wUv" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/inside/mountain,
@@ -28763,10 +27263,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"wXe" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "wXl" = (
 /obj/structure/table/wood,
 /obj/structure/table/wood,
@@ -28815,14 +27311,6 @@
 /obj/item/bodybag,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/den)
-"wZE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/handy/assaultron,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "wZL" = (
 /obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -29075,27 +27563,11 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"xiO" = (
-/obj/structure/debris/v3{
-	layer = 2
-	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/bunker)
 "xjk" = (
 /obj/structure/chair/bench,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"xjn" = (
-/obj/structure/closet/anchored,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "xjE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -29236,14 +27708,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/den)
-"xos" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/obj/structure/junk/locker,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "xoS" = (
 /obj/effect/landmark/start/f13/raider,
 /turf/open/indestructible/ground/inside/mountain,
@@ -29321,10 +27785,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/den)
-"xsh" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "xsy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -29363,10 +27823,6 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"xuW" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "xvg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -29386,15 +27842,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
-"xvZ" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/bunker)
 "xwm" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/caves)
@@ -29461,14 +27908,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/den)
-"xAa" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "xAf" = (
 /obj/machinery/power/smes/engineering,
 /obj/effect/decal/cleanable/dirt,
@@ -29558,10 +27997,6 @@
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor,
 /area/f13/den)
-"xFe" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/closed/mineral/random/low_chance,
-/area/f13/bunker)
 "xFN" = (
 /obj/structure/simple_door/fakeglass,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -29919,22 +28354,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"ybL" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/bunker)
-"ybS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/hatch,
-/obj/structure/barricade/wooden/planks,
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/bunker)
 "ycc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -29952,10 +28371,6 @@
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
-/area/f13/bunker)
-"ydf" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "ydP" = (
 /obj/structure/handrail/g_central{
@@ -30071,12 +28486,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/caves)
-"yls" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/handy/assaultron,
-/obj/effect/decal/fakelattice,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "ymg" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1";
@@ -61683,10 +60092,10 @@ tur
 tur
 tur
 tur
-rex
-rex
-rex
-rex
+eLE
+eLE
+eLE
+eLE
 uoO
 uoO
 uoO
@@ -61917,35 +60326,35 @@ tur
 tur
 tur
 tur
-rex
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-cfR
-cfR
-ybS
-cfR
-cfR
-eLE
-eLE
-eLE
-eLE
-eLE
-yhT
-yhT
-yhT
-yhT
-yhT
-rex
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -62174,35 +60583,35 @@ uoO
 uoO
 uoO
 uoO
-rex
-yhT
-osY
-gPj
-ujY
-ydf
-wXe
-vfo
-vfo
-xsh
-yhT
-yhT
-uLX
-vDC
-nPE
-yhT
-eLE
-eLE
-yhT
-yhT
-yhT
-yhT
-taP
-tjG
-eZx
-yhT
-rex
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -62430,34 +60839,34 @@ uoO
 uoO
 uoO
 uoO
-rex
-rex
-yhT
-ujY
-yhT
-yhT
-yhT
-mOY
-ujY
-ujY
-vfo
-yhT
-yhT
-xos
-iiK
-hsN
-yhT
-yhT
-yhT
-yhT
-qfx
-vfo
-ujY
-vwg
-piO
-lvx
-yhT
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -62687,38 +61096,38 @@ uoO
 uoO
 uoO
 uoO
-rex
-yhT
-yhT
-joH
-yhT
-yhT
-yhT
-xjn
-ujY
-rin
-uaR
-yhT
-yhT
-mHA
-uSi
-lwq
-yhT
-yhT
-aXl
-yhT
-nYd
-qIx
-yhT
-mBL
-wbu
-fKz
-yhT
-rex
-rex
-rex
-rex
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -62944,38 +61353,38 @@ aoj
 aoj
 uoO
 uoO
-rex
-yhT
-fPQ
-gXQ
-sKR
-pon
-yhT
-mOY
-nll
-vfo
-rjY
-yhT
-yhT
-yhT
-dAQ
-yhT
-yhT
-yhT
-eXJ
-yhT
-ouq
-yhT
-yhT
-fJu
-vFv
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -63201,38 +61610,38 @@ uoO
 uoO
 uoO
 uoO
-rex
-yhT
-fKm
-niW
-rPQ
-prL
-yhT
-jze
-ujY
-gjJ
-ujY
-yhT
-qiL
-niW
-mHA
-mHA
-wpj
-yhT
-hTg
-fvw
-gjJ
-pdR
-bhO
-pdR
-wTH
-mKt
-yhT
-fvg
-wMR
-tWo
-yhT
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -63458,38 +61867,38 @@ uoO
 uoO
 uoO
 uoO
-rex
-yhT
-fMJ
-hYt
-rjY
-pAY
-yhT
-hvF
-dIV
-xSi
-vfo
-yhT
-osY
-wpj
-xvZ
-rjY
-flz
-yhT
-kkK
-qNR
-kBs
-vfo
-xSi
-pdR
-lTX
-rjY
-yhT
-fUO
-vDC
-wTH
-yhT
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -63714,41 +62123,41 @@ uoO
 uoO
 uoO
 uoO
-aoj
-rex
-yhT
-fPQ
-nll
-sKR
-qRy
-yhT
-oRK
-eZh
-vfo
-uaR
-yhT
-gFZ
-kQc
-pon
-ahV
-hmn
-yhT
-kkK
-wbu
-pdR
-wTH
-aYl
-ufh
-pdR
-pdR
-ouq
-vGr
-aYl
-vDC
-yhT
-rex
-rex
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -63972,40 +62381,40 @@ uoO
 uoO
 uoO
 uoO
-rex
-yhT
-fQo
-rPQ
-ujY
-rOT
-yhT
-xuW
-ujY
-ujY
-xsh
-yhT
-rGo
-niW
-vDC
-mHA
-xvZ
-yhT
-wag
-pdR
-nwa
-riZ
-aAL
-pdR
-rnw
-pRA
-yhT
-dNW
-vGr
-kre
-yhT
-yhT
-yhT
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -64228,41 +62637,41 @@ uoO
 uoO
 uoO
 uoO
-rex
-rex
-yhT
-gNg
-iCd
-sKR
-sfx
-yhT
-nWb
-osY
-ujY
-xsh
-yhT
-mQd
-wpj
-mHA
-ujY
-rjY
-yhT
-mKH
-pRA
-uzy
-pdR
-wbu
-rLZ
-pdR
-ujY
-yhT
-boV
-tpW
-vGr
-tTW
-rjY
-yhT
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -64485,41 +62894,41 @@ uoO
 uoO
 uoO
 aoj
-rex
-yhT
-yhT
-yhT
-yhT
-mRk
-yhT
-kkd
-kkd
-yhT
-ouq
-yhT
-yhT
-yhT
-ouq
-yhT
-ouq
-yhT
-yhT
-yhT
-eXJ
-yhT
-yhT
-yhT
-yhT
-eXJ
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-ujY
-yhT
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -64742,41 +63151,41 @@ uoO
 uoO
 aoj
 uoO
-rex
-yhT
-aBr
-hsR
-ujY
-mHA
-rKY
-qIj
-mKt
-osY
-pdR
-aek
-pdR
-nYd
-nYd
-iBp
-riZ
-wTH
-wKS
-eZh
-pdR
-wbu
-pdR
-yhT
-wuT
-hYt
-kdk
-faC
-qiL
-bNF
-vyK
-yhT
-ujY
-yhT
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -64999,41 +63408,41 @@ uoO
 uoO
 aoj
 uoO
-rex
-yhT
-vbu
-ujY
-wTH
-tap
-xiO
-vCr
-aLJ
-vDC
-vvW
-wRn
-rjY
-wTH
-ujY
-wZE
-vDC
-wTH
-yls
-vfo
-snc
-pdR
-vfo
-eXJ
-deH
-wTH
-iiK
-nBe
-vDC
-tam
-wyT
-yhT
-rjY
-yhT
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -65256,41 +63665,41 @@ uoO
 uoO
 aoj
 uoO
-rex
-yhT
-dYM
-kSx
-vDC
-wpj
-uLI
-osY
-xSi
-xSi
-xSi
-iGB
-vDC
-ufh
-vvW
-pdR
-ujY
-xSi
-wbu
-wbu
-wTH
-syz
-vDC
-yhT
-wRS
-yls
-hEn
-yhT
-vfU
-jwS
-tam
-tTW
-ujY
-yhT
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -65513,41 +63922,41 @@ uoO
 uoO
 aoj
 uoO
-rex
-yhT
-aHf
-fji
-niW
-qRy
-yhT
-sPX
-sPX
-iHW
-yhT
-yhT
-yhT
-ouq
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-vFv
-yhT
-yhT
-yhT
-qwG
-vDC
-wxe
-jwS
-vfU
-gQo
-ujY
-yhT
-yhT
-yhT
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -65770,41 +64179,41 @@ uoO
 uoO
 uoO
 uoO
-rex
-yhT
-faK
-gTk
-rjY
-jwN
-yhT
-sPX
-sPX
-qVw
-yhT
-bLa
-snf
-xAa
-dtB
-cim
-uog
-yhT
-vRs
-vSW
-eZh
-cGN
-mKH
-yhT
-jud
-dum
-dHQ
-tam
-nTc
-osY
-vDC
-yhT
-rex
-rex
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 eLE
@@ -66027,39 +64436,39 @@ uoO
 uoO
 uoO
 uoO
-rex
-yhT
-cIY
-osY
-ujY
-laO
-yhT
-uHT
-rjY
-vXS
-yhT
-aPb
-vDC
-flz
-uIk
-pFY
-ubj
-yhT
-vRs
-xSi
-kSx
-wTH
-ujY
-jVT
-dum
-msi
-uEj
-yhT
-vfU
-osY
-osY
-yhT
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -66284,39 +64693,39 @@ uoO
 uoO
 uoO
 uoO
-rex
-yhT
-dwY
-niW
-rXn
-leT
-yhT
-hcO
-osY
-uHH
-yhT
-ggi
-vDC
-ujY
-rAQ
-hcf
-hcf
-yhT
-vfo
-xSi
-riZ
-wTH
-xSi
-jVT
-osY
-ujY
-ocv
-yhT
-ybL
-vfU
-hqn
-yhT
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -66541,39 +64950,39 @@ uoO
 uoO
 uoO
 aoj
-rex
-yhT
-laO
-niW
-fji
-mvO
-yhT
-yhT
-jCE
-yhT
-yhT
-ezR
-osY
-rjY
-oWK
-vWg
-ujY
-kDe
-pdR
-pRA
-pdR
-wbu
-pdR
-qoW
-sdX
-ujY
-iMF
-yhT
-fLU
-tTW
-fLU
-yhT
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -66798,39 +65207,39 @@ uoO
 uoO
 uoO
 aoj
-rex
-yhT
-faK
-ujY
-iNP
-mQd
-yhT
-wcQ
-pdR
-guj
-yhT
-twb
-ujY
-osY
-vri
-rjY
-qIx
-yhT
-rnt
-vDC
-vxG
-vRs
-pRA
-yhT
-rlz
-ekj
-uEj
-yhT
-rjY
-osY
-yhT
-rex
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -67055,38 +65464,38 @@ uoO
 uoO
 uoO
 uoO
-rex
-yhT
-yhT
-hMJ
-jfx
-oeA
-yhT
-xos
-vDC
-lGD
-yhT
-ggi
-cuT
-xAa
-hcf
-rAQ
-tGA
-yhT
-qeW
-fwR
-xSi
-hFb
-vOE
-yhT
-rlz
-fLU
-fLU
-yhT
-ujY
-yhT
-yhT
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -67312,38 +65721,38 @@ uoO
 uoO
 uoO
 aoj
-rex
-rex
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-vFv
-yhT
-yhT
-ttE
-ejj
-owF
-emV
-vDC
-doa
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-fGF
-wTH
-kcE
-yhT
-ujY
-yhT
-rex
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -67570,36 +65979,36 @@ uoO
 uoO
 aoj
 uoO
-rex
-rex
-rex
-rex
-rex
-rex
-wwE
-oQp
-oQp
-yhT
-pAR
-ltr
-ujY
-uIk
-wpO
-avY
-yhT
-rex
-rex
-rex
-rex
-rex
-yhT
-wJo
-pSE
-fMX
-yhT
-osY
-yhT
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -67833,30 +66242,30 @@ uoO
 uoO
 uoO
 uoO
-uOF
-wAg
-eAK
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-tDc
-htG
-htG
-htG
-tDc
-yhT
-tTW
-yhT
-yhT
-yhT
-rjY
-yhT
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -68085,35 +66494,35 @@ uoO
 uoO
 uoO
 uoO
-aBb
-aBb
-aBb
-aBb
-uoO
-xVz
-xVz
-xFe
-rex
-rex
-rex
-rex
-rex
-rex
-rex
-rex
-rex
 uoO
 uoO
 uoO
-rex
-yhT
-cDH
-ujY
-ujY
-ujY
-rjY
-yhT
-rex
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -68342,17 +66751,6 @@ uoO
 uoO
 uoO
 uoO
-aBb
-aBb
-aBb
-aBb
-aBb
-lnr
-lnr
-aBb
-aBb
-aBb
-aBb
 uoO
 uoO
 uoO
@@ -68362,18 +66760,29 @@ uoO
 uoO
 uoO
 uoO
-rex
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-rex
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -68598,19 +67007,7 @@ aoj
 uoO
 uoO
 uoO
-aBb
-aBb
-aBb
-tOz
-aBb
-aBb
-aBb
-lnr
-aBb
-aBb
-aBb
-aBb
-aBb
+hkD
 uoO
 uoO
 uoO
@@ -68619,18 +67016,30 @@ uoO
 uoO
 uoO
 uoO
-rex
-rex
-rex
-rex
-rex
-rex
-rex
-rex
-rex
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -96,6 +96,11 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"aek" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "aes" = (
 /obj/structure/window/reinforced/spawner{
 	color = "#777777";
@@ -202,10 +207,8 @@
 "ahV" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/enclave)
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "aiQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -471,6 +474,16 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/tunnel)
+"avY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "awd" = (
 /obj/structure/table/wood/poker,
 /obj/item/dice{
@@ -586,13 +599,10 @@
 /area/f13/caves)
 "aAL" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/bedsheet,
-/obj/effect/landmark/start/f13/usprivate,
-/obj/structure/bed,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/obj/structure/bed/oldalt,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "aAX" = (
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -608,12 +618,12 @@
 	},
 /area/f13/bunker)
 "aBr" = (
-/obj/structure/table,
-/obj/item/book/granter/trait/midsurgery,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
+/obj/structure/junk/locker,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "aCo" = (
 /obj/structure/closet/crate{
 	icon_state = "medicalcrate"
@@ -686,9 +696,9 @@
 	},
 /area/f13/brotherhood/operations)
 "aEL" = (
-/obj/structure/mirror,
-/turf/closed/wall/r_wall/rust,
-/area/f13/enclave)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/tunnel)
 "aFb" = (
 /obj/item/soap,
 /obj/structure/rack,
@@ -791,11 +801,11 @@
 	},
 /area/f13/den)
 "aHf" = (
-/obj/structure/curtain,
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "aHj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -839,6 +849,14 @@
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"aLJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/debris/v3{
+	layer = 2
+	},
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "aMg" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
@@ -865,6 +883,15 @@
 /turf/closed/indestructible/vaultdoor{
 	desc = "A wall made out of metal, really fucking tough metal. Someone built this waaaay in advance.";
 	name = "bunker wall"
+	},
+/area/f13/bunker)
+"aPb" = (
+/obj/structure/junk/locker,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
 	},
 /area/f13/bunker)
 "aPr" = (
@@ -939,11 +966,6 @@
 	},
 /turf/open/floor/wood/f13/oakbroken,
 /area/f13/tunnel)
-"aSM" = (
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
-/area/f13/enclave)
 "aTB" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -988,8 +1010,9 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "aXl" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/enclave)
+/obj/structure/stairs/west,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "aXJ" = (
 /obj/structure/closet/crate/large,
 /obj/item/circuitboard/machine/protolathe,
@@ -1014,6 +1037,11 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
+/area/f13/bunker)
+"aYl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/abomhorror,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "aYI" = (
 /obj/structure/barricade/bars,
@@ -1193,19 +1221,6 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/tunnel)
-"bgL" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 23
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
-	},
-/area/f13/enclave)
 "bgV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -1220,6 +1235,19 @@
 "bhq" = (
 /obj/item/wrench/crude,
 /turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"bhO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "bis" = (
 /obj/effect/decal/cleanable/dirt{
@@ -1389,9 +1417,9 @@
 /area/f13/tunnel)
 "boV" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood,
+/obj/structure/junk/small/table,
 /turf/open/floor/carpet/black,
-/area/f13/enclave)
+/area/f13/bunker)
 "bpa" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -1905,6 +1933,13 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/brotherhood/operations)
+"bLa" = (
+/obj/structure/junk/locker,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/bunker)
 "bMe" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/subway,
@@ -1961,10 +1996,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "bNF" = (
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/machinery/light/small/broken{
+	dir = 8
 	},
-/area/f13/enclave)
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/bunker)
 "bOf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -2289,6 +2326,10 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"cfR" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "cfU" = (
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2326,14 +2367,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "cim" = (
-/obj/machinery/light{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "ciF" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -2604,10 +2648,14 @@
 /area/f13/tunnel)
 "cuT" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/assaultron,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "cvd" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -2787,6 +2835,10 @@
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"cDH" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "cDL" = (
 /obj/item/stack/cable_coil/random/five,
 /obj/effect/decal/cleanable/dirt,
@@ -2881,6 +2933,13 @@
 	},
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
+"cGN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "cGZ" = (
 /obj/structure/table/booth,
 /turf/open/indestructible/ground/inside/subway,
@@ -2930,11 +2989,16 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "cIY" = (
-/obj/structure/table/optable,
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/bunker)
 "cKI" = (
 /obj/item/gun/ballistic/automatic/tribalbow{
 	desc = "A simple wooden bow with small pieces of turquiose. This one looks particularly blood-covered. Who the fuck brings a /BOW/ to a /BUNKER/"
@@ -3235,12 +3299,6 @@
 	icon_state = "bluemark"
 	},
 /area/f13/bunker)
-"cUi" = (
-/obj/machinery/photocopier,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/enclave)
 "cUk" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -3513,7 +3571,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "deX" = (
 /obj/structure/simple_door/fakeglass,
 /obj/effect/decal/cleanable/dirt,
@@ -3658,7 +3716,7 @@
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "doi" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3810,12 +3868,21 @@
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "duf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"dum" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/bunker)
 "duv" = (
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3858,14 +3925,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dwY" = (
-/obj/machinery/light{
+/obj/machinery/light/small/broken{
 	dir = 1
 	},
-/obj/structure/table/optable,
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
+/obj/structure/showcase/horrific_experiment{
+	icon_state = "pod_0_maintenance"
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/bunker)
 "dxd" = (
 /obj/structure/reagent_dispensers/barrel,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3958,6 +4027,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"dAQ" = (
+/obj/structure/door_assembly/door_assembly_grunge,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/bunker)
 "dBb" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/table/wood,
@@ -4153,12 +4229,11 @@
 /area/f13/brotherhood/offices1st)
 "dHQ" = (
 /obj/structure/table,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife,
+/obj/structure/barricade/sandbags,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "dID" = (
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/gloves/color/white/bos,
@@ -4173,6 +4248,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
+"dIV" = (
+/mob/living/simple_animal/hostile/handy/gutsy,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "dJm" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/subway,
@@ -4331,10 +4410,10 @@
 /area/f13/bunker)
 "dNW" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/cabinet,
 /obj/item/clothing/suit/armor/f13/battlecoat/tan/enclave,
-/turf/open/floor/carpet/black,
-/area/f13/enclave)
+/obj/structure/closet/anchored,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "dOf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/one_barrel,
@@ -4462,14 +4541,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"dSO" = (
-/obj/machinery/door/airlock/hatch{
-	req_one_access_txt = "134"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/enclave)
 "dSU" = (
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -4582,13 +4653,11 @@
 	},
 /area/f13/tunnel)
 "dYM" = (
-/obj/item/bedsheet,
-/obj/effect/landmark/start/f13/usspy,
-/obj/structure/bed,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
+/obj/structure/showcase/horrific_experiment{
+	icon_state = "pod_0"
 	},
-/area/f13/enclave)
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "dYQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -4788,24 +4857,20 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
+"ejj" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "ejr" = (
 /obj/structure/barricade/wooden,
 /obj/effect/mine/stun,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"ejG" = (
-/obj/structure/table,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 23
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
-	},
-/area/f13/enclave)
 "ejM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/autoname{
@@ -4830,14 +4895,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/den)
 "ekj" = (
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 12
-	},
+/obj/structure/barricade/sandbags,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "ekl" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom"
@@ -4900,7 +4962,7 @@
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "enl" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
@@ -5190,7 +5252,7 @@
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "eAa" = (
 /obj/machinery/vending/sovietsoda,
 /turf/open/floor/f13{
@@ -5212,6 +5274,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper/crumpled,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"eAK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/timeddoor/sixtyminute,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "eAQ" = (
 /obj/structure/nest/scorpion,
@@ -5795,16 +5862,14 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/tunnel)
 "eZx" = (
-/obj/structure/decoration/vent,
 /obj/machinery/shower{
 	dir = 1
 	},
-/obj/structure/curtain,
-/obj/effect/turf_decal/stripes/white/box,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/enclave)
+/obj/item/gun/energy/laser/plasma,
+/obj/effect/decal/remains/human,
+/obj/item/clothing/head/helmet/f13/helmet/enclave/peacekeeper,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "eZU" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/lattice/catwalk,
@@ -5827,14 +5892,14 @@
 /area/f13/bunker)
 "faC" = (
 /obj/structure/sink/kitchen,
-/turf/closed/wall/r_wall/rust,
-/area/f13/enclave)
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "faK" = (
-/obj/structure/closet/crate/freezer/blood/anchored,
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
+/obj/structure/showcase/horrific_experiment,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "faR" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5919,19 +5984,6 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/operations)
-"fgo" = (
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/enclave)
-"fgy" = (
-/obj/item/circuitboard/machine/ore_silo,
-/obj/structure/frame/machine,
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/enclave)
 "fgG" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating/tunnel,
@@ -6000,13 +6052,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "fji" = (
-/obj/item/bedsheet,
-/obj/effect/landmark/start/f13/usprivate,
-/obj/structure/bed,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
+/mob/living/simple_animal/hostile/abomhorror,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "fjN" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy/assaultron,
@@ -6067,6 +6117,11 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"flz" = (
+/mob/living/simple_animal/hostile/handy/assaultron,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "flC" = (
 /obj/machinery/door/airlock/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -6126,19 +6181,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"fnW" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/decoration/vent,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/enclave)
 "fnZ" = (
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_y = 32
@@ -6294,8 +6336,9 @@
 "fvg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/office,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/carpet/black,
-/area/f13/enclave)
+/area/f13/bunker)
 "fvo" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -6308,13 +6351,11 @@
 	},
 /area/f13/tunnel)
 "fvw" = (
-/obj/machinery/light{
+/obj/machinery/light/small/broken{
 	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "fws" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/computer/terminal{
@@ -6333,10 +6374,11 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "fwX" = (
 /obj/machinery/workbench/advanced,
 /obj/effect/turf_decal/stripes/box,
@@ -6544,14 +6586,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
-"fEA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/office/dark{
-	dir = 1;
-	icon_state = "officechair_dark"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/enclave)
 "fEB" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
@@ -6596,10 +6630,9 @@
 /area/f13/tunnel)
 "fGF" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/enclave)
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "fGO" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -6648,6 +6681,12 @@
 /obj/machinery/light,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
+"fJu" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "fJx" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -6667,14 +6706,23 @@
 	},
 /area/f13/bunker)
 "fKm" = (
-/obj/machinery/light{
+/obj/machinery/light/small/broken{
 	dir = 1
 	},
-/obj/machinery/autolathe,
+/obj/structure/junk/machinery,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
+"fKz" = (
+/obj/structure/decoration/vent,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/box,
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "fKP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -6737,11 +6785,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "fMJ" = (
-/obj/machinery/workbench/advanced,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "fMR" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -6762,10 +6813,8 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/kitchenspike,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "fNc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -6842,20 +6891,20 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "fPQ" = (
-/obj/machinery/rnd/production/protolathe,
+/obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "fQo" = (
-/obj/machinery/light{
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/machinery/light/small/broken{
 	dir = 1
 	},
-/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "fQF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/sandbags,
@@ -6971,6 +7020,11 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"fUO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/office,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "fUR" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -7165,14 +7219,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/operations)
-"gej" = (
-/obj/machinery/door/airlock/hatch{
-	req_one_access_txt = "134"
-	},
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/enclave)
 "ger" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood/f13/old,
@@ -7199,14 +7245,11 @@
 	},
 /area/f13/brotherhood/offices1st)
 "ggi" = (
-/obj/structure/closet/anchored,
-/obj/item/card/id/prisoner/one,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/under/rank/prisoner,
+/obj/structure/junk/locker,
 /turf/open/floor/f13{
 	icon_state = "redmark"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "ggm" = (
 /obj/structure/table{
 	layer = 2.9
@@ -7316,6 +7359,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"gjJ" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gkm" = (
 /mob/living/simple_animal/hostile/centaur,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -7618,14 +7668,9 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
 	},
-/obj/machinery/shower{
-	dir = 4
-	},
 /obj/structure/decoration/vent,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gul" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy/assaultron/nsb,
@@ -7865,13 +7910,16 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "gFZ" = (
-/obj/machinery/light{
+/obj/machinery/light/small/broken{
 	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "dark"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/bunker)
 "gGG" = (
 /obj/effect/mine/explosive,
 /obj/machinery/light/small,
@@ -7979,11 +8027,9 @@
 	},
 /area/f13/brotherhood/operations)
 "gNg" = (
-/obj/machinery/computer/rdconsole,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/enclave)
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "gNj" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -8076,6 +8122,10 @@
 	dir = 10;
 	icon_state = "redmark"
 	},
+/area/f13/bunker)
+"gQo" = (
+/mob/living/simple_animal/hostile/handy/sentrybot,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "gQI" = (
 /obj/structure/table,
@@ -8174,10 +8224,17 @@
 	},
 /area/f13/followers)
 "gTk" = (
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/bunker)
 "gTv" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 5
@@ -8247,11 +8304,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"gUF" = (
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
-	},
-/area/f13/enclave)
 "gVb" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -8349,10 +8401,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "gXQ" = (
+/obj/effect/decal/remains/human,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "gYt" = (
 /obj/structure/lattice{
 	density = 1
@@ -8453,12 +8506,19 @@
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "hcC" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"hcO" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/bunker)
 "hcS" = (
@@ -8669,12 +8729,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "hmn" = (
-/obj/machinery/light,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/enclave)
+/obj/machinery/light/small/built,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "hmL" = (
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8811,11 +8870,9 @@
 	},
 /area/f13/bunker)
 "hqn" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
-/area/f13/enclave)
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/bunker)
 "hqt" = (
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/snacks/soylentgreen,
@@ -8902,12 +8959,12 @@
 	},
 /area/f13/followers)
 "hsN" = (
-/obj/structure/closet/anchored,
 /obj/machinery/light/small,
+/obj/structure/junk/locker,
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "hsP" = (
 /obj/structure/decoration/vent,
 /obj/effect/decal/cleanable/dirt,
@@ -8916,16 +8973,14 @@
 	},
 /area/f13/tunnel)
 "hsR" = (
-/obj/machinery/light{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/item/book/granter/trait/chemistry,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/obj/structure/junk/locker,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "htu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/bos{
@@ -8983,13 +9038,9 @@
 "hvr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hvw" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -9002,11 +9053,12 @@
 	},
 /area/f13/followers)
 "hvF" = (
-/obj/machinery/suit_storage_unit/enclave,
-/turf/open/floor/f13{
-	icon_state = "redmark"
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hvG" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -9227,19 +9279,23 @@
 	},
 /area/f13/bunker)
 "hEn" = (
-/obj/machinery/light,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/fridge/standard,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/enclave)
+/obj/machinery/light/small,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "hEp" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"hFb" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hFM" = (
 /obj/machinery/button/crematorium,
 /obj/structure/table,
@@ -9445,23 +9501,14 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "hMJ" = (
-/obj/item/storage/bag/chemistry{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -10;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -10;
-	pixel_y = 4
-	},
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
-	},
-/area/f13/enclave)
+/obj/item/clothing/under/f13/enclave/science,
+/obj/item/clothing/mask/gas/enclave,
+/obj/item/clothing/shoes/f13/enclave/serviceboots,
+/obj/structure/closet/anchored,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "hMQ" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13{
@@ -9600,6 +9647,10 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
+/area/f13/bunker)
+"hTg" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "hUn" = (
 /obj/effect/decal/cleanable/generic,
@@ -9845,6 +9896,11 @@
 "idK" = (
 /turf/open/floor/plasteel/freezer,
 /area/f13/den)
+"iej" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/mine/explosive,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "iep" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -9993,12 +10049,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "iiK" = (
-/obj/effect/turf_decal/vg_decals/radiation_custom,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "iiZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -10109,28 +10166,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/den)
-"imP" = (
-/obj/structure/rack,
-/obj/item/gun/ballistic/automatic/assault_carbine,
-/obj/item/gun/ballistic/automatic/assault_carbine,
-/obj/item/gun/ballistic/automatic/assault_carbine,
-/obj/item/gun/ballistic/automatic/assault_carbine,
-/obj/item/gun/ballistic/automatic/assault_carbine,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/item/ammo_box/magazine/m556/rifle/extended,
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/enclave)
 "imX" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
@@ -10445,14 +10480,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "iBp" = (
-/obj/machinery/light{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "iCd" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -10460,7 +10493,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "iCh" = (
 /obj/effect/landmark/start/f13/headscribe,
 /obj/effect/decal/cleanable/dirt,
@@ -10547,13 +10580,20 @@
 /obj/effect/decal/cleanable/blood/gibs/human,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
-"iHW" = (
-/obj/machinery/mineral/equipment_vendor,
-/obj/effect/turf_decal/stripes/white/box,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
+"iGB" = (
+/obj/machinery/light/small/broken{
+	dir = 4
 	},
-/area/f13/enclave)
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"iHW" = (
+/obj/effect/turf_decal/stripes/white/box,
+/obj/structure/wreck/trash/brokenvendor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/bunker)
 "iId" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 5
@@ -10658,11 +10698,11 @@
 /area/f13/building)
 "iMF" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "iMP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -10697,12 +10737,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/den)
 "iNP" = (
-/obj/effect/landmark/start/f13/usscientist,
 /obj/structure/chair/office/dark,
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
-	},
-/area/f13/enclave)
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "iNY" = (
 /obj/structure/closet/cardboard,
 /turf/open/indestructible/ground/outside/graveldirt,
@@ -11216,12 +11253,14 @@
 	},
 /area/f13/brotherhood/rnd)
 "jfx" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
-	},
-/area/f13/enclave)
+/obj/item/book/granter/trait/chemistry,
+/obj/structure/closet/anchored,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "jfE" = (
 /obj/structure/fence/handrail_end/non_dense{
 	pixel_x = -16;
@@ -11280,13 +11319,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"jgC" = (
-/obj/structure/grille,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/enclave)
 "jgL" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -11461,8 +11493,11 @@
 	},
 /area/f13/bunker)
 "joH" = (
-/turf/closed/wall/r_wall/rust,
-/area/f13/enclave)
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/bunker)
 "jpe" = (
 /obj/machinery/light{
 	dir = 4
@@ -11586,6 +11621,18 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"jud" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/bunker)
 "jug" = (
 /obj/structure/table/wood,
 /obj/item/flashlight,
@@ -11672,33 +11719,18 @@
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/f13/vault_floor,
 /area/f13/den)
-"jwt" = (
-/obj/machinery/door/airlock/hatch{
-	req_one_access_txt = "134"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
 "jwA" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jwN" = (
-/obj/item/bedsheet/medical,
-/obj/structure/bed,
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
-	},
-/area/f13/enclave)
+/obj/structure/table/optable,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "jwS" = (
-/obj/structure/grille,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/bunker)
 "jwZ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -11741,6 +11773,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"jze" = (
+/obj/structure/junk/locker,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "jzg" = (
 /obj/structure/rack,
 /obj/item/stack/crafting/electronicparts/three,
@@ -11821,13 +11860,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/den)
 "jCE" = (
-/obj/machinery/door/airlock/hatch{
-	req_one_access_txt = "134"
+/mob/living/simple_animal/hostile/handy/gutsy,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
 	},
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/enclave)
+/area/f13/bunker)
 "jCU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -12265,6 +12302,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"jVT" = (
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/bunker)
 "jWa" = (
 /obj/structure/closet/crate{
 	icon_state = "medicalcrate"
@@ -12499,10 +12542,8 @@
 "kcE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/kitchenspike,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "kcY" = (
 /obj/structure/barricade/wooden/strong,
 /obj/machinery/door/airlock/abandoned,
@@ -12525,7 +12566,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "kdH" = (
 /obj/structure/safe/floor,
 /turf/closed/wall/r_wall,
@@ -12678,6 +12719,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"kkd" = (
+/obj/structure/debris/v3{
+	layer = 2
+	},
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "kkg" = (
 /obj/structure/sign/poster/contraband/donut_corp{
 	pixel_y = 32
@@ -12748,11 +12795,9 @@
 /area/f13/bunker)
 "kkK" = (
 /obj/effect/turf_decal/delivery/white,
-/obj/structure/closet/anchored,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/obj/structure/junk/locker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "kkU" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -12843,6 +12888,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"kre" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "krt" = (
 /obj/structure/barricade/bars,
 /obj/effect/decal/cleanable/dirt,
@@ -13035,13 +13085,9 @@
 /area/f13/tunnel)
 "kBs" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/bedsheet,
-/obj/effect/landmark/start/f13/usspy,
-/obj/structure/bed,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/obj/structure/bed/oldalt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "kBx" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -13100,8 +13146,8 @@
 /area/f13/den)
 "kDe" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/r_wall/rust,
-/area/f13/enclave)
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "kDS" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -13378,13 +13424,11 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/den)
 "kQc" = (
-/obj/machinery/computer/camera_advanced{
-	dir = 4
-	},
+/obj/structure/wreck/trash/machinepile,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "kQy" = (
 /obj/structure/table{
 	pixel_y = 6
@@ -13449,10 +13493,8 @@
 "kSx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "kTl" = (
 /obj/structure/decoration/vent/rusty,
 /obj/item/radio,
@@ -13577,11 +13619,9 @@
 	},
 /area/f13/bunker)
 "laO" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
-	},
-/area/f13/enclave)
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "laU" = (
 /obj/machinery/computer/rdconsole{
 	dir = 4
@@ -13753,13 +13793,15 @@
 	},
 /area/f13/brotherhood/operations)
 "leT" = (
-/obj/machinery/light,
-/obj/item/bedsheet/medical,
-/obj/structure/bed,
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
+/obj/structure/table/optable,
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/bunker)
 "lfg" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Brig";
@@ -14121,13 +14163,11 @@
 	},
 /area/f13/clinic)
 "ltr" = (
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/enclave)
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "lts" = (
 /obj/structure/table,
 /obj/item/kitchen/knife/butcher,
@@ -14170,6 +14210,10 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
+"lvx" = (
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "lwc" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -14179,15 +14223,12 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
 	},
-/obj/machinery/shower{
-	dir = 8
-	},
 /obj/structure/decoration/vent,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "lwz" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14399,13 +14440,11 @@
 	},
 /area/f13/bunker)
 "lGD" = (
-/obj/machinery/light,
 /obj/structure/closet/anchored,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/enclave)
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "lGH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/waste{
@@ -14668,13 +14707,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "lTX" = (
-/obj/item/bedsheet,
-/obj/effect/landmark/start/f13/ussgt,
-/obj/structure/bed,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/obj/structure/bed/old,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "lUm" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/decal/fakelattice,
@@ -15288,6 +15323,13 @@
 /obj/effect/landmark/start/f13/ncrveteranranger,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"msi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/gutsy,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/bunker)
 "msv" = (
 /obj/structure/table/reinforced,
 /obj/item/twohanded/sledgehammer,
@@ -15360,10 +15402,10 @@
 /area/f13/building)
 "mvO" = (
 /obj/machinery/chem_master/advanced,
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "mwG" = (
 /obj/item/ammo_casing/shotgun/buckshot,
 /obj/structure/wreck/trash/engine,
@@ -15498,6 +15540,14 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/den)
+"mBL" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/reagent_dispensers/barrel/explosive,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "mBS" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -15637,10 +15687,13 @@
 /area/f13/tunnel)
 "mHA" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/bunker)
 "mHK" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -15700,16 +15753,21 @@
 	icon_state = "showroomfloor"
 	},
 /area/f13/bunker)
+"mKt" = (
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "mKE" = (
 /mob/living/simple_animal/hostile/handy/gutsy/nsb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "mKH" = (
 /obj/structure/closet/crate/bin,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "mKY" = (
 /obj/machinery/door/unpowered/wooddoor,
 /turf/open/floor/carpet,
@@ -15803,11 +15861,6 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"mOw" = (
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/enclave)
 "mOz" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -15820,6 +15873,10 @@
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
+"mOY" = (
+/obj/structure/junk/locker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "mPa" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -15851,11 +15908,11 @@
 	},
 /area/f13/bunker)
 "mQd" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "mQj" = (
 /obj/structure/toilet{
 	dir = 1
@@ -15871,13 +15928,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "mRk" = (
-/obj/machinery/door/airlock/hatch{
-	req_one_access_txt = "134"
-	},
+/obj/machinery/door/airlock/hatch,
+/obj/structure/barricade/wooden/planks,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "mRz" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/carpet,
@@ -16389,10 +16445,13 @@
 	},
 /area/f13/tunnel)
 "niW" = (
-/turf/open/floor/f13{
-	icon_state = "dark"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/bunker)
 "njZ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/beakers,
@@ -16424,12 +16483,12 @@
 	},
 /area/f13/brotherhood/medical)
 "nll" = (
-/obj/machinery/cell_charger,
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "redmark"
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "nlH" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard{
@@ -16499,12 +16558,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"npa" = (
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/enclave)
 "npi" = (
 /obj/structure/table/optable/abductor,
 /obj/effect/decal/remains/xeno,
@@ -16799,13 +16852,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nBe" = (
-/obj/machinery/door/airlock/hatch{
-	req_one_access_txt = "134"
-	},
+/obj/machinery/door/airlock/hatch,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "nBh" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/breadslice/plain,
@@ -17125,18 +17176,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "nPE" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
-	},
-/obj/machinery/shower{
-	dir = 4
-	},
 /obj/structure/decoration/vent,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/bunker)
 "nQe" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -17264,11 +17312,9 @@
 /area/f13/building)
 "nTc" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/enclave)
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/bunker)
 "nTr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
@@ -17447,10 +17493,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "nYd" = (
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "nYw" = (
 /obj/machinery/door/airlock/wood{
 	req_access_txt = "121"
@@ -17568,11 +17618,12 @@
 /area/f13/brotherhood/offices1st)
 "ocv" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
+/obj/machinery/light/small/built,
+/obj/structure/junk/micro,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "odj" = (
 /obj/effect/decal/remains,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -17687,11 +17738,14 @@
 	},
 /area/f13/brotherhood/medical)
 "oeA" = (
-/obj/machinery/chem_heater,
-/turf/open/floor/f13{
-	icon_state = "bluedirtyfull"
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/bunker)
 "ofm" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/inside/mountain,
@@ -18042,13 +18096,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "ouq" = (
-/obj/machinery/door/airlock/hatch{
-	req_one_access_txt = "134"
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/enclave)
+/obj/machinery/door/airlock/hatch,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ouz" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -18108,7 +18159,7 @@
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "owX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office{
@@ -18576,6 +18627,10 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"oQp" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "oQs" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -18611,14 +18666,12 @@
 	},
 /area/f13/bunker)
 "oRK" = (
-/obj/machinery/light{
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/suit_storage_unit/enclave,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "oRZ" = (
 /obj/structure/table/wood/bar,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
@@ -18806,7 +18859,7 @@
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "oWM" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -18947,10 +19000,8 @@
 /area/f13/brotherhood/medical)
 "pdR" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "pem" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/east,
@@ -19093,10 +19144,9 @@
 /area/f13/tunnel)
 "piO" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/enclave)
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "piT" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -19207,10 +19257,9 @@
 /area/f13/ncr)
 "pon" = (
 /obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/enclave)
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "poM" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13{
@@ -19270,13 +19319,11 @@
 	},
 /area/f13/clinic)
 "prL" = (
-/obj/machinery/light,
 /obj/structure/table,
-/obj/item/hand_labeler,
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/enclave)
+/obj/machinery/light/small,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "prM" = (
 /obj/structure/table/reinforced,
 /obj/item/book/granter/trait/chemistry,
@@ -19531,19 +19578,17 @@
 /area/f13/bunker)
 "pAR" = (
 /obj/structure/closet/anchored,
-/obj/item/card/id/prisoner/three,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/under/rank/prisoner,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/f13{
 	icon_state = "redmark"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "pAY" = (
 /obj/structure/rack,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/enclave)
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "pBe" = (
 /obj/machinery/light/small,
 /mob/living/simple_animal/hostile/deathclaw,
@@ -19698,6 +19743,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"pFY" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "pGw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -20012,6 +20063,11 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"pRA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "pRM" = (
 /obj/machinery/telecomms/message_server,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -20040,14 +20096,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "pSE" = (
-/obj/machinery/light{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/enclave)
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "pTD" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -20062,14 +20117,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/den)
-"pUB" = (
-/obj/machinery/door/airlock/hatch{
-	req_one_access_txt = "134"
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/enclave)
 "pVA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -20337,10 +20384,9 @@
 /area/f13/bunker)
 "qeW" = (
 /obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "qfu" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -20352,14 +20398,17 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "qfx" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -13
+/obj/effect/decal/fakelattice,
+/obj/structure/closet/anchored,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/enclave)
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "qfB" = (
 /obj/machinery/door/airlock/wood{
 	name = "Ranger Quarters";
@@ -20437,11 +20486,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qiL" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
-/area/f13/enclave)
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "qiO" = (
 /obj/item/chair,
 /turf/open/indestructible/ground/inside/subway,
@@ -20575,6 +20623,12 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"qoW" = (
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/bunker)
 "qpc" = (
 /obj/machinery/sleeper{
 	density = 1;
@@ -20816,6 +20870,12 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"qwG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
 "qwH" = (
@@ -21089,12 +21149,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"qIj" = (
+/obj/structure/debris/v3{
+	layer = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "qIx" = (
 /obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/enclave)
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "qIB" = (
 /obj/structure/lattice{
 	layer = 3
@@ -21211,19 +21276,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"qML" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/enclave)
 "qMO" = (
 /obj/structure/table{
 	layer = 2.9
@@ -21276,14 +21328,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
-"qNd" = (
-/obj/structure/toilet/greyscale{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/enclave)
 "qNw" = (
 /obj/machinery/door/keycard{
 	puzzle_id = "library"
@@ -21322,6 +21366,14 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/den)
+"qNR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "qOD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/box/bodybags{
@@ -21443,14 +21495,10 @@
 /turf/open/water,
 /area/f13/caves)
 "qRy" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/plastic/five,
-/obj/item/stack/sheet/leather/five,
-/obj/item/stack/sheet/hay/five,
-/turf/open/floor/f13{
-	icon_state = "dark"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "qRM" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/meatsalted,
@@ -21459,11 +21507,6 @@
 "qRO" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/den)
-"qRV" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/carpet/black,
-/area/f13/enclave)
 "qSG" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -21589,10 +21632,10 @@
 	pixel_y = -2
 	},
 /obj/effect/turf_decal/stripes/white/box,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "qVC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -21945,6 +21988,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"rin" = (
+/mob/living/simple_animal/hostile/handy/sentrybot/nsb/riot,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "riF" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -21960,6 +22008,11 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
+/area/f13/bunker)
+"riZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "rjq" = (
 /obj/structure/toilet{
@@ -21985,23 +22038,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "rjY" = (
-/obj/structure/rack,
-/obj/item/storage/belt/military/assault/enclave,
-/obj/item/storage/belt/military/assault/enclave,
-/obj/item/storage/belt/military/assault/enclave,
-/obj/item/storage/belt/military/assault/enclave,
-/obj/item/storage/belt/military/assault/enclave,
-/obj/item/storage/belt/military/assault/enclave,
-/obj/item/clothing/head/helmet/f13/helmet/enclave/peacekeeper,
-/obj/item/clothing/head/helmet/f13/helmet/enclave/peacekeeper,
-/obj/item/clothing/head/helmet/f13/helmet/enclave/peacekeeper,
-/obj/item/clothing/head/helmet/f13/helmet/enclave/peacekeeper,
-/obj/item/clothing/head/helmet/f13/helmet/enclave/peacekeeper,
-/obj/item/clothing/head/helmet/f13/helmet/enclave/peacekeeper,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/enclave)
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "rkH" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/f13{
@@ -22058,13 +22097,13 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "rlz" = (
-/obj/machinery/door/airlock/hatch{
-	req_one_access_txt = "134"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+	icon_state = "dark"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "rlW" = (
 /obj/structure/reagent_dispensers/barrel/three{
 	pixel_x = -14
@@ -22109,15 +22148,23 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/tunnel)
+"rnt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "rnw" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/bedsheet,
-/obj/effect/landmark/start/f13/ussgt,
-/obj/structure/bed,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
+/obj/structure/junk/small/bed,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rnI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
@@ -22566,20 +22613,13 @@
 /obj/item/ammo_box/a308,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"rAD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
-/area/f13/enclave)
 "rAQ" = (
 /obj/structure/barricade/bars,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "rAW" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/f13{
@@ -22701,6 +22741,12 @@
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/f13{
 	icon_state = "bluefull"
+	},
+/area/f13/bunker)
+"rGo" = (
+/mob/living/simple_animal/hostile/handy/gutsy,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
 "rGw" = (
@@ -22888,6 +22934,16 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/operations)
+"rLZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rMk" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -22949,14 +23005,14 @@
 /turf/open/floor/carpet,
 /area/f13/den)
 "rOT" = (
-/obj/machinery/light,
-/obj/structure/rack,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/turf/open/floor/f13{
-	icon_state = "dark"
+/obj/machinery/light/small/broken,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/bunker)
 "rPg" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13{
@@ -23003,11 +23059,9 @@
 	},
 /area/f13/brotherhood/medical)
 "rPQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/enclave)
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "rQm" = (
 /obj/structure/closet/crate/large,
 /obj/item/storage/box/stockparts/basic,
@@ -23138,13 +23192,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"rWm" = (
-/obj/machinery/light,
-/obj/machinery/microwave/stove,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/enclave)
 "rWD" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood{
@@ -23175,14 +23222,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "rXn" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/structure/chair/office,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/area/f13/bunker)
 "rXA" = (
 /obj/structure/timeddoor,
 /obj/structure/timeddoor,
@@ -23296,6 +23340,12 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/water,
 /area/f13/caves)
+"sdX" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "sef" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/flora/rock/jungle,
@@ -23352,14 +23402,10 @@
 "sfx" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical,
-/obj/item/storage/toolbox/mechanical/old,
-/obj/item/storage/toolbox/mechanical/old,
-/obj/item/storage/toolbox/emergency/old,
-/obj/item/storage/toolbox/electrical,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "sfy" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical/old,
@@ -23561,12 +23607,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"slw" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/enclave)
 "slT" = (
 /obj/structure/flora/junglebush/b,
 /turf/open/water,
@@ -23606,14 +23646,22 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"snc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/gutsy,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "snf" = (
-/obj/machinery/light{
+/obj/machinery/light/small/broken{
 	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "snP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -23744,6 +23792,13 @@
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
+/area/f13/bunker)
+"syz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "syU" = (
 /obj/structure/dresser,
@@ -23942,11 +23997,13 @@
 	},
 /area/f13/den)
 "sKR" = (
-/obj/structure/simple_door/metal/dirtystore,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/bunker)
 "sLx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -23998,11 +24055,6 @@
 /obj/structure/table,
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"sNC" = (
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/enclave)
 "sNF" = (
 /obj/structure/closet/fridge,
 /obj/item/storage/fancy/egg_box,
@@ -24035,7 +24087,7 @@
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "sPK" = (
 /obj/structure/bed/old,
 /turf/open/floor/plasteel/f13{
@@ -24048,11 +24100,10 @@
 /turf/open/floor/carpet,
 /area/f13/den)
 "sPX" = (
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "sPY" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/structure/spider/stickyweb,
@@ -24291,18 +24342,16 @@
 	},
 /area/f13/bunker)
 "tam" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/bunker)
 "tap" = (
-/obj/machinery/light,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/enclave)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
 "taI" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -24312,15 +24361,9 @@
 /area/f13/tunnel)
 "taP" = (
 /obj/structure/decoration/vent,
-/obj/machinery/shower{
-	pixel_y = 23
-	},
-/obj/structure/curtain,
-/obj/effect/turf_decal/stripes/white/box,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/enclave)
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "tbE" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -24564,14 +24607,14 @@
 	},
 /area/f13/bunker)
 "tjG" = (
-/obj/machinery/light{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/enclave)
+/obj/effect/decal/fakelattice,
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "tjI" = (
 /obj/structure/chair/sofa/right,
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
@@ -24703,15 +24746,13 @@
 	},
 /area/f13/brotherhood/rnd)
 "tpW" = (
-/obj/machinery/light{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed/old,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/bedsheet/black,
-/obj/effect/landmark/start/f13/uslt,
-/obj/structure/bed/old,
 /turf/open/floor/carpet/black,
-/area/f13/enclave)
+/area/f13/bunker)
 "tqE" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -24823,14 +24864,9 @@
 	},
 /area/f13/tunnel)
 "ttE" = (
-/obj/structure/closet/anchored,
-/obj/item/card/id/prisoner/two,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/under/rank/prisoner,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/enclave)
+/obj/structure/junk/locker,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "ttW" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -24923,18 +24959,14 @@
 /obj/structure/table{
 	layer = 2.9
 	},
-/obj/item/storage/box/handcuffs,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "twj" = (
 /obj/item/instrument/saxophone,
 /obj/structure/rack,
@@ -25054,8 +25086,8 @@
 /area/f13/brotherhood/rnd)
 "tDc" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/turf/closed/indestructible/rock,
+/area/f13/bunker)
 "tDo" = (
 /obj/structure/table/wood/poker,
 /obj/effect/decal/cleanable/dirt,
@@ -25141,10 +25173,13 @@
 /area/f13/tunnel)
 "tGA" = (
 /obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "tGW" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/den)
@@ -25474,13 +25509,12 @@
 /area/f13/den)
 "tWo" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/table/wood,
 /turf/open/floor/carpet/black,
-/area/f13/enclave)
+/area/f13/bunker)
 "tWR" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -25644,27 +25678,9 @@
 /area/f13/bunker)
 "uaR" = (
 /obj/structure/rack,
-/obj/item/clothing/shoes/f13/explorer,
-/obj/item/clothing/shoes/f13/diesel,
-/obj/item/clothing/shoes/f13/diesel/alt,
-/obj/item/clothing/shoes/f13/military/plated,
-/obj/item/clothing/shoes/f13/military/leather,
-/obj/item/clothing/shoes/f13/military,
-/obj/item/clothing/shoes/f13/raidertreads,
-/obj/item/clothing/under/f13/legskirt/tac,
-/obj/item/clothing/under/f13/brahminf,
-/obj/item/clothing/under/f13/cowboyt,
-/obj/item/clothing/under/f13/machinist,
-/obj/item/clothing/under/f13/lumberjack,
-/obj/item/clothing/under/f13/vault,
-/obj/item/clothing/under/f13/raider_leather,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/enclave)
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ubh" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -25674,6 +25690,18 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
+	},
+/area/f13/bunker)
+"ubj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
 "ubr" = (
@@ -25735,6 +25763,11 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
+"ufh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ufQ" = (
 /obj/structure/decoration/warning,
 /turf/closed/wall/rust,
@@ -25898,10 +25931,16 @@
 /area/f13/bunker)
 "uog" = (
 /obj/structure/bed/mattress/pregame,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "uoq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -26192,13 +26231,11 @@
 	},
 /area/f13/tunnel)
 "uzy" = (
-/obj/machinery/light{
+/obj/machinery/light/small/broken{
 	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "uAc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26277,11 +26314,11 @@
 	},
 /area/f13/brotherhood/reactor)
 "uEj" = (
-/obj/machinery/processor,
+/obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "uEm" = (
 /obj/effect/landmark/start/f13/enforcer,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -26323,16 +26360,24 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"uHH" = (
+/obj/effect/turf_decal/arrows/white{
+	dir = 8;
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/stripes/white/box,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "uHT" = (
 /obj/structure/table,
-/obj/item/storage/bag/ore,
-/obj/item/pickaxe/drill/diamonddrill,
-/obj/item/t_scanner/adv_mining_scanner,
-/obj/item/clothing/glasses/meson,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
+/obj/machinery/light/small/broken{
+	dir = 1
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/bunker)
 "uHU" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
@@ -26344,7 +26389,7 @@
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "uIE" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -26442,14 +26487,12 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "uLI" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
+/obj/structure/debris/v3{
+	layer = 2
 	},
-/area/f13/enclave)
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
 "uLM" = (
 /obj/structure/table,
 /obj/item/clothing/under/f13/enclave_officer,
@@ -26475,14 +26518,14 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
 	},
-/obj/machinery/shower{
-	dir = 4
-	},
 /obj/structure/decoration/vent,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/bunker)
 "uMA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/f13/rotten,
@@ -26503,42 +26546,6 @@
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/carpet,
 /area/f13/den)
-"uMQ" = (
-/obj/structure/rack,
-/obj/item/clothing/head/helmet/f13/combat/enclave,
-/obj/item/clothing/head/helmet/f13/combat/enclave,
-/obj/item/clothing/head/helmet/f13/combat/enclave,
-/obj/item/clothing/head/helmet/f13/combat/enclave,
-/obj/item/clothing/head/helmet/f13/combat/enclave,
-/obj/item/clothing/suit/armor/f13/combat/enclave,
-/obj/item/clothing/suit/armor/f13/combat/enclave,
-/obj/item/clothing/suit/armor/f13/combat/enclave,
-/obj/item/clothing/suit/armor/f13/combat/enclave,
-/obj/item/clothing/suit/armor/f13/combat/enclave,
-/obj/item/clothing/mask/infiltrator,
-/obj/item/clothing/mask/infiltrator,
-/obj/item/clothing/mask/infiltrator,
-/obj/item/clothing/mask/infiltrator,
-/obj/item/clothing/mask/infiltrator,
-/obj/item/clothing/gloves/f13/military,
-/obj/item/clothing/gloves/f13/military,
-/obj/item/clothing/gloves/f13/military,
-/obj/item/clothing/gloves/f13/military,
-/obj/item/clothing/gloves/f13/military,
-/obj/item/clothing/shoes/f13/enclave/serviceboots,
-/obj/item/clothing/shoes/f13/enclave/serviceboots,
-/obj/item/clothing/shoes/f13/enclave/serviceboots,
-/obj/item/clothing/shoes/f13/enclave/serviceboots,
-/obj/item/clothing/shoes/f13/enclave/serviceboots,
-/obj/item/clothing/under/f13/enclave/peacekeeper,
-/obj/item/clothing/under/f13/enclave/peacekeeper,
-/obj/item/clothing/under/f13/enclave/peacekeeper,
-/obj/item/clothing/under/f13/enclave/peacekeeper,
-/obj/item/clothing/under/f13/enclave/peacekeeper,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/enclave)
 "uMY" = (
 /obj/machinery/light{
 	dir = 4
@@ -26560,6 +26567,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"uOF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "uOL" = (
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/gloves/color/white/bos,
@@ -26623,10 +26634,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uSi" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "uSI" = (
 /obj/structure/chair/wood,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -26766,10 +26780,14 @@
 	},
 /area/f13/den)
 "vbu" = (
-/turf/open/floor/f13{
-	icon_state = "purplefull"
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/bunker)
 "vbV" = (
 /obj/structure/handrail/g_central{
 	dir = 4;
@@ -26863,11 +26881,11 @@
 	},
 /area/f13/tunnel)
 "vfo" = (
-/obj/structure/rack,
-/turf/open/floor/f13{
-	icon_state = "redmark"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "vfx" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -26905,14 +26923,12 @@
 	},
 /area/f13/brotherhood/operations)
 "vfU" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/bunker)
 "vfV" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -27115,7 +27131,7 @@
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "vrD" = (
 /obj/structure/table/abductor{
 	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
@@ -27178,6 +27194,11 @@
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"vvW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/gutsy,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "vwa" = (
 /obj/structure/chair/wood/modern{
 	dir = 8;
@@ -27185,40 +27206,21 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"vwg" = (
+/obj/structure/decoration/vent,
+/obj/effect/turf_decal/stripes/white/box,
+/obj/structure/reagent_dispensers/barrel/explosive,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "vwh" = (
 /obj/machinery/light_switch{
 	pixel_x = 27
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
-"vwj" = (
-/obj/structure/rack,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/card/id/dogtag/enclave/recruit,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/enclave)
 "vws" = (
 /obj/machinery/conveyor/auto{
 	dir = 1
@@ -27251,10 +27253,11 @@
 "vxG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/office,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "vxK" = (
 /obj/machinery/door/window,
 /obj/effect/decal/cleanable/dirt,
@@ -27271,11 +27274,9 @@
 /area/f13/bunker)
 "vyK" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
-/area/f13/enclave)
+/obj/structure/wreck/trash/brokenvendor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/bunker)
 "vyL" = (
 /obj/structure/statue/uranium/nuke,
 /turf/open/indestructible/ground/inside/subway,
@@ -27321,6 +27322,14 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/den)
+"vCr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/debris/v3{
+	layer = 2
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
 "vCF" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /obj/effect/decal/waste{
@@ -27389,13 +27398,9 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
 "vFv" = (
-/obj/machinery/door/airlock/hatch{
-	req_one_access_txt = "134"
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "vFx" = (
 /obj/structure/chair/comfy/brown,
 /obj/item/clothing/head/crown,
@@ -27404,8 +27409,11 @@
 /area/f13/tunnel)
 "vGr" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/carpet/black,
-/area/f13/enclave)
+/area/f13/bunker)
 "vGT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -27541,6 +27549,12 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"vOE" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "vPB" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt{
@@ -27615,10 +27629,8 @@
 "vRs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "vRw" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -27646,10 +27658,8 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "vTm" = (
 /obj/structure/lattice{
 	layer = 2
@@ -27705,6 +27715,13 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/operations)
+"vWg" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "vWj" = (
 /obj/item/paper/crumpled{
 	info = "By order order of the Boss, the Den has 3 rules. No murdering while you're inside. No stealing while you're inside. Pay a tribute to the boss for providing a safe haven, if you are able to do so.";
@@ -27748,17 +27765,13 @@
 	},
 /area/f13/bunker)
 "vXS" = (
-/obj/machinery/light,
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 4;
-	output_dir = 8
-	},
 /obj/effect/turf_decal/stripes/white/box,
 /obj/effect/turf_decal/delivery/white,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "vXU" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -27855,6 +27868,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/reactor)
+"wag" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/closet/anchored,
+/obj/item/clothing/under/f13/enclave/peacekeeper,
+/obj/item/clothing/shoes/f13/enclave/serviceboots,
+/obj/item/clothing/gloves/f13/military,
+/obj/item/clothing/head/helmet/f13/helmet/enclave/peacekeeper,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "waL" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plating/tunnel,
@@ -27876,6 +27899,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"wbu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "wbW" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -27899,15 +27929,18 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
 	},
-/obj/machinery/shower{
-	dir = 4
-	},
 /obj/structure/decoration/vent,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"wdt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "greenrustyfull"
 	},
-/area/f13/enclave)
+/area/f13/tunnel)
 "wdF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -28092,18 +28125,18 @@
 /area/f13/brotherhood/rnd)
 "wpj" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "dark"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "wpO" = (
-/obj/machinery/light{
+/obj/machinery/light/small/broken{
 	dir = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "wqD" = (
 /obj/effect/turf_decal/bot_white,
 /obj/effect/decal/cleanable/dirt,
@@ -28126,16 +28159,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"wrY" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/anchored,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/enclave)
 "wsd" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/mountain,
@@ -28214,7 +28237,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "wvi" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -28257,11 +28280,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "wwE" = (
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/timeddoor/sixtyminute,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/area/f13/bunker)
 "wwW" = (
 /obj/structure/sink{
 	dir = 4;
@@ -28274,6 +28298,11 @@
 	icon_state = "housebase"
 	},
 /area/f13/den)
+"wxe" = (
+/obj/structure/table,
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "wxL" = (
 /obj/structure/table/wood/fancy/green,
 /turf/open/indestructible/ground/inside/subway,
@@ -28283,11 +28312,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "wyT" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
-/area/f13/enclave)
+/obj/structure/wreck/trash/brokenvendor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/bunker)
 "wzw" = (
 /obj/structure/fence/handrail_end/non_dense{
 	pixel_x = -16;
@@ -28459,10 +28486,8 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/gecko,
 /obj/item/reagent_containers/food/snacks/meat/slab/gecko,
 /obj/item/reagent_containers/food/snacks/meat/slab/gecko,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/enclave)
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "wJQ" = (
 /obj/structure/barricade/bars,
 /obj/structure/barricade/bars,
@@ -28522,6 +28547,15 @@
 	id = "pain"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"wKS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "wLv" = (
 /turf/closed/wall/r_wall,
@@ -28583,15 +28617,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/den)
 "wMR" = (
-/obj/machinery/light{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/junk/small/tv,
+/obj/machinery/light/small/broken{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
 /turf/open/floor/carpet/black,
-/area/f13/enclave)
+/area/f13/bunker)
 "wNk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -28643,6 +28675,10 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"wRn" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "wRA" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -28654,6 +28690,13 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"wRS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/bunker)
 "wSb" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
@@ -28678,10 +28721,9 @@
 /area/f13/ncr)
 "wTH" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/enclave)
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "wUv" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/inside/mountain,
@@ -28733,11 +28775,9 @@
 	},
 /area/f13/tunnel)
 "wXe" = (
-/obj/structure/closet/anchored,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/enclave)
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "wXl" = (
 /obj/structure/table/wood,
 /obj/structure/table/wood,
@@ -28786,6 +28826,14 @@
 /obj/item/bodybag,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/den)
+"wZE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/assaultron,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "wZL" = (
 /obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -29039,14 +29087,11 @@
 	},
 /area/f13/brotherhood/rnd)
 "xiO" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/structure/debris/v3{
+	layer = 2
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/enclave)
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
 "xjk" = (
 /obj/structure/chair/bench,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -29054,13 +29099,14 @@
 /area/f13/tunnel)
 "xjn" = (
 /obj/structure/closet/anchored,
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/enclave)
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "xjE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -29099,6 +29145,10 @@
 /obj/structure/table/wood/fancy/blackred,
 /turf/open/floor/carpet/black,
 /area/f13/tunnel)
+"xld" = (
+/mob/living/simple_animal/hostile/handy/sentrybot/nsb/riot,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "xlH" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
@@ -29202,15 +29252,13 @@
 	},
 /area/f13/den)
 "xos" = (
-/obj/structure/closet/anchored,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
+/obj/machinery/light/small/broken{
 	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/enclave)
+/obj/structure/junk/locker,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "xoS" = (
 /obj/effect/landmark/start/f13/raider,
 /turf/open/indestructible/ground/inside/mountain,
@@ -29290,17 +29338,8 @@
 /area/f13/den)
 "xsh" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "xsy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -29340,13 +29379,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "xuW" = (
-/obj/machinery/autolathe/ammo/unlocked,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/ore/blackpowder/fifty,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/enclave)
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "xvg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -29367,13 +29402,14 @@
 	},
 /area/f13/brotherhood/mining)
 "xvZ" = (
-/obj/structure/chair/f13chair1{
-	dir = 4
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "xwm" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/caves)
@@ -29441,10 +29477,13 @@
 	},
 /area/f13/den)
 "xAa" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "xAf" = (
 /obj/machinery/power/smes/engineering,
 /obj/effect/decal/cleanable/dirt,
@@ -29534,6 +29573,10 @@
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor,
 /area/f13/den)
+"xFe" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
 "xFN" = (
 /obj/structure/simple_door/fakeglass,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -29892,20 +29935,21 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "ybL" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/bunker)
 "ybS" = (
-/obj/machinery/door/airlock/hatch{
-	req_one_access_txt = "134"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/hatch,
+/obj/structure/barricade/wooden/planks,
+/obj/structure/timeddoor/sixtyminute,
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
 	},
-/area/f13/enclave)
+/area/f13/bunker)
 "ycc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -29925,19 +29969,9 @@
 	},
 /area/f13/bunker)
 "ydf" = (
-/obj/structure/rack,
-/obj/item/gun/energy/laser/aer12,
-/obj/item/gun/energy/laser/aer12,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/enclave)
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ydP" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -30052,6 +30086,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/caves)
+"yls" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/assaultron,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "ymg" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1";
@@ -60856,9 +60896,9 @@ weW
 weW
 weW
 weW
-wWF
-tur
-wWF
+aEL
+weW
+aEL
 weW
 weW
 weW
@@ -61113,9 +61153,9 @@ weW
 weW
 weW
 weW
-wWF
-tur
-wWF
+aEL
+weW
+aEL
 weW
 weW
 weW
@@ -61371,7 +61411,7 @@ miI
 wWF
 wWF
 wWF
-sKR
+miI
 miI
 wWF
 bcM
@@ -61391,7 +61431,7 @@ bcM
 bcM
 bcM
 bcM
-wWF
+wdt
 wWF
 wWF
 miI
@@ -61658,10 +61698,10 @@ tur
 tur
 tur
 tur
-uoO
-uoO
-uoO
-uoO
+rex
+rex
+rex
+rex
 uoO
 uoO
 uoO
@@ -61892,33 +61932,33 @@ tur
 tur
 tur
 tur
-uoO
-uoO
-uoO
-uoO
-uoO
-joH
-joH
-joH
-joH
-joH
-joH
-joH
-joH
+rex
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+cfR
+cfR
 ybS
-joH
-joH
-uoO
-uoO
-uoO
-uoO
-uoO
-joH
-joH
-joH
-joH
-joH
-aoj
+cfR
+cfR
+eLE
+eLE
+eLE
+eLE
+eLE
+yhT
+yhT
+yhT
+yhT
+yhT
+rex
 aoj
 aoj
 uoO
@@ -62149,33 +62189,33 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-joH
+rex
+yhT
+osY
+gPj
+ujY
+ydf
 wXe
-mOw
-mOw
-vwj
-joH
-joH
+vfo
+vfo
+xsh
+yhT
+yhT
 uLX
-pdR
+vDC
 nPE
-joH
-uoO
-uoO
-joH
-aEL
-joH
-joH
+yhT
+eLE
+eLE
+yhT
+yhT
+yhT
+yhT
 taP
 tjG
 eZx
-joH
-aoj
+yhT
+rex
 aoj
 aoj
 uoO
@@ -62405,34 +62445,34 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-joH
-wXe
-mOw
-mOw
-uMQ
-joH
-joH
+rex
+rex
+yhT
+ujY
+yhT
+yhT
+yhT
+mOY
+ujY
+ujY
+vfo
+yhT
+yhT
 xos
 iiK
 hsN
-joH
-joH
-joH
-joH
+yhT
+yhT
+yhT
+yhT
 qfx
-qNd
-joH
-taP
+vfo
+ujY
+vwg
 piO
-eZx
-joH
-uoO
+lvx
+yhT
+rex
 uoO
 uoO
 uoO
@@ -62662,38 +62702,38 @@ uoO
 uoO
 uoO
 uoO
-uoO
+rex
+yhT
+yhT
 joH
-joH
-joH
-joH
-joH
-joH
+yhT
+yhT
+yhT
 xjn
-mOw
-mOw
-imP
-joH
-joH
-fnW
+ujY
+rin
+uaR
+yhT
+yhT
+mHA
 uSi
 lwq
-joH
-joH
+yhT
+yhT
 aXl
-joH
+yhT
 nYd
 qIx
-joH
-taP
-piO
-eZx
-joH
-uoO
-uoO
-uoO
-uoO
-uoO
+yhT
+mBL
+wbu
+fKz
+yhT
+rex
+rex
+rex
+rex
+rex
 uoO
 uoO
 uoO
@@ -62919,38 +62959,38 @@ aoj
 aoj
 uoO
 uoO
-uoO
-joH
-fgy
+rex
+yhT
+fPQ
 gXQ
-gXQ
+sKR
 pon
-joH
-wXe
-mOw
-mOw
+yhT
+mOY
+nll
+vfo
 rjY
-joH
-joH
-joH
-pUB
-joH
-joH
-joH
-vFv
-joH
+yhT
+yhT
+yhT
+dAQ
+yhT
+yhT
+yhT
+eXJ
+yhT
 ouq
-joH
-joH
-joH
-ouq
-joH
-joH
-joH
-joH
-joH
-joH
-uoO
+yhT
+yhT
+fJu
+iej
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+rex
 uoO
 uoO
 uoO
@@ -63176,38 +63216,38 @@ uoO
 uoO
 uoO
 uoO
-uoO
-joH
+rex
+yhT
 fKm
 niW
-gXQ
+rPQ
 prL
-joH
-wXe
-mOw
-mOw
-ydf
-joH
-gXQ
-gXQ
+yhT
+jze
+ujY
+gjJ
+ujY
+yhT
+qiL
+niW
+mHA
 mHA
 wpj
-mHA
-joH
-vbu
+yhT
+hTg
 fvw
-vbu
+gjJ
+pdR
+bhO
+pdR
 wTH
-wTH
-wTH
-wTH
-fvw
-joH
+mKt
+yhT
 fvg
 wMR
 tWo
-joH
-uoO
+yhT
+rex
 uoO
 uoO
 uoO
@@ -63433,38 +63473,38 @@ uoO
 uoO
 uoO
 uoO
-uoO
-joH
+rex
+yhT
 fMJ
-gXQ
-gXQ
+hYt
+rjY
 pAY
-joH
+yhT
 hvF
-mOw
-mOw
+dIV
+xSi
 vfo
-joH
-niW
+yhT
+osY
 wpj
 xvZ
-gXQ
-niW
-joH
+rjY
+flz
+yhT
 kkK
-wTH
+qNR
 kBs
-vbu
-fji
-wTH
+vfo
+xSi
+pdR
 lTX
-vbu
-joH
-fvg
-boV
-fEA
-joH
-uoO
+rjY
+yhT
+fUO
+vDC
+wTH
+yhT
+rex
 uoO
 uoO
 uoO
@@ -63690,40 +63730,40 @@ uoO
 uoO
 uoO
 aoj
-uoO
-joH
+rex
+yhT
 fPQ
-niW
-gXQ
+nll
+sKR
 qRy
-joH
+yhT
 oRK
-mOw
-mOw
+eZh
+vfo
 uaR
-joH
+yhT
 gFZ
 kQc
-fgo
+pon
 ahV
 hmn
-joH
+yhT
 kkK
+wbu
+pdR
 wTH
-wTH
-wTH
-wTH
-wTH
-wTH
-wTH
-jwt
+aYl
+ufh
+pdR
+pdR
+ouq
 vGr
-vGr
-vGr
-joH
-uoO
-aoj
-aoj
+aYl
+vDC
+yhT
+rex
+rex
+rex
 uoO
 uoO
 eLE
@@ -63947,40 +63987,40 @@ uoO
 uoO
 uoO
 uoO
-uoO
-joH
+rex
+yhT
 fQo
-niW
-gXQ
+rPQ
+ujY
 rOT
-joH
+yhT
 xuW
-mOw
-mOw
-qML
-joH
-gXQ
-gXQ
-xiO
-mHA
+ujY
+ujY
+xsh
+yhT
+rGo
 niW
-joH
-kkK
-wTH
-dYM
-wTH
+vDC
+mHA
+xvZ
+yhT
+wag
+pdR
+nwa
+riZ
 aAL
-wTH
+pdR
 rnw
-kSx
-joH
+pRA
+yhT
 dNW
 vGr
-vGr
-joH
-uoO
-aoj
-aoj
+kre
+yhT
+yhT
+yhT
+rex
 uoO
 uoO
 eLE
@@ -64203,41 +64243,41 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-joH
+rex
+rex
+yhT
 gNg
 iCd
-gXQ
+sKR
 sfx
-joH
-nll
-mOw
-mOw
+yhT
+nWb
+osY
+ujY
 xsh
-joH
-cUi
+yhT
+mQd
 wpj
 mHA
-niW
-npa
-joH
+ujY
+rjY
+yhT
 mKH
-kSx
+pRA
 uzy
-wTH
-wTH
-uLI
-wTH
-vbu
-joH
+pdR
+wbu
+rLZ
+pdR
+ujY
+yhT
 boV
 tpW
-qRV
-joH
-uoO
-aoj
-aoj
+vGr
+tTW
+rjY
+yhT
+rex
 uoO
 uoO
 eLE
@@ -64460,41 +64500,41 @@ uoO
 uoO
 uoO
 aoj
-aoj
-joH
-joH
-joH
-joH
+rex
+yhT
+yhT
+yhT
+yhT
 mRk
-joH
-joH
-joH
-joH
-dSO
-joH
-joH
-joH
-mRk
-joH
-gej
-joH
-joH
-joH
-vFv
-joH
-joH
-joH
-joH
-mRk
-joH
-joH
-joH
-joH
-joH
-joH
-uoO
-aoj
-aoj
+yhT
+kkd
+kkd
+yhT
+ouq
+yhT
+yhT
+yhT
+ouq
+yhT
+ouq
+yhT
+yhT
+yhT
+eXJ
+yhT
+yhT
+yhT
+yhT
+eXJ
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+ujY
+yhT
+rex
 uoO
 uoO
 eLE
@@ -64717,41 +64757,41 @@ uoO
 uoO
 aoj
 uoO
-uoO
-joH
+rex
+yhT
 aBr
 hsR
-vbu
-wTH
-vbu
-vbu
-vbu
-fvw
-wTH
-wTH
-wTH
-vbu
-vbu
+ujY
+mHA
+rKY
+qIj
+mKt
+osY
+pdR
+aek
+pdR
+nYd
+nYd
 iBp
+riZ
 wTH
-wTH
-kSx
-vbu
-wTH
-iBp
-wTH
-joH
+wKS
+eZh
+pdR
+wbu
+pdR
+yhT
 wuT
-gXQ
+hYt
 kdk
 faC
 qiL
 bNF
 vyK
-joH
-uoO
-aoj
-aoj
+yhT
+ujY
+yhT
+rex
 uoO
 uoO
 eLE
@@ -64974,41 +65014,41 @@ uoO
 uoO
 aoj
 uoO
-uoO
-joH
+rex
+yhT
 vbu
-vbu
+ujY
 wTH
-kSx
-vbu
-kSx
+tap
+xiO
+vCr
+aLJ
+vDC
+vvW
+wRn
+rjY
 wTH
+ujY
+wZE
+vDC
 wTH
-wTH
-vbu
-vbu
-wTH
-vbu
-wTH
-wTH
-wTH
-wTH
-vbu
-wTH
-wTH
-vbu
-mRk
+yls
+vfo
+snc
+pdR
+vfo
+eXJ
 deH
-mHA
-mHA
+wTH
+iiK
 nBe
-rPQ
-bNF
+vDC
+tam
 wyT
-joH
-uoO
-aoj
-aoj
+yhT
+rjY
+yhT
+rex
 uoO
 uoO
 eLE
@@ -65231,41 +65271,41 @@ uoO
 uoO
 aoj
 uoO
-uoO
-joH
-vbu
+rex
+yhT
+dYM
 kSx
-wTH
-wTH
-uLI
-vbu
-vbu
-vbu
-vbu
-vbu
-uLI
-wTH
-wTH
-wTH
-vbu
-vbu
-uLI
-wTH
-wTH
-wTH
-wTH
-joH
+vDC
 wpj
-wpj
+uLI
+osY
+xSi
+xSi
+xSi
+iGB
+vDC
+ufh
+vvW
+pdR
+ujY
+xSi
+wbu
+wbu
+wTH
+syz
+vDC
+yhT
+wRS
+yls
 hEn
-joH
-rAD
-aSM
+yhT
+vfU
+jwS
 tam
-joH
-uoO
-aoj
-aoj
+tTW
+ujY
+yhT
+rex
 uoO
 uoO
 eLE
@@ -65488,41 +65528,41 @@ uoO
 uoO
 aoj
 uoO
-uoO
-joH
+rex
+yhT
 aHf
-aHf
-aHf
-aHf
-joH
-slw
-sNC
+fji
+niW
+qRy
+yhT
+sPX
+sPX
 iHW
-joH
-joH
-joH
-dSO
-joH
-joH
-joH
-joH
-joH
-joH
+yhT
+yhT
+yhT
+ouq
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
 vFv
-joH
-joH
-joH
-mHA
-wpj
-pon
+yhT
+yhT
+yhT
+qwG
+vDC
+wxe
 jwS
-rAD
-bNF
-tap
-joH
-uoO
-aoj
-aoj
+vfU
+gQo
+ujY
+yhT
+yhT
+yhT
+rex
 uoO
 uoO
 eLE
@@ -65745,41 +65785,41 @@ uoO
 uoO
 uoO
 uoO
-uoO
-joH
-bgL
+rex
+yhT
+faK
 gTk
-gUF
+rjY
 jwN
-joH
+yhT
 sPX
-sNC
+sPX
 qVw
-joH
-wXe
+yhT
+bLa
 snf
 xAa
 dtB
 cim
 uog
-joH
+yhT
 vRs
 vSW
-vbu
-iBp
+eZh
+cGN
 mKH
-joH
-wpj
-mHA
+yhT
+jud
+dum
 dHQ
-jgC
+tam
 nTc
-bNF
-nTc
-joH
-uoO
-uoO
-uoO
+osY
+vDC
+yhT
+rex
+rex
+rex
 uoO
 uoO
 eLE
@@ -66002,39 +66042,39 @@ uoO
 uoO
 uoO
 uoO
-uoO
-joH
+rex
+yhT
 cIY
-gUF
-gUF
+osY
+ujY
 laO
-joH
+yhT
 uHT
-sNC
+rjY
 vXS
-joH
-wXe
-owF
-xAa
+yhT
+aPb
+vDC
+flz
 uIk
-xAa
-cuT
-joH
+pFY
+ubj
+yhT
 vRs
-fwR
+xSi
 kSx
 wTH
-vbu
-pon
-mHA
-mHA
-rWm
-joH
-nTc
-aSM
-tam
-joH
-uoO
+ujY
+jVT
+dum
+msi
+uEj
+yhT
+vfU
+osY
+osY
+yhT
+rex
 uoO
 uoO
 uoO
@@ -66259,39 +66299,39 @@ uoO
 uoO
 uoO
 uoO
-uoO
-joH
+rex
+yhT
 dwY
-gUF
-gTk
+niW
+rXn
 leT
-joH
-uHT
-sNC
-qVw
-joH
-wXe
-cuT
-xAa
+yhT
+hcO
+osY
+uHH
+yhT
+ggi
+vDC
+ujY
 rAQ
 hcf
 hcf
-joH
-vbu
-vbu
+yhT
+vfo
+xld
+riZ
 wTH
 wTH
-wTH
-pon
-niW
-gXQ
+jVT
+osY
+ujY
 ocv
-joH
+yhT
 ybL
 vfU
 hqn
-joH
-uoO
+yhT
+rex
 uoO
 uoO
 uoO
@@ -66516,39 +66556,39 @@ uoO
 uoO
 uoO
 aoj
-uoO
-joH
-ejG
-gUF
-gUF
+rex
+yhT
+laO
+niW
+fji
 mvO
-joH
-joH
+yhT
+yhT
 jCE
-joH
-joH
+yhT
+yhT
 ezR
-xAa
-xAa
+osY
+rjY
 oWK
-mOw
-uog
+vWg
+ujY
 kDe
-wTH
-kSx
-wTH
-wTH
-wTH
-fgo
-gXQ
-gXQ
+pdR
+pRA
+pdR
+wbu
+pdR
+qoW
+sdX
+ujY
 iMF
-joH
-joH
-joH
-joH
-joH
-uoO
+yhT
+fLU
+tTW
+fLU
+yhT
+rex
 uoO
 uoO
 uoO
@@ -66773,39 +66813,39 @@ uoO
 uoO
 uoO
 aoj
-uoO
-joH
+rex
+yhT
 faK
-gUF
+ujY
 iNP
 mQd
-joH
+yhT
 wcQ
 pdR
 guj
-joH
+yhT
 twb
-xAa
-mOw
+ujY
+osY
 vri
-xAa
-xAa
-joH
-vRs
-vSW
+rjY
+qIx
+yhT
+rnt
+vDC
 vxG
 vRs
 hvr
-joH
-niW
+yhT
+rlz
 ekj
 uEj
-joH
-uoO
-uoO
-uoO
-uoO
-uoO
+yhT
+rjY
+osY
+yhT
+rex
+rex
 uoO
 uoO
 uoO
@@ -67030,40 +67070,40 @@ uoO
 uoO
 uoO
 uoO
-uoO
-joH
-joH
+rex
+yhT
+yhT
 hMJ
 jfx
 oeA
-joH
-wrY
-pdR
+yhT
+xos
+vDC
 lGD
-joH
+yhT
 ggi
 cuT
 xAa
 hcf
 rAQ
 tGA
-joH
+yhT
 qeW
 fwR
-rXn
-qeW
-fwR
-joH
+xSi
+hFb
+vOE
+yhT
 rlz
-joH
-joH
-joH
+fLU
+fLU
+yhT
+ujY
+yhT
+yhT
+rex
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -67287,40 +67327,40 @@ uoO
 uoO
 uoO
 aoj
-uoO
-uoO
-joH
-joH
-joH
-joH
-joH
-joH
-pUB
-joH
-joH
+rex
+rex
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+vFv
+yhT
+yhT
 ttE
-mOw
+ejj
 owF
 emV
-cuT
+vDC
 doa
-joH
-joH
-joH
-joH
-joH
-joH
-joH
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
 fGF
-fGF
+wTH
 kcE
-joH
+yhT
+ujY
+yhT
+rex
+rex
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -67545,36 +67585,36 @@ uoO
 uoO
 aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-xVz
+rex
+rex
+rex
+rex
+rex
+rex
 wwE
-xVz
-xVz
-joH
+oQp
+oQp
+yhT
 pAR
 ltr
-mOw
+ujY
 uIk
 wpO
-cuT
-joH
-uoO
-uoO
-uoO
-uoO
-uoO
-joH
+avY
+yhT
+rex
+rex
+rex
+rex
+rex
+yhT
 wJo
 pSE
 fMX
-joH
-uoO
-uoO
-uoO
+yhT
+osY
+yhT
+rex
 uoO
 uoO
 uoO
@@ -67808,9 +67848,9 @@ uoO
 uoO
 uoO
 uoO
+uOF
 wAg
-wAg
-wAg
+eAK
 kDe
 kDe
 kDe
@@ -67823,15 +67863,15 @@ tDc
 htG
 htG
 htG
-htG
-joH
-joH
-joH
-joH
-joH
-uoO
-uoO
-uoO
+tDc
+yhT
+tTW
+yhT
+yhT
+yhT
+rjY
+yhT
+rex
 uoO
 uoO
 uoO
@@ -68065,30 +68105,30 @@ aBb
 aBb
 aBb
 uoO
+xVz
+xVz
+xFe
+rex
+rex
+rex
+rex
+rex
+rex
+rex
+rex
+rex
 uoO
 uoO
 uoO
-aBb
-hkD
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+rex
+yhT
+cDH
+ujY
+ujY
+ujY
+rjY
+yhT
+rex
 uoO
 uoO
 uoO
@@ -68322,12 +68362,12 @@ aBb
 aBb
 aBb
 aBb
+lnr
+lnr
 aBb
 aBb
 aBb
 aBb
-aBb
-aBb
 uoO
 uoO
 uoO
@@ -68337,15 +68377,15 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+rex
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+rex
 uoO
 uoO
 aoj
@@ -68580,12 +68620,12 @@ tOz
 aBb
 aBb
 aBb
+lnr
 aBb
 aBb
 aBb
 aBb
 aBb
-aBb
 uoO
 uoO
 uoO
@@ -68594,15 +68634,15 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+rex
+rex
+rex
+rex
+rex
+rex
+rex
+rex
+rex
 uoO
 uoO
 aoj

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -47,8 +47,8 @@
 	title = "Enclave Sergeant"
 	flag = F13USSGT
 	faction = "Enclave"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are in charge of the recruiting for the remnants of the Enclave. You are to recruit all those interested to your cause."
 	forbids = "You are not allowed to have friendly interactions with those outside of the Enclave."
 	enforces = "You must maintain the secrecy of organization."
@@ -94,8 +94,8 @@
 	title = "Enclave Scientist"
 	flag = F13USSCIENTIST
 	faction = "Enclave"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You're responsible for the maintenance of the base, the knowledge you've accumulated over the years is the only thing keeping the remnants alive. You've dabbled in enough to be considered a Professor in proficiency, but they call you Doctor. Support your dwindling forces and listen to the Lieutenant."
 	forbids = "The Enclave forbids you from leaving the base alone while it is still habitable."
 	enforces = "You must maintain the secrecy of organization."
@@ -151,8 +151,8 @@
 	title = "Enclave Lieutenant"
 	flag = F13USLT
 	faction = "Enclave"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the Lieutenant in charge of commanding the remnants of the Enclave forces in the area. You are to recruit all those interested to your cause."
 	forbids = "You are not allowed to have friendly interactions with those outside of the Enclave."
 	enforces = "You must maintain the secrecy of organization."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title says all

## Why It's Good For The Game

After talking, staff agreed for its removal, Enclave will be disabled for a set amount of time and in its place will be put a new bunker. That's pretty much it.

## Changelog
:cl:
add: bunker
del: sneedclave
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
