### PR TITLE
Adds a new faction called The Children of the Cathedral

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -217,8 +217,8 @@ Coven Stuff
 	total_positions = 4
 	spawn_positions = 4
 	description = "You are a Servitor of the Children of the Cathedral. As the Servitor you answer directly to the High Priests. Super Mutants are the primary military force of your organization. From far away to the west, in The Cathedral, New California. You have come to do the bidding of The Master, your holy leader. He is long dead only his ideals remain in your mind. Unleash the Unity. Your job is to organize missions to subvert the power of the local factions, spread scripture, protect and recruit citizens, and disperse technology to the people. The High Priests of the Cathedral have given you the permission to recruit and command your own squad, given that they eventually submit to the Children of the Cathedral's FEV treatment. You spread the scripture of the Unity. you distribute technology to the masses and though you are in open war with the Brotherhood and the NCR. it is your sworn duty to preserve all life in the name of fulfilling the Unity. In the eyes of your superiors, all deserve a chance to bask in the shadow of the Unity."
-	forbids = ""
-	enforces = ""
+	forbids = "Disrespecting the Unity. Using drugs such as Jet. Painting the Cathedral in a bad light.Killing without reason. Theft while in the Uniform."
+	enforces = "Helping the common Waster.Destabilizing the BOS and NCR. Converting those worthy to become Super Mutants.Sharing tech to the common wastelander "
 	supervisors = "The High-Priests."
 	selection_color = "#95a5a6"
     exp_type = EXP_TYPE_FALLOUT

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -211,41 +211,44 @@ Coven Stuff
 */
 
 /datum/job/wasteland/covenwitch
-	title = "Coven Witch"
+	title = "Cathedral Servitor"
 	flag = EVENTCOVEN
-	faction = "Coven"
-	total_positions = 0
-	spawn_positions = 0
-	description = "You are a Witch of the Iron Coven. As the Witch you answer directly to the Exalted and the Matriarchs. The commanding officer in this region is a Matriarch by the name of The Harbinger. Circumstances may change the identity of the local commanding officer, but you will forevermore answer to the bidding of any and all Matriarchs. You are the equivilent of a Brotherhood Knight in rank, but your role has changed in the century since your people betrayed the Brotherhood of Steel. Witches are the primary military force of your organization. From far away to the east, in Dallas, New Orleans, and the sprawling metropolis that is Miami, you have come to do the bidding of the Grand Matriarch, your holy leader. She orders that the people of this region, like any other, be subjugated to her will. Your job is to organize missions to subvert the power of the local factions, spread scripture, protect and recruit citizens, and disperse technology to the people. The Matriarchs of the Coven have given you the permission to recruit and command your own squad, given that they eventually submit to the Iron Church's FEV treatment. You spread the scripture of the Iron Codex, you distribute technology to the masses and though you are in open war with the people of this area, it is your sworn duty to preserve all life in the name of fulfilling the Prophecy. All lives lost are a tragedy. In the eyes of your superiors, all deserve a chance to bask in the shadow of the Void."
+	faction = "Children of the Cathedral"
+	total_positions = 4
+	spawn_positions = 4
+	description = "You are a Servitor of the Children of the Cathedral. As the Servitor you answer directly to the High Priests. Super Mutants are the primary military force of your organization. From far away to the west, in The Cathedral, New California. You have come to do the bidding of The Master, your holy leader. He is long dead only his ideals remain in your mind. Unleash the Unity. Your job is to organize missions to subvert the power of the local factions, spread scripture, protect and recruit citizens, and disperse technology to the people. The High Priests of the Cathedral have given you the permission to recruit and command your own squad, given that they eventually submit to the Children of the Cathedral's FEV treatment. You spread the scripture of the Unity. you distribute technology to the masses and though you are in open war with the Brotherhood and the NCR. it is your sworn duty to preserve all life in the name of fulfilling the Unity. In the eyes of your superiors, all deserve a chance to bask in the shadow of the Unity."
 	forbids = ""
 	enforces = ""
-	supervisors = "Exalted and the Matriarchs."
+	supervisors = "The High-Priests."
 	selection_color = "#95a5a6"
+    exp_type = EXP_TYPE_FALLOUT
+	exp_requirements = 1200
 
 	outfit = /datum/outfit/job/wasteland/covenwitch
 
 /datum/outfit/job/wasteland/covenwitch
-	name = "Coven Witch"
+	name = "Cathedral Servitor"
 	jobtype = /datum/job/wasteland/covenwitch
 	backpack = /obj/item/storage/backpack/satchel/leather
+	head =          /obj/item/clothing/head/hooded/cult_hoodie/eldritch
 	ears = 			/obj/item/radio/headset/headset_sci
 	glasses = 		/obj/item/clothing/glasses/night
 	mask = 			/obj/item/clothing/mask/gas/syndicate
 	uniform =		/obj/item/clothing/under/syndicate/combat
-	suit = 			/obj/item/clothing/suit/hooded/cloak/goliath
+	suit = 			/obj/item/clothing/suit/hooded/cultrobes/eldritch
 	belt = 			/obj/item/storage/belt/military/army
 	shoes = 		/obj/item/clothing/shoes/plate/red
 	gloves = 		/obj/item/clothing/gloves/plate/red
 	id = 			/obj/item/card/id/syndicate/anyone
 	l_hand =		/obj/item/nullrod/claymore/darkblade
-	suit_store =  	/obj/item/gun/ballistic/automatic/pistol/suppressed
+	suit_store =  	/obj/item/gun/ballistic/automatic/pistol/pistol22
 
 	backpack_contents = list(
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=2,
 		/obj/item/flashlight/flare/culttorch=1,
 		/obj/item/grenade/flashbang=1,
 		/obj/item/pda=1,
-		/obj/item/reagent_containers/glass/bottle/FEV_solution=1
+		/obj/item/reagent_containers/glass/bottle/FEV_solution=2
 		)
 /*
 Great Khan


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reenables the iron Coven and turns them into the Unity worshipping Children of the Cathedral
## Why It's Good For The Game
Quite a few people have been asking for a Mutant faction and when I was looking through the code I notice the Iron Coven. They are supposed to be a group of healers that have to find each other. Run advertisements about the greatness of the Unity and the High-Priests. While destabilizing the NCR and BOS
## Changelog
:cl:
code: Changed the "Iron Coven" into the Children of the Cathedral changed their Outfits guns and laws
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
