### PR TITLE
Fixes ChangeTurf() resetting dynamic_lumcount

### DIFF
--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -156,8 +156,7 @@
 
 ///Clears the affected_turfs lazylist, removing from its contents the effects of being near the light.
 /datum/component/overlay_lighting/proc/clean_old_turfs()
-	for(var/t in affected_turfs)
-		var/turf/lit_turf = t
+	for(var/turf/lit_turf as anything in affected_turfs)
 		lit_turf.dynamic_lumcount -= lum_power
 	affected_turfs = null
 
@@ -167,9 +166,12 @@
 	if(!current_holder)
 		return
 	var/atom/movable/light_source = GET_LIGHT_SOURCE
+	. = list()
 	for(var/turf/lit_turf in view(lumcount_range, get_turf(light_source)))
 		lit_turf.dynamic_lumcount += lum_power
-		LAZYADD(affected_turfs, lit_turf)
+		. += lit_turf
+	if(length(.))
+		affected_turfs = .
 
 
 ///Clears the old affected turfs and populates the new ones.
@@ -413,9 +415,9 @@
 	. = lum_power
 	lum_power = new_lum_power
 	var/difference = . - lum_power
-	for(var/t in affected_turfs)
-		var/turf/lit_turf = t
+	for(var/turf/lit_turf as anything in affected_turfs)
 		lit_turf.dynamic_lumcount -= difference
+
 
 ///Here we append the behavior associated to changing lum_power.
 /datum/component/overlay_lighting/proc/cast_directional_light()

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -87,7 +87,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	var/old_lc_bottomleft = lc_bottomleft
 
 	var/old_directional_opacity = directional_opacity
-
+	var/old_dynamic_lumcount = dynamic_lumcount
 	var/old_sunlight_state = sunlight_state
 
 	var/old_exl = explosion_level
@@ -125,6 +125,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 
 	base_opacity = initial(opacity)
 	directional_opacity = old_directional_opacity
+	dynamic_lumcount = old_dynamic_lumcount
 
 	if(SSlighting.initialized)
 		lighting_object = old_lighting_object

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -41,7 +41,7 @@
 	var/tiled_dirt = FALSE // use smooth tiled dirt decal
 
 	///Lumcount added by sources other than lighting datum objects, such as the overlay lighting component.
-	var/dynamic_lumcount = 0 // Not yet added to this codebase.
+	var/dynamic_lumcount = 0
 
 	///Which directions does this turf block the vision of, taking into account both the turf's opacity and the movable opacity_sources.
 	var/directional_opacity = NONE

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -94,7 +94,7 @@
 	if (!lighting_object)
 		return FALSE
 
-	return !lighting_object.luminosity
+	return !(lighting_object.luminosity || dynamic_lumcount)
 
 
 /turf/proc/set_base_opacity(new_base_opacity)


### PR DESCRIPTION
Fixes a bug in which when a turf changes, the dynamic lumcount is not preserved.
This affects miners with pocket lights and nyctophobia, among other things.