### PR TITLE
Kitty centurion.

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -198,6 +198,7 @@ kept here incase it gets reworked later*/
 	backpack_contents = list(
 					/obj/item/melee/powerfist/goliath=1,
 					/obj/item/ammo_box/magazine/m556/rifle=2)
+
 /datum/outfit/loadout/UwUturion
 	name =			"Kitty centurion"
 	suit =			/obj/item/clothing/suit/chickensuit

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -139,7 +139,8 @@
 	loadout_options = list(
 	/datum/outfit/loadout/palacent, //10mm SMG, large magazines and thermic lance
 	/datum/outfit/loadout/rangerhunter, //hunting revolver and ripper
-	/datum/outfit/loadout/centurion //marksman and powerfist
+	/datum/outfit/loadout/centurion, //marksman and powerfist
+	/datum/outfit/loadout/UwUturion //Cats ears, chicken costume and dclaw fist
 	)
 /*	/datum/outfit/loadout/berserkercenturion
 kept here incase it gets reworked later*/
@@ -197,7 +198,13 @@ kept here incase it gets reworked later*/
 	backpack_contents = list(
 					/obj/item/melee/powerfist/goliath=1,
 					/obj/item/ammo_box/magazine/m556/rifle=2)
-
+/datum/outfit/loadout/UwUturion
+	name = 			"Kitty centurion"
+	suit = 			/obj/item/clothing/suit/chickensuit
+	head = 			/obj/item/clothing/head/collectable/kitty
+	suit_store =	/obj/item/pneumatic_cannon
+	backpack_contents = list(
+					/obj/item/dildo=20)
 /* /datum/outfit/loadout/berserkercenturion
 	name = 			"Praetorian Candidate"
 	suit = 			/obj/item/clothing/suit/armor/f13/legion/centurion

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -199,9 +199,9 @@ kept here incase it gets reworked later*/
 					/obj/item/melee/powerfist/goliath=1,
 					/obj/item/ammo_box/magazine/m556/rifle=2)
 /datum/outfit/loadout/UwUturion
-	name = 			"Kitty centurion"
-	suit = 			/obj/item/clothing/suit/chickensuit
-	head = 			/obj/item/clothing/head/collectable/kitty
+	name =			"Kitty centurion"
+	suit =			/obj/item/clothing/suit/chickensuit
+	head =			/obj/item/clothing/head/collectable/kitty
 	suit_store =	/obj/item/pneumatic_cannon
 	backpack_contents = list(
 					/obj/item/dildo=20)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
New centurion loadout to cater to our more intimate playerbase.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
For too long have centurions been a staple of robustness and authority. It's time for the role to take a new turn and focus on the more mellow parts of Fortune 13. This is why I introduce to you the new kit; Kitty Centurion. It comes loaded not only with a pneumatic dildo cannon but also cat ears and a fluffy chicken suit. It has no usage in combat whatsoever but hey- at least it'll be good for the folk who just wants to "relax" with the captures ;)))) <3
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
