### PR TITLE
Vault rework and addition 2: Electric warcrime-aloo

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -1,8 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaC" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/structure/displaycase,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "aaF" = (
 /obj/structure/chair/bench,
@@ -16,16 +18,6 @@
 /obj/effect/mine/shrapnel/sting,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
-"aaK" = (
-/obj/machinery/power/am_control_unit,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/f13/vault)
 "abc" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -49,14 +41,6 @@
 /obj/structure/timeddoor,
 /turf/closed/wall/f13/tunnel,
 /area/f13/bunker)
-"aci" = (
-/obj/machinery/sleeper,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
 "acG" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
@@ -88,43 +72,50 @@
 /area/f13/underground/cave)
 "adZ" = (
 /obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "25"
+	name = "Operating Theatre";
+	req_access_txt = "45; 5"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "aer" = (
-/obj/machinery/computer/upload/ai,
-/turf/open/floor/plasteel/dark,
+/obj/structure/table/wood/fancy/red,
+/obj/machinery/computer/security{
+	dir = 8;
+	network = "vault"
+	},
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "aeH" = (
-/obj/machinery/door/airlock/maintenance/abandoned,
-/turf/open/floor/wood,
+/obj/structure/dresser,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "agt" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
+/obj/item/clothing/suit/armor/f13/power_armor/excavator{
+	pixel_y = -2
 	},
-/obj/structure/toilet,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/obj/item/clothing/head/helmet/f13/power_armor/excavator{
+	pixel_x = 2;
+	pixel_y = 12
 	},
+/obj/structure/kitchenspike{
+	desc = "A nice rack for a nice set of Power Armor.";
+	name = "Power Armor Rack"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "agM" = (
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 8
-	},
-/area/f13/vault)
-"ahh" = (
-/turf/open/floor/plasteel/dark,
+/obj/structure/table,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "ahI" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
 "aim" = (
-/turf/closed/indestructible/rock,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
 "aiq" = (
 /obj/structure/wreck/trash/two_barrels,
@@ -142,12 +133,6 @@
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
-"aiI" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
 "aiS" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
@@ -159,24 +144,8 @@
 	},
 /area/f13/bunker)
 "akq" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
-"akt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
-/area/f13/vault)
-"akw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/table,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
 "akA" = (
 /obj/machinery/autolathe,
@@ -193,17 +162,11 @@
 /obj/effect/mob_spawn/human/corpse/damaged,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
-"akP" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/vault)
 "alO" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/doughslice,
-/obj/item/reagent_containers/food/snacks/doughslice,
-/turf/open/floor/plasteel/cafeteria,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
 "anz" = (
 /obj/structure/table/reinforced,
@@ -214,17 +177,10 @@
 	},
 /area/f13/bunker)
 "anY" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/bot,
-/obj/item/ammo_box/shotgun/buck,
-/obj/item/ammo_box/shotgun/buck,
-/obj/item/ammo_box/shotgun/buck,
-/obj/item/ammo_box/shotgun/buck,
-/obj/item/ammo_box/shotgun/bean,
-/obj/item/ammo_box/shotgun/bean,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 10
+/obj/machinery/light/small{
+	dir = 4
 	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
 "apb" = (
 /obj/item/trash/can,
@@ -399,19 +355,8 @@
 	},
 /area/f13/bunker)
 "ayN" = (
-/obj/structure/table,
-/obj/item/crafting/duct_tape,
-/obj/item/crafting/duct_tape,
-/obj/item/crafting/lunchbox,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
-"ayT" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Office";
-	req_access_txt = "47"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/caution{
+	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
@@ -469,9 +414,12 @@
 /turf/open/floor/holofloor/carpet,
 /area/f13/bunker)
 "aCL" = (
-/obj/structure/nest/radroach,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/vault)
 "aDZ" = (
 /turf/open/floor/f13{
 	dir = 8;
@@ -515,22 +463,16 @@
 	},
 /area/f13/bunker)
 "aFT" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/f13{
-	icon_state = "grass2"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
 "aGJ" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
+/obj/structure/chair{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
 "aGL" = (
 /obj/structure/table,
@@ -562,10 +504,6 @@
 /mob/living/simple_animal/hostile/raider/ranged/boss,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
-"aIu" = (
-/obj/machinery/vending/robotics,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "aIQ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button{
@@ -576,20 +514,16 @@
 	},
 /area/f13/bunker)
 "aIS" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel/caution{
-	dir = 8
-	},
+/obj/structure/chair/comfy/black,
+/obj/effect/landmark/start/f13/overseer,
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "aJe" = (
-/obj/structure/decoration/hatch{
-	dir = 4
+/obj/structure/table/wood/fancy/red,
+/obj/machinery/computer/crew{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "aJr" = (
 /obj/structure/table/abductor{
@@ -600,7 +534,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "aJx" = (
-/obj/structure/bodycontainer/morgue,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "aJC" = (
@@ -617,11 +551,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
-"aJI" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/vault)
 "aKU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -630,8 +559,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "aLh" = (
-/obj/structure/table/booth,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/obj/machinery/light,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
 "aLx" = (
 /obj/structure/rack,
@@ -683,11 +615,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
-"aNW" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "aOA" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -724,8 +651,11 @@
 	},
 /area/f13/underground/cave)
 "aSm" = (
-/obj/effect/landmark/start/f13/vaultdweller,
-/turf/open/floor/plasteel/cafeteria,
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access_txt = "1"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "aSK" = (
 /turf/open/floor/f13{
@@ -733,11 +663,11 @@
 	},
 /area/f13/bunker)
 "aTC" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access_txt = "1"
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "aTO" = (
 /obj/item/ammo_box/magazine/w308,
@@ -791,24 +721,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
-"aWc" = (
-/obj/machinery/conveyor/inverted{
-	dir = 6;
-	id = "QMLoad"
-	},
-/obj/effect/turf_decal/stripes/line{
+"aWo" = (
+/obj/structure/toilet{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
-"aWo" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
 "aXE" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -835,13 +753,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
-"aZd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
 "aZP" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -880,11 +791,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "bcr" = (
-/obj/machinery/vending/wardrobe/cargo_wardrobe,
-/obj/machinery/status_display/supply{
-	pixel_y = 32
+/obj/structure/table/wood/fancy/red,
+/obj/machinery/computer/terminal{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "bcE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -938,8 +849,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "bgX" = (
-/obj/structure/chair/comfy/brown,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/table,
+/obj/item/clothing/neck/cloak/overseer,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "bgY" = (
 /obj/machinery/vending/dinnerware,
@@ -953,19 +869,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "bhU" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor{
-	icon_state = "rightsecure";
-	req_access_txt = "10, 11"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"big" = (
-/obj/machinery/door/airlock/wood{
-	id_tag = "vaultd6";
-	name = "Dorm 6"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "biF" = (
 /obj/machinery/vending/cigarette,
@@ -981,41 +886,25 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "bje" = (
-/obj/machinery/door/airlock/wood{
-	name = "Bathrooms"
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "bjy" = (
-/obj/structure/flora/ausbushes/sparsegrass{
-	pixel_x = 14
+/obj/item/reagent_containers/food/snacks/grown/citrus/lemon{
+	desc = "It appear's to be a normal lemon, however it's labeled as being the Vault Blueprints. Odd.";
+	name = "Vault Blueprints"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/vault)
 "bjJ" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"bjK" = (
-/obj/structure/table,
-/obj/structure/table,
-/obj/item/stamp/captain{
-	name = "overseer's rubber stamp";
-	pixel_x = -4;
-	pixel_y = 3
-	},
-/obj/item/pen/fountain/captain{
-	desc = "It's an expensive Oak fountain pen, engraved with the numbers 113. The nib is quite sharp.";
-	name = "overseer's fountain pen";
-	pixel_x = 7;
-	pixel_y = 5
-	},
-/obj/item/flashlight/lamp{
-	pixel_x = -14;
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/vault)
 "bjT" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/tunnel,
@@ -1045,8 +934,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "blH" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/obj/machinery/door/window,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "blJ" = (
 /obj/structure/wreck/trash/three_barrels,
@@ -1060,28 +952,15 @@
 /obj/structure/debris/v3,
 /turf/closed/indestructible/rock,
 /area/f13/underground/cave)
-"bnB" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
-/area/f13/vault)
-"bnK" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/item/seeds/apple/gold,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
-/area/f13/vault)
 "bnQ" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "boj" = (
-/obj/machinery/vending/donksofttoyvendor,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "bpr" = (
 /obj/structure/closet/crate,
@@ -1097,14 +976,10 @@
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
 "bqE" = (
-/obj/structure/rack,
-/obj/machinery/button/door{
-	id = "vaultd2";
-	normaldoorcontrol = 1;
-	pixel_x = 26;
-	specialfunctions = 4
+/obj/structure/chair/office{
+	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "bqF" = (
 /obj/item/soap/homemade,
@@ -1117,26 +992,13 @@
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
-"bsw" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "btc" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
-/area/f13/vault)
-"buU" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -32
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/fence/wooden{
+	dir = 1;
+	icon_state = "post_wood"
 	},
-/obj/structure/chair/f13foldupchair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/turf/open/floor/grass,
 /area/f13/vault)
 "bwT" = (
 /obj/machinery/shower{
@@ -1148,13 +1010,10 @@
 	},
 /area/f13/bunker)
 "bxc" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/obj/effect/landmark/start/f13/overseer,
+/obj/structure/bed,
+/obj/item/bedsheet/captain,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "bxs" = (
 /obj/structure/mopbucket,
@@ -1170,15 +1029,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
-"bxu" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/f13/vault)
 "bya" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -1195,7 +1045,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "byI" = (
-/turf/open/floor/plasteel,
+/obj/structure/cable,
+/obj/machinery/power/am_control_unit,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "byS" = (
 /obj/structure/rack,
@@ -1206,14 +1058,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"byY" = (
-/turf/open/floor/plasteel/yellow/side,
-/area/f13/vault)
-"bzb" = (
-/obj/item/bedsheet/captain,
-/obj/structure/bed/old,
-/turf/open/floor/carpet/black,
-/area/f13/vault)
 "bzd" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy{
@@ -1222,10 +1066,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "bzn" = (
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "bzF" = (
 /obj/structure/chair,
@@ -1233,13 +1077,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"bzV" = (
-/obj/structure/table/booth,
-/obj/item/reagent_containers/food/snacks/enchiladas{
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "bAx" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -1251,12 +1088,13 @@
 	},
 /area/f13/bunker)
 "bAG" = (
-/obj/structure/closet/wardrobe/cargotech,
-/obj/item/clothing/neck/cloak/qm,
-/obj/item/pda/quartermaster,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 10
+/obj/item/clothing/under/misc/bathrobe,
+/obj/machinery/shower{
+	dir = 8
 	},
+/obj/effect/landmark/start/f13/overseer,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "bAL" = (
 /obj/structure/table/wood,
@@ -1265,9 +1103,8 @@
 	},
 /area/f13/bunker)
 "bAR" = (
-/turf/open/floor/plasteel/yellow/side{
-	dir = 5
-	},
+/obj/structure/bed,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
 "bAX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1277,11 +1114,10 @@
 	},
 /area/f13/bunker)
 "bBo" = (
-/obj/machinery/door/airlock/wood{
-	id_tag = "vaultd3";
-	name = "Dorm 3"
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "bCd" = (
 /obj/item/bedsheet/black,
@@ -1299,14 +1135,9 @@
 /area/f13/bunker)
 "bCL" = (
 /obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "bCR" = (
 /obj/machinery/light/fo13colored/Red{
@@ -1318,15 +1149,13 @@
 	},
 /area/f13/bunker)
 "bDq" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad"
+/obj/structure/chair/sofa/corp/right,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/fence/handrail{
-	dir = 4;
-	pixel_x = -15
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "bEm" = (
 /obj/effect/decal/cleanable/blood,
@@ -1336,10 +1165,9 @@
 	},
 /area/f13/bunker)
 "bEK" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/carpet/black,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/grass,
 /area/f13/vault)
 "bET" = (
 /obj/structure/chair/f13chair2,
@@ -1349,13 +1177,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
-"bEV" = (
-/obj/machinery/door/airlock/security{
-	name = "Brig";
-	req_access_txt = "1"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "bFa" = (
 /obj/machinery/door/airlock/grunge/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -1372,12 +1193,6 @@
 "bFu" = (
 /turf/open/water,
 /area/f13/underground/cave)
-"bHb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/vault)
 "bHC" = (
 /obj/effect/decal/remains/human,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -1388,14 +1203,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
-"bIM" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
-	},
-/area/f13/vault)
 "bJM" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13{
@@ -1446,15 +1253,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"bKE" = (
-/obj/machinery/door/airlock{
-	name = "Hydroponics"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "bMf" = (
 /obj/structure/window/plastitanium,
 /obj/structure/grille,
@@ -1501,21 +1299,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
-"bQQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname{
-	dir = 9;
-	network = list("Vault")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"bRz" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
 "bRI" = (
 /turf/closed/wall/f13/wood,
 /area/f13/underground/cave)
@@ -1533,11 +1316,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "bSU" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 16
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "bSW" = (
 /obj/structure/table,
@@ -1557,10 +1339,6 @@
 /mob/living/simple_animal/hostile/raider/tribal,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
-"bTC" = (
-/obj/machinery/computer/med_data,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "bTS" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/underground/cave)
@@ -1569,11 +1347,8 @@
 /turf/open/water,
 /area/f13/bunker)
 "bUN" = (
-/obj/machinery/door/airlock/security{
-	name = "Brig";
-	req_access_txt = "1"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
 "bVe" = (
 /obj/structure/chair/bench,
@@ -1616,8 +1391,8 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "bYw" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "bYA" = (
 /turf/closed/mineral/random/low_chance,
@@ -1648,32 +1423,36 @@
 	},
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
-"bZY" = (
-/obj/structure/chair/booth{
-	dir = 4
-	},
-/obj/effect/landmark/start/f13/vaultdweller,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "caQ" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/machinery/door/window/brigdoor/security/cell/northleft{
+	dir = 2;
+	id = "vaultc2";
+	name = "Cell 2"
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
 "cbg" = (
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
 "cbv" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks,
-/obj/structure/sign/warning,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/vault)
 "ccw" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1773,7 +1552,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ciO" = (
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/obj/machinery/vending/wardrobe/science_wardrobe,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
 /area/f13/vault)
 "ciT" = (
 /obj/effect/turf_decal/arrows{
@@ -1799,12 +1581,6 @@
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
-"cmp" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "cms" = (
 /obj/structure/rack,
 /obj/item/soap,
@@ -1813,25 +1589,10 @@
 	},
 /area/f13/bunker)
 "cmt" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
+/obj/structure/chair/comfy/black{
+	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
-"cmu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "cmM" = (
 /obj/item/bedsheet/orange,
@@ -1840,25 +1601,15 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"cnA" = (
+"cnH" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "0-8"
 	},
-/obj/structure/sign/poster/official/safety_eye_protection{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/vault)
-"cnH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/darkred/corner{
-	dir = 8
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
 "cnL" = (
 /obj/item/bedsheet/yellow,
@@ -1872,11 +1623,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "cpp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access_txt = "1"
 	},
-/turf/open/floor/plating/f13,
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "cpq" = (
 /obj/machinery/door/poddoor{
@@ -1895,14 +1646,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "cpR" = (
-/obj/machinery/vending/cola/space_up,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
-"crs" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/machinery/autolathe/ammo,
+/obj/item/book/granter/crafting_recipe/gunsmith_one,
+/obj/item/book/granter/crafting_recipe/gunsmith_two,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "csa" = (
 /obj/structure/table/wood,
@@ -1922,11 +1669,9 @@
 /area/f13/bunker)
 "cve" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
-	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
 "cvG" = (
 /obj/structure/closet/crate,
@@ -1971,19 +1716,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "cyk" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
 "cyG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 15
 	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
 "cyK" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -2008,11 +1757,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"cAz" = (
-/obj/structure/cable,
-/obj/machinery/power/terminal,
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "cAK" = (
 /obj/structure/rack{
 	dir = 8;
@@ -2029,8 +1773,10 @@
 	},
 /area/f13/bunker)
 "cBA" = (
-/obj/machinery/mech_bay_recharge_port,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/obj/effect/landmark/start/f13/vaultsecurityofficer,
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "cCf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2041,18 +1787,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"cCQ" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "cCZ" = (
-/obj/structure/table/wood,
-/obj/item/clothing/head/collectable/tophat,
-/turf/open/floor/wood,
-/area/f13/vault)
-"cEv" = (
-/obj/structure/chair/stool/retro,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/obj/structure/rack,
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "cEG" = (
 /obj/machinery/light/fo13colored/Red,
@@ -2065,12 +1802,6 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
-"cEU" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "cFf" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/plasteel/f13{
@@ -2091,12 +1822,11 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "cHe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 6
+/obj/structure/table,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "cHv" = (
@@ -2146,11 +1876,10 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "cKF" = (
-/obj/effect/landmark/start/f13/vaultdoctor,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
 "cKH" = (
 /obj/structure/rack,
@@ -2178,10 +1907,16 @@
 	},
 /area/f13/bunker)
 "cNv" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/costume,
-/obj/item/storage/crayons,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "Vault East Trading Shutters";
+	name = "East Trading Shutters";
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "cND" = (
 /obj/structure/table/wood,
@@ -2221,9 +1956,10 @@
 	},
 /area/f13/bunker)
 "cSA" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
 "cSF" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -2236,23 +1972,11 @@
 	},
 /area/f13/bunker)
 "cTl" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"cTy" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "cTB" = (
 /obj/machinery/hydroponics/constructable,
@@ -2268,10 +1992,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "cUJ" = (
+/obj/structure/dresser,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "cVc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2302,12 +2027,6 @@
 "cYi" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
-"cYq" = (
-/obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/vault)
 "cYx" = (
 /obj/structure/table/wood,
 /obj/item/trash/plate,
@@ -2316,12 +2035,14 @@
 	},
 /area/f13/bunker)
 "cZs" = (
-/obj/structure/rack,
-/obj/item/pickaxe,
-/obj/item/pickaxe/drill,
-/obj/item/pickaxe/drill,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/tunnel)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/vault)
 "cZw" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -2331,9 +2052,12 @@
 	},
 /area/f13/bunker)
 "dai" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access_txt = "1"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/vault)
 "dao" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/decal/cleanable/dirt,
@@ -2346,11 +2070,12 @@
 	},
 /area/f13/bunker)
 "dbn" = (
-/obj/item/clothing/suit/toggle/lawyer,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
 /area/f13/vault)
 "dbo" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -2380,17 +2105,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"ddk" = (
-/obj/machinery/conveyor/inverted{
-	dir = 10;
-	id = "garbage"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "ddn" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -2408,22 +2122,24 @@
 	},
 /area/f13/bunker)
 "deX" = (
-/turf/open/floor/plating/tunnel,
-/area/f13/tunnel)
-"deZ" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "dfc" = (
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 32
+	},
+/obj/machinery/camera/autoname{
+	network = list("Vault")
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "dfX" = (
-/obj/machinery/computer/upload/ai{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
 /area/f13/vault)
 "dgM" = (
 /obj/structure/bookcase,
@@ -2444,13 +2160,14 @@
 /turf/closed/indestructible/rock,
 /area/f13/underground/cave)
 "dhm" = (
-/obj/structure/chair/comfy/black,
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_y = 30
+/obj/machinery/door/airlock/security/glass{
+	name = "Armory";
+	req_access_txt = "1"
 	},
-/turf/open/floor/f13/wood,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/vault)
 "dhZ" = (
 /obj/structure/ladder/unbreakable{
@@ -2546,43 +2263,42 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "dlX" = (
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/f13/vault)
+"dnh" = (
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"dmO" = (
+"dnj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/f13/vault)
+"dnA" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
+	},
+/obj/item/clothing/glasses/night,
+/obj/item/clothing/glasses/night,
+/obj/item/clothing/glasses/night,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/vault)
+"dog" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"dnh" = (
-/obj/structure/table,
-/obj/item/storage/fancy/rollingpapers,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
-"dnj" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/vault)
-"dnA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname{
-	dir = 9;
-	network = list("Vault")
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/vault)
-"dog" = (
-/obj/machinery/autolathe,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
 "doK" = (
 /obj/effect/turf_decal/arrows{
@@ -2616,9 +2332,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "dqe" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/clothing_middle,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/window/spawner/east,
+/obj/structure/window/spawner/north,
+/obj/structure/window/spawner/west,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
 /area/f13/vault)
 "dqV" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin,
@@ -2627,21 +2349,26 @@
 	},
 /area/f13/underground/cave)
 "dre" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "drg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "rampdowntop"
-	},
+/obj/structure/sign/warning/radiation,
+/turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
 "drs" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "drH" = (
 /obj/structure/barricade/wooden,
@@ -2675,14 +2402,32 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "dvm" = (
-/obj/machinery/door/airlock/maintenance/abandoned,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
+	},
 /area/f13/vault)
 "dxB" = (
-/obj/machinery/door/airlock/mining{
-	name = "Casp Bay"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/rack,
+/obj/item/clothing/under/f13/vault,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/gloves/color/black,
+/obj/item/storage/belt/security,
+/obj/item/melee/classic_baton/telescopic,
+/obj/item/assembly/flash/handheld,
+/obj/item/restraints/handcuffs,
+/obj/item/gun/ballistic/automatic/pistol/n99,
+/obj/item/ammo_box/magazine/m10mm_adv/simple,
+/obj/item/ammo_box/magazine/m10mm_adv/simple,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/head/helmet/riot/vaultsec,
+/obj/item/clothing/glasses/sunglasses,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "dxN" = (
 /obj/structure/barricade/wooden/strong,
@@ -2696,28 +2441,28 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "dAl" = (
-/obj/structure/sign/departments/medbay,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/item/storage/belt/military/assault,
+/obj/item/clothing/suit/armor/f13/combat/swat,
+/obj/item/clothing/mask/gas/sechailer/swat,
+/obj/item/clothing/head/helmet/f13/combat/swat,
+/obj/item/clothing/glasses/legiongoggles,
+/obj/structure/window/reinforced,
+/obj/item/grenade/chem_grenade/teargas,
+/obj/item/grenade/flashbang,
+/obj/machinery/door/window/brigdoor{
+	dir = 4
 	},
-/area/f13/vault)
-"dAJ" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/vault)
-"dBr" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/black,
-/area/f13/vault)
-"dBY" = (
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
-/area/f13/vault)
-"dCj" = (
-/obj/machinery/light/small{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/dark,
+/area/f13/vault)
+"dBr" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "dCt" = (
 /obj/structure/table/glass,
@@ -2733,25 +2478,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
 "dCI" = (
-/obj/structure/table,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/computer/rdconsole/core/vault,
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
-/obj/machinery/camera/autoname{
-	dir = 1;
-	network = list("Vault")
-	},
-/obj/item/grenade/barrier{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/darkred/side,
 /area/f13/vault)
 "dCU" = (
 /obj/item/radio/intercom{
@@ -2782,10 +2512,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "dDP" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/rnd/production/protolathe,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "dFC" = (
 /obj/machinery/light/fo13colored/Red{
@@ -2820,42 +2550,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "dGy" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
-"dGU" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/circuitboard/machine/mechfab,
-/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/obj/effect/landmark/start/f13/vaultscientist,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "dHs" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = 30
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/computer/rdconsole/core/vault,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
 "dHZ" = (
 /obj/structure/rack{
@@ -2872,18 +2579,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"dIN" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 16
-	},
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/vault)
 "dKH" = (
 /obj/machinery/shower{
 	dir = 8
@@ -2926,40 +2621,30 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/water,
 /area/f13/underground/cave)
-"dNC" = (
-/obj/machinery/chem_master/condimaster{
-	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
-	name = "BrewMaster 2199"
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
 "dNU" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "dOD" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/obj/machinery/rnd/production/circuit_imprinter,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 5
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
 "dOE" = (
 /obj/machinery/mineral/unloading_machine,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
 "dOF" = (
-/obj/machinery/door/window/brigdoor{
-	icon_state = "rightsecure";
-	req_access_txt = "31"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/caution,
+/obj/structure/window/spawner/east,
+/obj/structure/window/spawner/west,
+/obj/structure/window/spawner,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
 /area/f13/vault)
 "dPu" = (
 /obj/structure/table/wood,
@@ -2988,21 +2673,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
-"dRs" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "dRx" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"dRB" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "dRD" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/ears/earmuffs,
@@ -3017,13 +2691,18 @@
 	},
 /area/f13/bunker)
 "dSc" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/effect/turf_decal/bot,
+/obj/item/gun/energy/laser/wattz,
+/obj/item/gun/energy/laser/wattz,
+/obj/item/gun/energy/laser/wattz,
+/obj/item/gun/energy/laser/wattz,
+/obj/structure/rack,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "dSf" = (
-/obj/item/soap,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/darkpurple/corner{
+	dir = 1
+	},
 /area/f13/vault)
 "dSK" = (
 /obj/item/ammo_casing/c9mm,
@@ -3041,12 +2720,16 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "dTR" = (
-/obj/structure/curtain,
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	pixel_y = 27
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 4
+	},
 /area/f13/vault)
 "dUq" = (
 /obj/structure/decoration/rag,
@@ -3057,16 +2740,9 @@
 	name = "temple wall"
 	},
 /area/f13/bunker)
-"dUD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/departments/botany,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "dVu" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/carpet/black,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
 /area/f13/vault)
 "dVO" = (
 /obj/structure/fence{
@@ -3083,23 +2759,27 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
-"dVW" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
-	},
-/obj/structure/rack,
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 25
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/vault)
 "dWA" = (
-/obj/structure/chair{
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/item/storage/belt/military/assault,
+/obj/item/clothing/suit/armor/f13/combat/swat,
+/obj/item/clothing/mask/gas/sechailer/swat,
+/obj/item/clothing/head/helmet/f13/combat/swat,
+/obj/item/clothing/glasses/legiongoggles,
+/obj/structure/window/reinforced,
+/obj/item/grenade/chem_grenade/teargas,
+/obj/item/grenade/flashbang,
+/obj/machinery/door/window/brigdoor{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "dWZ" = (
 /obj/structure/rack,
@@ -3108,18 +2788,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"dXb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"dXp" = (
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre";
-	req_access_txt = "";
-	req_one_access_txt = ""
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "dXx" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -3169,14 +2837,14 @@
 	},
 /area/f13/bunker)
 "dYn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/workbench/advanced,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "Machine Shop";
+	operating = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
@@ -3185,16 +2853,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
-"dYV" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
 "dZI" = (
 /obj/item/bedsheet/hop{
 	name = "overseer's bedsheet"
@@ -3240,8 +2898,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "edM" = (
-/obj/effect/landmark/start/f13/vaultengineer,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "eee" = (
 /obj/effect/decal/remains/human,
@@ -3280,15 +2943,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
-"egw" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 30
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "ehk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor{
@@ -3297,8 +2951,12 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "ehx" = (
-/obj/machinery/vending/wardrobe/hydro_wardrobe,
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/effect/turf_decal/bot,
+/obj/item/gun/energy/laser/aer9,
+/obj/item/gun/energy/laser/aer9,
+/obj/item/gun/energy/laser/aer9,
+/obj/structure/rack,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "eih" = (
 /obj/item/locked_box/weapon/range/tier3,
@@ -3314,41 +2972,26 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "eiz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "eiF" = (
-/obj/structure/rack,
-/obj/item/clothing/under/f13/vault,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/gloves/color/black,
-/obj/item/storage/belt/security,
-/obj/item/melee/classic_baton/telescopic,
-/obj/item/assembly/flash/handheld,
-/obj/item/restraints/handcuffs,
-/obj/item/gun/ballistic/automatic/pistol/n99,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/clothing/suit/armor/vest,
-/obj/item/clothing/head/helmet/riot/vaultsec,
-/obj/item/clothing/glasses/sunglasses,
-/obj/effect/spawner/lootdrop/armory_contraband,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
-/turf/open/floor/plasteel/dark,
+/obj/structure/table,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 4
+	},
 /area/f13/vault)
 "ejG" = (
 /obj/structure/simple_door/tent,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
 "ekD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/tunnel)
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/vault)
 "ekS" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Impassable Airlock"
@@ -3368,11 +3011,10 @@
 	},
 /area/f13/underground/cave)
 "elo" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
 	},
-/obj/machinery/chem_master/condimaster,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "elN" = (
 /obj/structure/bookcase,
@@ -3383,11 +3025,10 @@
 	},
 /area/f13/bunker)
 "emC" = (
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = -15
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "emN" = (
 /obj/effect/turf_decal/arrows{
@@ -3395,17 +3036,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"enm" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "enq" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/chair/sofa/corp{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "enr" = (
 /obj/machinery/door/poddoor/shutters{
@@ -3418,13 +3053,12 @@
 /area/f13/bunker)
 "enx" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/machinery/door/airlock/highsecurity{
-	name = "Gatehouse";
-	req_access_txt = "1"
+/obj/structure/chair/sofa/corp{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "enC" = (
 /obj/machinery/light/broken,
@@ -3445,22 +3079,30 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "epr" = (
-/obj/structure/table,
-/obj/item/storage/box/gloves{
-	pixel_x = -5;
-	pixel_y = 6
+/obj/structure/closet/cabinet{
+	name = "wardrobe"
 	},
-/obj/item/storage/box/masks{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/item/clothing/suit/bunnysuit,
+/obj/item/clothing/head/bunnyhead,
+/obj/item/clothing/accessory/maidapron,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/organ/ears/cat,
+/obj/item/clothing/head/rabbitears,
+/obj/item/restraints/handcuffs/fake/kinky,
+/obj/item/toy/plush/carrot,
+/obj/item/dildo/random,
+/obj/item/dildo/random,
+/obj/item/clothing/under/misc/bathrobe,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "eql" = (
-/obj/machinery/light{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 8
+	},
 /area/f13/vault)
 "eqx" = (
 /obj/machinery/conveyor{
@@ -3471,10 +3113,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
 "eqF" = (
-/obj/structure/decoration/hatch{
-	dir = 4
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "erm" = (
 /obj/machinery/light{
@@ -3520,17 +3165,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "evR" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"ewu" = (
-/obj/structure/table,
-/obj/item/wrench/power,
-/obj/item/weldingtool/experimental{
-	pixel_x = -27;
-	pixel_y = 2
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Server Room"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "exi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3538,12 +3180,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"exl" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
 "eAb" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -3559,10 +3195,14 @@
 /turf/open/water,
 /area/f13/bunker)
 "eBf" = (
-/obj/effect/turf_decal/box,
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Server Room"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "eBg" = (
 /obj/structure/table/wood,
@@ -3577,9 +3217,15 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "eBU" = (
-/obj/machinery/light,
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 4
+	},
 /area/f13/vault)
 "eDm" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3587,12 +3233,6 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
-"eDn" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "eDt" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/item/stock_parts/cell/ammo/ec,
@@ -3604,30 +3244,15 @@
 	},
 /area/f13/bunker)
 "eDB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/obj/structure/bookcase/random,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "eDF" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/table/reinforced,
+/obj/item/paper_bin/construction,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
-	},
-/obj/structure/sign/poster/official/twelve_gauge{
-	pixel_y = 32
-	},
-/obj/item/clothing/glasses/night,
-/obj/item/clothing/glasses/night,
-/obj/item/clothing/glasses/night,
-/obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
 	},
 /area/f13/vault)
 "eDL" = (
@@ -3659,23 +3284,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"eET" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/closet/crate/science,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"eEX" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
 "eFh" = (
 /obj/structure/window/plastitanium,
 /obj/structure/grille,
@@ -3707,10 +3315,10 @@
 	},
 /area/f13/bunker)
 "eHf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "eHl" = (
 /obj/structure/table/wood,
@@ -3739,15 +3347,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "eJD" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/bed/dogbed,
-/mob/living/simple_animal/pet/dog/pug{
-	desc = "A young pug with a squished face and tiny nostrils. Its breathing sounds heavy and labored.";
-	name = "Otis"
-	},
-/turf/open/floor/carpet/black,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "eKu" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3755,9 +3356,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "eLb" = (
-/obj/effect/turf_decal/box,
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "eLS" = (
 /obj/structure/wreck/trash/two_barrels,
@@ -3766,14 +3368,11 @@
 	},
 /area/f13/bunker)
 "eOH" = (
-/obj/item/am_shielding_container,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
-"eOI" = (
-/obj/machinery/vending/wallmed,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
+/obj/machinery/light/broken{
+	dir = 8;
+	icon_state = "tube-broken"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "eOS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3802,22 +3401,19 @@
 	},
 /area/f13/wasteland)
 "eQq" = (
-/obj/structure/vaultdoor{
-	name = "vault 113 door";
-	pixel_x = -32;
-	pixel_y = -32
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
 "eRf" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/table,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/obj/machinery/aug_manipulator,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 4
+	},
 /area/f13/vault)
 "eRS" = (
 /obj/machinery/chem_dispenser,
@@ -3834,14 +3430,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"eUX" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/wood,
-/area/f13/vault)
-"eVu" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "eWA" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -3851,14 +3439,10 @@
 	},
 /area/f13/bunker)
 "eWF" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -32
+/obj/structure/chair/sofa/corp{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "rampdowntop"
-	},
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "eXq" = (
 /obj/item/radio/intercom{
@@ -3883,8 +3467,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "eYz" = (
-/obj/machinery/rnd/server/vault,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/door/airlock/mining{
+	name = "Casp Bay"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "eZa" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -3901,20 +3490,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"eZw" = (
-/obj/machinery/smartfridge/bottlerack,
-/turf/open/floor/wood,
-/area/f13/vault)
 "eZF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
-"eZM" = (
-/obj/machinery/door/airlock/maintenance/abandoned,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
 "fac" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -3931,10 +3512,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "faZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/item/pen/fourcolor,
+/obj/item/paper_bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "fbm" = (
 /obj/structure/chair/bench,
@@ -3942,25 +3526,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "fbt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/vault)
-"fcb" = (
-/obj/structure/table/wood,
-/obj/item/storage/book,
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "fcq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "fcG" = (
 /obj/item/radio/intercom{
@@ -3992,25 +3567,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
-"fdI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/vault)
-"fdN" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "fdZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
@@ -4029,10 +3585,10 @@
 	},
 /area/f13/bunker)
 "feS" = (
-/obj/structure/chair/middle{
+/obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "ffD" = (
 /obj/structure/window/plastitanium,
@@ -4040,22 +3596,10 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "ffQ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/goonplaque{
-	desc = "This is a plaque detailing and honoring the corporate dollars lost creating the vault. All craftsmanship is of the highest quality. The Business men are laughing. The Workers are crying. It menaces with spikes of gold."
-	},
-/area/f13/vault)
-"fgs" = (
-/obj/effect/turf_decal/arrows{
+/obj/structure/chair/sofa/corp/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/vault)
-"fgt" = (
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "fhn" = (
 /obj/effect/decal/cleanable/blood,
@@ -4063,12 +3607,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "fhA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
+/obj/structure/sign/warning/radiation/rad_area,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
 "fiq" = (
 /obj/effect/turf_decal/box,
@@ -4077,36 +3619,26 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "fiJ" = (
-/obj/machinery/light{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/button/door{
-	id = 103;
-	name = "Blast Doors";
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
 "fjt" = (
-/obj/machinery/vending/wardrobe/jani_wardrobe,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/vault)
-"fjH" = (
-/obj/machinery/light{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/vault)
+"fjH" = (
+/obj/machinery/rnd/server/vault,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
 "fjN" = (
-/obj/effect/turf_decal/weather/snow/corner{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "fke" = (
 /obj/structure/chair/stool,
@@ -4129,22 +3661,11 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/bar,
 /area/f13/bunker)
-"fky" = (
-/obj/structure/chair/booth{
-	dir = 8
-	},
-/obj/effect/landmark/start/f13/vaultdweller,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "fkA" = (
-/obj/machinery/door/airlock/security{
-	name = "Brig";
-	req_access_txt = "1"
-	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "fkT" = (
 /obj/structure/table/wood,
@@ -4192,8 +3713,11 @@
 	},
 /area/f13/bunker)
 "fpn" = (
-/obj/machinery/vending/wardrobe/law_wardrobe,
-/turf/open/floor/wood,
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
 "fpy" = (
 /obj/structure/stone_tile/surrounding,
@@ -4253,14 +3777,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"fuq" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "fuP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/storage/trash_stack,
@@ -4278,22 +3794,21 @@
 	},
 /area/f13/bunker)
 "fvZ" = (
-/obj/structure/sign/departments/custodian,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "fwb" = (
 /mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
-"fwu" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "fwO" = (
 /obj/item/ammo_casing/c9mm,
 /obj/machinery/door/poddoor{
@@ -4320,17 +3835,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
-"fyg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "fyx" = (
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
@@ -4351,10 +3855,10 @@
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
 "fyM" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
 "fzh" = (
 /obj/structure/table,
@@ -4374,25 +3878,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"fzF" = (
-/obj/structure/flora/ausbushes/palebush{
-	pixel_x = 9
-	},
-/obj/structure/flora/ausbushes/stalkybush,
-/obj/structure/flora/ausbushes/lavendergrass{
-	pixel_x = 20
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	pixel_x = -3
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_x = 9;
-	pixel_y = -2
-	},
-/turf/open/floor/f13{
-	icon_state = "grass2"
-	},
-/area/f13/vault)
 "fBZ" = (
 /obj/effect/decal/cleanable/glass/plasma,
 /turf/open/floor/carpet/green,
@@ -4402,13 +3887,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/f13/underground/cave)
-"fDJ" = (
-/obj/machinery/door/airlock/maintenance/abandoned,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
 "fEC" = (
 /obj/structure/rack,
 /obj/item/crafting/buzzer,
@@ -4430,25 +3908,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
-"fGz" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/f13/vaultdoctor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "fGA" = (
-/obj/structure/bookcase/manuals/engineering,
-/obj/structure/window/reinforced/tinted,
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/vault)
-"fHg" = (
 /obj/structure/table,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 6
+	},
 /area/f13/vault)
 "fHk" = (
 /obj/effect/turf_decal/arrows{
@@ -4467,13 +3935,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "fIu" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
-	},
+/obj/item/circuitboard/machine/smes,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "fIF" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4487,34 +3950,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"fJp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/vault)
-"fJN" = (
-/obj/machinery/holopad,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/vault)
-"fKi" = (
-/obj/structure/weightlifter,
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "fKv" = (
 /obj/item/ammo_casing/c9mm,
 /obj/effect/decal/cleanable/dirt,
@@ -4558,22 +3993,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "fNo" = (
-/obj/structure/flora/ausbushes/stalkybush,
-/obj/structure/flora/ausbushes/lavendergrass{
-	pixel_x = -4
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	pixel_y = -3
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_x = -6
-	},
-/obj/structure/flora/ausbushes/genericbush{
-	pixel_x = -17
-	},
-/turf/open/floor/f13{
-	icon_state = "grass2"
-	},
+/obj/structure/bookcase/manuals/engineering,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "fNR" = (
 /obj/structure/flora/stump,
@@ -4594,10 +4015,11 @@
 	},
 /area/f13/wasteland)
 "fPm" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetbrown"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "fPC" = (
 /obj/structure/barricade/wooden,
@@ -4605,7 +4027,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
 "fPP" = (
-/turf/open/floor/carpet/black,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "fQU" = (
 /obj/structure/closet/wardrobe,
@@ -4633,11 +4061,11 @@
 	},
 /area/f13/bunker)
 "fTs" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 6
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "fTP" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
@@ -4649,10 +4077,13 @@
 	},
 /area/f13/underground/cave)
 "fTR" = (
-/obj/structure/chair/left{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "fUg" = (
 /obj/structure/table,
@@ -4679,12 +4110,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"fWM" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
 "fYc" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin,
 /turf/open/floor/carpet/green,
@@ -4707,23 +4132,15 @@
 	},
 /area/f13/bunker)
 "fYo" = (
-/obj/structure/sign/barsign,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "fYO" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/water,
 /area/f13/bunker)
-"fYY" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/table,
-/obj/item/book/granter/trait/pa_wear,
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "fYZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4739,12 +4156,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/bunker)
 "fZC" = (
-/obj/structure/flora/ausbushes/sparsegrass{
-	pixel_x = 20;
-	pixel_y = 3
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/vault)
 "fZK" = (
 /obj/structure/table/abductor{
 	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
@@ -4772,19 +4189,6 @@
 /mob/living/simple_animal/hostile/raider/baseball,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"gdh" = (
-/obj/structure/flora/ausbushes/stalkybush,
-/obj/structure/flora/ausbushes/lavendergrass{
-	pixel_y = 2
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	pixel_x = 17
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/f13{
-	icon_state = "grass2"
-	},
-/area/f13/vault)
 "gdj" = (
 /obj/machinery/shower{
 	dir = 8
@@ -4794,8 +4198,13 @@
 	},
 /area/f13/bunker)
 "geI" = (
-/obj/machinery/computer/cargo,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fence/wooden{
+	dir = 1;
+	icon_state = "post_wood"
+	},
+/turf/open/floor/grass,
 /area/f13/vault)
 "geY" = (
 /obj/structure/stone_tile/cracked,
@@ -4837,12 +4246,13 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "ggN" = (
-/obj/machinery/light,
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/machinery/disposal/deliveryChute{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "ggY" = (
 /obj/structure/decoration/rag{
@@ -4851,9 +4261,12 @@
 /turf/closed/wall/f13/tentwall,
 /area/f13/bunker)
 "ghE" = (
-/turf/open/floor/plasteel/caution{
-	dir = 4
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "Vault Disposals";
+	operating = 1
 	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "ghW" = (
 /obj/structure/closet/wardrobe,
@@ -4863,10 +4276,6 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
-"gia" = (
-/obj/structure/reagent_dispensers/barrel,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "gii" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
@@ -4876,30 +4285,27 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "giH" = (
-/obj/machinery/washing_machine,
-/obj/item/clothing/under/sundress,
-/obj/item/clothing/under/sundress,
-/obj/item/clothing/under/suit_jacket,
-/obj/item/clothing/under/suit_jacket,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/vault)
-"giK" = (
-/obj/structure/flora/ausbushes/sparsegrass{
-	pixel_x = 23;
-	pixel_y = -1
-	},
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"gjf" = (
-/obj/structure/bookcase/random,
-/obj/structure/window/reinforced/tinted{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
-/turf/open/floor/f13/wood,
+/area/f13/vault)
+"giK" = (
+/obj/machinery/recycler,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "Vault Disposals";
+	operating = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/vault)
+"gjf" = (
+/obj/machinery/light,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "Vault Disposals";
+	operating = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "gjI" = (
 /obj/machinery/door/airlock/hatch,
@@ -4908,17 +4314,14 @@
 	},
 /area/f13/bunker)
 "gkf" = (
-/obj/machinery/door/window/brigdoor/security/cell/northleft{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
+/obj/item/wrench,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "gkv" = (
-/obj/machinery/door/airlock/security{
-	name = "Barracks";
-	req_access_txt = "1"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "glz" = (
 /obj/structure/chair/f13chair2{
@@ -4932,13 +4335,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
-"glT" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/effect/landmark/start/f13/vaultheadofsecurity,
-/turf/open/floor/carpet/black,
-/area/f13/vault)
 "glY" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -4952,10 +4348,13 @@
 	},
 /area/f13/bunker)
 "gmz" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 5
+/obj/structure/table,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "gnh" = (
@@ -4982,16 +4381,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "gog" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
-"goo" = (
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/wood/f13/oak,
+/area/f13/vault)
+"goo" = (
+/obj/machinery/door/airlock/science/glass{
+	name = "Science";
+	req_access_txt = "31"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
 "gor" = (
 /obj/structure/chair{
@@ -5044,13 +4444,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"grL" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner{
-	pixel_y = 6
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
 "grM" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/gloves/fingerless,
@@ -5058,21 +4451,9 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"grW" = (
-/obj/machinery/computer/card{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
-/area/f13/vault)
 "grY" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
-	},
-/obj/structure/rack,
-/obj/item/storage/box/PDAs,
-/turf/open/floor/carpet/black,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
 /area/f13/vault)
 "gsH" = (
 /obj/item/storage/trash_stack,
@@ -5103,10 +4484,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "gts" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/landmark/start/f13/vaultdweller,
+/obj/machinery/door/airlock/mining{
+	name = "Mining Equipment"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "gun" = (
@@ -5132,17 +4515,27 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "gvo" = (
-/obj/structure/closet/crate/wooden,
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/machinery/door/airlock/science/glass{
+	name = "Science";
+	req_access_txt = "31"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
 "gvL" = (
-/obj/structure/table/reinforced,
-/obj/item/paper/guides/jobs/engi/solars{
-	info = "<h1>Welcome</h1><p>At Vault-Tec, your survival is our number one priority, enclosed within is a notice on your Casp System.</p><p>Thank you for joining in Vault-Tec's mandatory testing of the brand new C.A.S.P. system! The CASP, or Computerized Auto-Synthesis Protofabricator, is a new high tech design using a simple 'points' system to create anything you need! Simply feed the requested high priority items orany day to day crates and metals to synthesize points.</p><p>That's all there is to it!</p>";
-	name = "paper- 'Your very first C.A.S.P. system!'"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/stamp/qm,
-/turf/open/floor/plasteel/neutral,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "gwd" = (
 /turf/open/floor/f13/wood{
@@ -5207,12 +4600,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "gyP" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_y = -30
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "gzH" = (
 /obj/machinery/door/unpowered/wooddoor,
@@ -5223,10 +4617,11 @@
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
 "gAH" = (
-/obj/machinery/computer/security{
-	network = list("vault")
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/turf/open/floor/grass,
 /area/f13/vault)
 "gAQ" = (
 /obj/structure/table/reinforced,
@@ -5236,27 +4631,22 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"gAT" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/table/booth,
-/obj/item/reagent_containers/food/snacks/waffles{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "gAV" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin/construction,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Disposals"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "gBg" = (
-/obj/machinery/computer/crew,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "gBm" = (
 /obj/structure/table,
@@ -5264,12 +4654,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "gBD" = (
-/obj/machinery/vending/wallmed{
-	pixel_x = -30
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "gBL" = (
 /obj/machinery/status_display{
@@ -5282,15 +4673,6 @@
 /obj/machinery/biogenerator,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"gBW" = (
-/obj/effect/turf_decal/box,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
-/obj/structure/closet/crate/wooden,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "gBX" = (
 /obj/structure/weightlifter,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -5300,42 +4682,12 @@
 /obj/structure/stone_tile/surrounding/cracked,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"gCv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
-"gCQ" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/f13{
-	icon_state = "grass2"
-	},
-/area/f13/vault)
-"gDy" = (
-/obj/effect/turf_decal/box,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/obj/structure/closet/crate/wooden,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "gDI" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor{
-	dir = 4
+/obj/machinery/light/broken{
+	dir = 4;
+	icon_state = "tube-broken"
 	},
-/obj/item/stamp,
-/obj/item/stamp/denied,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "gDW" = (
 /mob/living/simple_animal/hostile/handy/protectron,
@@ -5367,10 +4719,6 @@
 /mob/living/simple_animal/hostile/raider/tribal,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"gGe" = (
-/obj/item/twohanded/required/kirbyplants/dead,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "gGY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/ladder/unbreakable{
@@ -5397,27 +4745,19 @@
 	},
 /area/f13/bunker)
 "gHu" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "gHO" = (
 /obj/structure/mirror,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
-"gIc" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
-/area/f13/vault)
 "gIv" = (
-/obj/structure/table,
-/obj/item/kitchen/knife{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/dresser,
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "gJi" = (
 /obj/structure/bookcase/random,
@@ -5426,11 +4766,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "gJk" = (
-/obj/machinery/door/airlock/wood{
-	id_tag = "vaultd1";
-	name = "Dorm 1"
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/obj/machinery/vending/robotics,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 9
+	},
 /area/f13/vault)
 "gKr" = (
 /turf/closed/wall/f13/supermart,
@@ -5446,38 +4788,23 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
-"gLi" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
 "gLD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/arrows{
-	dir = 8;
-	pixel_x = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/tunnel)
-"gLW" = (
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre";
-	req_access_txt = "45; 5"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/item/bedsheet/ce,
+/obj/effect/landmark/start/f13/vaultengineer,
+/obj/structure/bed,
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "gLY" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/yellow,
-/obj/item/folder/yellow,
-/obj/item/folder/yellow,
-/obj/item/paper_bin,
-/obj/item/stamp,
-/obj/item/stamp/denied,
-/turf/open/floor/plasteel/neutral,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "gMi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5493,12 +4820,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"gNy" = (
-/obj/structure/sign/departments/security,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
 "gOF" = (
 /obj/effect/turf_decal/delivery,
 /obj/item/soap/deluxe,
@@ -5513,33 +4834,12 @@
 	},
 /area/f13/wasteland)
 "gPM" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/medspray{
-	pixel_x = -9;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/medspray{
-	pixel_x = -6;
-	pixel_y = 1
-	},
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = 30
-	},
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = 6;
-	pixel_y = 10
-	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "gPT" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/f13{
-	icon_state = "grass2"
-	},
+/obj/structure/bookcase/manuals,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "gQm" = (
 /obj/effect/decal/remains/human,
@@ -5548,23 +4848,19 @@
 	},
 /area/f13/bunker)
 "gQo" = (
-/obj/structure/filingcabinet/chestdrawer/wheeled,
-/turf/open/floor/carpet/black,
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access_txt = "1"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "gQK" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"gRF" = (
-/obj/machinery/door/airlock/command{
-	name = "Bot Control";
-	req_access_txt = "19"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
-/area/f13/vault)
 "gRT" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /mob/living/simple_animal/hostile/handy/securitron,
@@ -5576,10 +4872,6 @@
 	},
 /turf/open/floor/pod,
 /area/f13/underground/cave)
-"gSY" = (
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "gTc" = (
 /obj/structure/stone_tile/block/burnt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5596,8 +4888,16 @@
 	},
 /area/f13/bunker)
 "gUw" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "gUA" = (
 /obj/item/ammo_box/c9mm,
@@ -5618,10 +4918,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"gVz" = (
-/obj/machinery/light/small,
-/turf/open/floor/wood,
-/area/f13/vault)
 "gVC" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
@@ -5629,37 +4925,29 @@
 	},
 /area/f13/bunker)
 "gWz" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "gXl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "gYe" = (
-/obj/machinery/camera/autoname{
-	dir = 10;
-	network = list("Vault")
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_y = -32
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/chair/f13foldupchair{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
 "gYw" = (
 /obj/structure/flora/junglebush/large,
@@ -5714,18 +5002,13 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "hbE" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
-"hbL" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/item/clothing/neck/stethoscope,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
 "hbP" = (
 /obj/machinery/light/broken{
@@ -5750,13 +5033,10 @@
 	},
 /area/f13/bunker)
 "hcp" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
 "hcu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5824,10 +5104,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "hhp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/table,
+/obj/item/wrench/power,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
 "hiH" = (
 /obj/effect/decal/fakelattice,
@@ -5837,18 +5116,20 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
 "hiL" = (
-/obj/machinery/light/small,
-/turf/open/floor/mineral/plastitanium,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "hiN" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/caution{
-	dir = 1
-	},
+/obj/structure/table,
+/obj/item/stack/cable_coil/red,
+/obj/item/crowbar/power,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
 "hkd" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/vault)
 "hkv" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -5887,15 +5168,7 @@
 	},
 /area/f13/underground/cave)
 "hmE" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/mug/coco{
-	pixel_y = 5
-	},
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_y = -32
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "hnk" = (
@@ -5907,18 +5180,6 @@
 "hns" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/underground/cave)
-"hnN" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/grown/apple/gold{
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/item/clothing/mask/cigarette/cigar{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/vault)
 "hnU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -5953,11 +5214,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "hpf" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
+/obj/structure/sign/warning/securearea,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/tunnel)
 "hpr" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/combat/sneakboots{
@@ -5982,11 +5241,8 @@
 	},
 /area/f13/bunker)
 "hpM" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
 "hpQ" = (
 /obj/structure/chair/f13chair1{
@@ -6038,14 +5294,8 @@
 	},
 /area/f13/underground/cave)
 "hrW" = (
-/obj/effect/turf_decal/bot,
-/obj/item/gun/energy/laser/aer9,
-/obj/item/gun/energy/laser/aer9,
-/obj/item/gun/energy/laser/aer9,
-/obj/structure/rack,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/grass,
 /area/f13/vault)
 "hsQ" = (
 /obj/effect/decal/cleanable/glass,
@@ -6069,16 +5319,14 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "huM" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/shaker{
-	pixel_x = 1;
-	pixel_y = 3
-	},
-/turf/open/floor/wood,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
 "hvB" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
 "hwI" = (
 /obj/machinery/conveyor{
@@ -6086,22 +5334,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
-"hwO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "hxr" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "hxx" = (
-/mob/living/simple_animal/hostile/venus_human_trap,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/machinery/door/airlock/engineering,
+/turf/open/floor/carpet/black,
+/area/f13/vault)
 "hxE" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -6111,11 +5350,8 @@
 	},
 /area/f13/bunker)
 "hys" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
 "hzt" = (
 /obj/effect/decal/remains/human,
@@ -6123,7 +5359,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "hzJ" = (
-/turf/open/floor/plasteel/floorgrime,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "hAQ" = (
 /obj/item/ammo_casing/c9mm,
@@ -6148,32 +5387,44 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "hBK" = (
-/obj/structure/bookcase,
-/obj/structure/window/reinforced/tinted,
-/obj/structure/window/reinforced/tinted{
-	dir = 4
+/obj/machinery/light{
+	light_color = "#e8eaff"
 	},
-/turf/open/floor/f13/wood,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
 "hBO" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plating/tunnel,
-/area/f13/tunnel)
+/obj/structure/cable,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/vault)
 "hCj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/light{
+	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/arrows{
-	dir = 8;
-	pixel_x = 8
+/obj/machinery/button/door{
+	id = "Vault Gas Storage";
+	name = "Gas Storage";
+	pixel_y = -26
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/tunnel)
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/vault)
 "hCt" = (
-/obj/structure/decoration/hatch{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/am_shielding_container,
+/obj/item/am_shielding_container,
+/obj/item/am_shielding_container,
+/obj/item/am_shielding_container,
+/obj/item/am_shielding_container,
+/obj/item/am_shielding_container,
+/obj/item/am_shielding_container,
+/obj/item/am_shielding_container,
+/obj/item/am_shielding_container,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
 "hDa" = (
 /obj/structure/simple_door/house{
@@ -6230,10 +5481,8 @@
 /turf/open/floor/plasteel/dark/side,
 /area/f13/bunker)
 "hHq" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/grass,
 /area/f13/vault)
 "hHu" = (
 /obj/structure/decoration/clock/active,
@@ -6263,11 +5512,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"hJD" = (
-/obj/item/bedsheet/hos,
-/obj/structure/bed/old,
-/turf/open/floor/carpet/black,
-/area/f13/vault)
 "hJW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
@@ -6286,10 +5530,23 @@
 	},
 /area/f13/bunker)
 "hKr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/rack,
+/obj/item/clothing/under/f13/vault,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/gloves/color/black,
+/obj/item/storage/belt/security,
+/obj/item/melee/classic_baton/telescopic,
+/obj/item/assembly/flash/handheld,
+/obj/item/restraints/handcuffs,
+/obj/item/gun/ballistic/automatic/pistol/n99,
+/obj/item/ammo_box/magazine/m10mm_adv/simple,
+/obj/item/ammo_box/magazine/m10mm_adv/simple,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/head/helmet/riot/vaultsec,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "hLm" = (
 /obj/structure/rack,
@@ -6338,28 +5595,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "hQl" = (
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/obj/item/ammo_box/c10mm/jhp,
-/obj/item/ammo_box/c10mm/jhp,
-/obj/item/ammo_box/c10mm/jhp,
-/obj/item/ammo_box/c10mm/jhp,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 10
-	},
+/turf/open/floor/grass,
 /area/f13/vault)
 "hQR" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/statue/sandstone/gravestone{
+	anchored = 1;
+	desc = "An old marble gravestone, all you can make out from the text is 'Here lies Overseer Hodd Toward, murdered by his own people'.";
+	pixel_y = 15
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/dirt,
 /area/f13/vault)
 "hRL" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -6393,24 +5642,18 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "hUS" = (
-/obj/structure/urinal{
-	pixel_y = 32
+/obj/structure/chair/office/light{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "hVK" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "hWj" = (
-/obj/machinery/door/airlock/security{
-	name = "Brig";
-	req_access_txt = "1"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "hXi" = (
 /obj/structure/closet/crate/bin,
@@ -6437,47 +5680,28 @@
 /mob/living/simple_animal/hostile/raider/ranged/sulphiteranged,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"hYq" = (
-/obj/structure/closet/fridge{
-	anchored = 1
-	},
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/rice,
-/turf/open/floor/plasteel/cafeteria,
-/area/f13/vault)
 "hZN" = (
-/turf/open/floor/plasteel/caution{
-	dir = 5
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/fence/wooden{
+	dir = 1;
+	icon_state = "post_wood"
 	},
+/turf/open/floor/grass,
 /area/f13/vault)
 "iaE" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/mug/tea{
-	pixel_x = -7;
-	pixel_y = 1
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/item/reagent_containers/food/drinks/mug/tea{
-	pixel_x = 8;
-	pixel_y = 9
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 4
 	},
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "iba" = (
-/obj/machinery/door/airlock/maintenance/abandoned,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/barricade/wooden,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table/wood,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "ibz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6494,28 +5718,9 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
-"icB" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/mob/living/simple_animal/parrot{
-	desc = "The mandatory Vault-tec animal protection foundation parrot. This one will not stop talking, much to your dismay.";
-	name = "Crackers"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/vault)
 "icJ" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_y = -30
-	},
-/turf/open/floor/carpet/black,
-/area/f13/vault)
-"icY" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/machinery/microwave/stove,
+/turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
 "idi" = (
 /obj/effect/decal/remains/human,
@@ -6536,9 +5741,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
-"ieI" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
 "ieZ" = (
 /obj/machinery/status_display{
 	desc = "A large glass display, used to show various types of information.";
@@ -6546,11 +5748,6 @@
 	},
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
-"ifg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
 "ifN" = (
 /obj/structure/rack,
 /obj/item/storage/backpack/security,
@@ -6564,14 +5761,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "igB" = (
-/turf/open/floor/mineral/plastitanium,
-/area/f13/vault)
-"igH" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/window/reinforced,
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "igV" = (
 /obj/effect/turf_decal/arrows{
@@ -6583,26 +5775,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "ihv" = (
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/turf/open/floor/plasteel/darkpurple/side,
+/turf/open/floor/plasteel/neutral,
 /area/f13/vault)
 "iiQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6644,10 +5817,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "imP" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/item/flashlight/lamp/green,
-/turf/open/floor/f13/wood,
+/obj/machinery/deepfryer,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
 "ina" = (
 /obj/item/gun/energy/laser/aer9,
@@ -6678,14 +5852,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
 "ipO" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/machinery/light/small{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/start/f13/vaultdweller,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "iqx" = (
 /obj/item/pickaxe,
@@ -6696,19 +5866,20 @@
 /turf/open/water,
 /area/f13/bunker)
 "irT" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/vault)
-"isM" = (
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/vault)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "itA" = (
-/obj/item/bedsheet/black,
-/obj/effect/landmark/start/f13/vaultsecurityofficer,
-/obj/structure/bed/old,
-/turf/open/floor/carpet/black,
+/obj/machinery/door/poddoor/shutters{
+	air_tight = 1;
+	id = "Vault Gas Storage";
+	name = "Gas Storage"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "itU" = (
 /obj/structure/table/wood,
@@ -6726,10 +5897,10 @@
 	},
 /area/f13/underground/cave)
 "iuD" = (
-/obj/structure/sign/departments/science,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "ivn" = (
 /obj/structure/rack,
@@ -6762,22 +5933,17 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
-"ivy" = (
-/obj/machinery/vending/clothing,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/vault)
 "ivA" = (
-/obj/effect/turf_decal/caution{
-	dir = 4
+/obj/machinery/workbench/advanced,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "Machine Shop";
+	operating = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"ivB" = (
-/obj/machinery/door/airlock/wood{
-	id_tag = "vaultd4";
-	name = "Dorm 4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
 "ivG" = (
 /obj/structure/table/wood/bar,
@@ -6787,30 +5953,29 @@
 	},
 /area/f13/bunker)
 "iwF" = (
-/obj/machinery/vending/wallmed{
-	pixel_x = 30
-	},
+/obj/structure/table,
+/obj/item/weldingtool/experimental,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
 "ixG" = (
-/obj/structure/chair{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/head/peaceflower{
+	name = "Flower bud";
+	pixel_y = 16
 	},
-/obj/effect/landmark/start/f13/vaultsecurityofficer,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/turf/open/floor/plating/dirt,
 /area/f13/vault)
 "ixW" = (
 /obj/structure/stacklifter,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "iyf" = (
-/obj/machinery/computer/robotics{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 8
+	},
 /area/f13/vault)
 "iyz" = (
 /obj/structure/rack,
@@ -6838,11 +6003,13 @@
 	},
 /area/f13/wasteland)
 "iAZ" = (
-/obj/machinery/door_timer{
-	id = "vaultc1";
-	pixel_y = 32
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
 /area/f13/vault)
 "iBu" = (
 /obj/structure/barricade/wooden/planks/pregame,
@@ -6864,8 +6031,10 @@
 /turf/open/floor/plasteel/bar,
 /area/f13/bunker)
 "iDb" = (
-/obj/structure/rack,
-/turf/open/floor/carpet/black,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/grass,
 /area/f13/vault)
 "iDp" = (
 /turf/open/floor/wood/f13/stage_br,
@@ -6883,15 +6052,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "iEF" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 5;
-	height = 7;
-	id = "supply_home";
-	name = "Cargo Bay";
-	width = 12
-	},
-/turf/open/floor/plasteel/elevatorshaft,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "iFk" = (
 /obj/machinery/portable_atmospherics/canister,
@@ -6915,10 +6077,8 @@
 	},
 /area/f13/wasteland)
 "iGj" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "iGR" = (
 /mob/living/simple_animal/hostile/cazador/young,
@@ -6930,29 +6090,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
-"iHk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/f13,
-/area/f13/vault)
-"iHy" = (
-/obj/effect/turf_decal/caution{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/vault)
 "iId" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/item/stock_parts/cell/ammo/ec,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "iJa" = (
-/obj/effect/turf_decal/arrows{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "iJg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6981,10 +6126,13 @@
 	},
 /area/f13/bunker)
 "iJz" = (
-/obj/structure/window/reinforced{
+/obj/machinery/computer/arcade,
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
+	},
 /area/f13/vault)
 "iJV" = (
 /obj/structure/table/reinforced,
@@ -7007,8 +6155,10 @@
 	},
 /area/f13/bunker)
 "iKK" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "iKL" = (
 /obj/structure/simple_door/room,
@@ -7037,11 +6187,9 @@
 	},
 /area/f13/bunker)
 "iOq" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/item/multitool/uplink,
-/turf/open/floor/plasteel,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "iOE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7065,10 +6213,6 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
-"iQu" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
 "iRe" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/f13{
@@ -7085,12 +6229,9 @@
 	},
 /area/f13/bunker)
 "iSF" = (
-/obj/machinery/status_display/supply{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
-	},
+/obj/machinery/autolathe,
+/obj/item/stack/sheet/plasteel/twenty,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "iTm" = (
 /obj/effect/decal/cleanable/dirt{
@@ -7104,35 +6245,25 @@
 /turf/closed/indestructible/riveted,
 /area/f13/tcoms)
 "iTR" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/caution{
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
+/turf/open/floor/grass,
 /area/f13/vault)
 "iVn" = (
-/obj/structure/flora/ausbushes/sparsegrass{
-	pixel_x = 6;
-	pixel_y = -8
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"iVH" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
-	},
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder/constructed,
+/turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
-"iWv" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
+"iVH" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "iWw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7148,8 +6279,13 @@
 	},
 /area/f13/bunker)
 "iXy" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "iXL" = (
 /turf/open/indestructible/ground/outside/road{
@@ -7160,26 +6296,15 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/water,
 /area/f13/bunker)
-"iYd" = (
-/obj/structure/table,
-/obj/item/pen/fountain,
-/obj/item/pda/lawyer,
-/obj/item/clothing/accessory/lawyers_badge,
-/obj/item/storage/briefcase/lawyer,
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
 "iYZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad"
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "iZa" = (
 /obj/machinery/light/sign,
@@ -7196,20 +6321,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/bunker)
-"jaY" = (
-/obj/machinery/smartfridge/food,
-/turf/open/floor/plasteel/cafeteria,
-/area/f13/vault)
-"jbc" = (
-/obj/structure/rack,
-/obj/machinery/button/door{
-	id = "vaultd3";
-	normaldoorcontrol = 1;
-	pixel_x = 26;
-	specialfunctions = 4
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
 "jbJ" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/f13/wood{
@@ -7274,7 +6385,10 @@
 	},
 /area/f13/underground/cave)
 "jef" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -7300,14 +6414,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
 "jip" = (
-/obj/structure/rack,
-/obj/machinery/button/door{
-	id = "vaultd1";
-	normaldoorcontrol = 1;
-	pixel_x = 26;
-	specialfunctions = 4
-	},
-/turf/open/floor/wood,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "jit" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7436,30 +6544,8 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"jvp" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad"
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/vault)
 "jvs" = (
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	icon_state = "rightsecure"
-	},
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"jvO" = (
-/obj/structure/bedsheetbin,
-/obj/structure/table,
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "jvS" = (
@@ -7476,8 +6562,11 @@
 /turf/open/floor/pod,
 /area/f13/underground/cave)
 "jwW" = (
-/obj/item/wrench,
-/turf/open/floor/plasteel,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/lattice,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/vault)
 "jxu" = (
 /obj/structure/reagent_dispensers/barrel/three,
@@ -7503,8 +6592,8 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "jyl" = (
-/obj/structure/dresser,
-/turf/open/floor/wood,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
 /area/f13/vault)
 "jzG" = (
 /obj/structure/closet/wardrobe,
@@ -7512,14 +6601,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "jAa" = (
-/obj/machinery/vending/medical,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
-"jBD" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/fence/corner/wooden,
+/obj/structure/fence/wooden{
+	dir = 1;
+	icon_state = "post_wood"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/turf/open/floor/grass,
 /area/f13/vault)
 "jBI" = (
 /obj/structure/closet/crate{
@@ -7557,20 +6644,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "jDJ" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/chair/comfy/brown{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "jDL" = (
 /obj/structure/table/reinforced,
@@ -7608,8 +6685,10 @@
 /turf/closed/wall/f13/wood,
 /area/f13/underground/cave)
 "jGA" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/chair/sofa/corp,
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
+	},
 /area/f13/vault)
 "jHA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7624,13 +6703,10 @@
 	},
 /area/f13/bunker)
 "jIZ" = (
-/obj/structure/table,
-/obj/item/kitchen/knife/butcher,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/obj/structure/chair/sofa/corp/left,
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
 	},
-/turf/open/floor/plasteel/floorgrime,
 /area/f13/vault)
 "jJI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7657,8 +6733,10 @@
 	},
 /area/f13/tunnel)
 "jMv" = (
-/obj/machinery/vending/sovietsoda,
-/turf/open/floor/f13/wood,
+/obj/structure/chair/sofa/corp/right,
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
+	},
 /area/f13/vault)
 "jNm" = (
 /obj/effect/decal/cleanable/robot_debris/old{
@@ -7699,11 +6777,12 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "jPB" = (
-/obj/structure/sign/poster/official/build{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/caution{
+/obj/structure/chair/sofa/corp/left,
+/obj/machinery/light{
 	dir = 4
+	},
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
 	},
 /area/f13/vault)
 "jPG" = (
@@ -7724,45 +6803,47 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "jPN" = (
-/obj/structure/closet/crate/bin,
+/obj/machinery/conveyor/inverted{
+	dir = 8;
+	id = "garbage"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/status_display/supply{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/area/f13/vault)
+"jPS" = (
+/obj/machinery/aug_manipulator,
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"jPS" = (
-/obj/machinery/holopad,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "jPX" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"jQh" = (
-/obj/machinery/conveyor{
-	dir = 9;
-	id = "garbage"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/fence/handrail{
-	dir = 4;
-	pixel_x = -15
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "jQj" = (
-/turf/open/floor/plasteel/yellow/side{
-	dir = 4
+/obj/machinery/button/door{
+	id = "Vault Room 4";
+	name = "Door Lock";
+	normaldoorcontrol = 1;
+	pixel_x = -28;
+	specialfunctions = 4
 	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "jQF" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/neutral,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "jQJ" = (
 /obj/structure/wreck/trash/machinepile,
@@ -7776,18 +6857,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"jRl" = (
-/obj/machinery/conveyor/inverted{
-	dir = 8;
-	id = "garbage"
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "jRr" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/carpet/green,
@@ -7823,12 +6892,17 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
 "jVD" = (
-/obj/structure/decoration/vent,
-/obj/structure/curtain,
-/obj/machinery/shower{
-	pixel_y = 27
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "jWl" = (
 /obj/structure/table,
@@ -7837,16 +6911,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "jWr" = (
-/obj/item/clothing/neck/cloak/hop,
-/obj/item/clothing/neck/cloak/cmo,
-/obj/structure/closet,
-/obj/item/instrument/violin/golden,
-/obj/item/reagent_containers/food/drinks/flask/gold{
-	desc = "A gold flask belonging to a the Overseer of Vault 133.";
-	name = "Overseer's flask"
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_cannabis,
-/turf/open/floor/carpet/black,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/floor/grass,
 /area/f13/vault)
 "jWN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7866,17 +6932,15 @@
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"kaB" = (
-/obj/machinery/computer/security{
-	network = list("vault")
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "kaO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "kaY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7898,20 +6962,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"kbq" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 16
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
-"kbR" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "kbS" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
@@ -7920,8 +6970,15 @@
 	},
 /area/f13/underground/cave)
 "kcm" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Crematorium"
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
@@ -7958,34 +7015,34 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "keC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/door/airlock/science/glass{
+	name = "Machine Shop";
+	req_access_txt = "31"
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "rampdowntop"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/f13/tunnel)
-"kfq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
-"kfJ" = (
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/vault)
+"kfq" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/machinery/computer/crew{
+	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"kgh" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
+"kfJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/closet/secure_closet/freezer/meat{
-	anchored = 1
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/item/reagent_containers/food/snacks/meat/slab/monkey,
-/obj/item/reagent_containers/food/snacks/meat/slab/monkey,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "kgo" = (
 /obj/item/trash/f13/cram,
@@ -8011,17 +7068,6 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/underground/cave)
-"kjM" = (
-/obj/machinery/conveyor/inverted,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/fence/handrail{
-	dir = 4;
-	pixel_x = -15
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "kkd" = (
 /obj/machinery/mineral/processing_unit,
 /turf/open/floor/f13/wood,
@@ -8038,11 +7084,17 @@
 	},
 /area/f13/bunker)
 "kkF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "rampdowntop"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/f13/tunnel)
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/vault)
 "kle" = (
 /obj/machinery/light{
 	dir = 1
@@ -8062,16 +7114,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "kml" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/table,
+/obj/item/integrated_circuit_printer,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/status_display/supply,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"kmR" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/carpet/black,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "kne" = (
 /obj/structure/closet/fridge,
@@ -8098,18 +7146,9 @@
 /turf/closed/indestructible/rock,
 /area/f13/bunker)
 "kol" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 16
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/vault)
-"kot" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/table,
+/obj/item/clothing/suit/armor/f13/battlecoat/vault/overseer,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "koy" = (
 /obj/machinery/light,
@@ -8122,8 +7161,16 @@
 	},
 /area/f13/wasteland)
 "kqn" = (
-/obj/item/twohanded/required/kirbyplants/dead,
-/turf/open/floor/f13/wood,
+/obj/structure/table/reinforced,
+/obj/item/sharpener,
+/obj/item/kitchen/knife,
+/obj/item/kitchen/rollingpin,
+/obj/item/clothing/head/chefhat,
+/obj/item/clothing/suit/apron/chef,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
 "kqx" = (
 /obj/structure/debris/v3,
@@ -8183,25 +7230,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
-"ktL" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_x = 6;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_y = 5
-	},
-/turf/open/floor/carpet/black,
-/area/f13/vault)
 "ktR" = (
 /obj/structure/closet/wardrobe,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -8211,19 +7239,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "ktW" = (
-/obj/item/stack/crafting/electronicparts/five,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "kuf" = (
-/obj/machinery/computer/secure_data{
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
-	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "kuM" = (
 /obj/machinery/seed_extractor,
@@ -8266,10 +7292,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "kvA" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/caution{
-	dir = 10
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/turf/open/floor/plating/f13,
 /area/f13/vault)
 "kvF" = (
 /obj/item/ammo_casing/c9mm,
@@ -8327,39 +7354,9 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"kBU" = (
-/obj/structure/flora/ausbushes/stalkybush,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/lavendergrass{
-	pixel_x = 10
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	pixel_x = -11
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/f13{
-	icon_state = "grass2"
-	},
-/area/f13/vault)
 "kCt" = (
-/obj/structure/table,
-/obj/machinery/camera/autoname{
-	dir = 10;
-	network = list("Vault")
-	},
-/obj/machinery/button/door{
-	id = 103;
-	name = "Blast Doors"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/vault)
-"kCB" = (
-/obj/item/detective_scanner,
-/obj/structure/closet,
-/obj/item/clothing/neck/cloak/hos,
-/obj/item/clothing/under/hosparademale,
-/obj/item/gun/ballistic/shotgun/police,
-/turf/open/floor/carpet/black,
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "kDk" = (
 /obj/structure/chair{
@@ -8374,49 +7371,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "kEr" = (
-/obj/structure/table,
-/obj/item/soap{
-	pixel_x = -1;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/vault)
-"kEu" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"kEV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
-"kFl" = (
-/obj/machinery/door/airlock/public/glass{
-	req_access_txt = "31"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/poddoor{
-	id = 103;
-	name = "Vault Blastdoor 1"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
-"kFE" = (
-/obj/machinery/door/airlock/command{
-	name = "Chief of Security's Quarters";
-	req_access_txt = "19"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/vault)
+"kEu" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/vault)
+"kFl" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "kFI" = (
 /obj/structure/closet/crate/bin,
@@ -8449,10 +7417,6 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"kGC" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
 "kHq" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -8461,10 +7425,18 @@
 	},
 /area/f13/bunker)
 "kHJ" = (
-/obj/machinery/computer/operating{
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
+/obj/machinery/door/window{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "kIx" = (
 /obj/effect/decal/remains/human,
@@ -8496,12 +7468,6 @@
 /obj/structure/debris/v4,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"kKj" = (
-/obj/machinery/computer/robotics{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "kKI" = (
 /obj/structure/stone_tile/slab,
 /mob/living/simple_animal/hostile/gecko,
@@ -8518,9 +7484,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
-"kLr" = (
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
 "kLt" = (
 /obj/machinery/conveyor_switch{
 	id = "mining_area"
@@ -8534,10 +7497,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"kMR" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/f13/wood,
-/area/f13/vault)
 "kMW" = (
 /obj/structure/chair/wood/modern{
 	dir = 1
@@ -8562,12 +7521,11 @@
 	},
 /area/f13/bunker)
 "kNp" = (
-/obj/machinery/computer/cargo{
-	dir = 4
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 8
-	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "kNt" = (
 /obj/structure/table/wood,
@@ -8576,13 +7534,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"kNH" = (
-/obj/effect/landmark/start/cyborg,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "kNL" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -8607,32 +7558,27 @@
 /turf/open/floor/carpet/black,
 /area/f13/bunker)
 "kPN" = (
-/obj/item/bedsheet/black,
-/obj/structure/bed/old,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "kQV" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
+/obj/machinery/autolathe,
+/obj/item/stack/sheet/plasteel/twenty,
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "kRm" = (
-/obj/item/chair,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "kRy" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "kSv" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "kSW" = (
@@ -8658,12 +7604,13 @@
 	},
 /area/f13/bunker)
 "kTc" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = 30
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "kTA" = (
 /obj/structure/flora/junglebush/large,
@@ -8677,20 +7624,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
 "kUP" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/wooden/planks,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
-"kVE" = (
-/obj/effect/landmark/start/f13/vaultscientist,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "kWd" = (
 /obj/structure/barricade/bars,
 /obj/effect/decal/cleanable/dirt,
@@ -8701,12 +7638,7 @@
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
 "kWC" = (
-/obj/item/clothing/glasses/meson,
-/obj/item/flashlight/lantern,
-/obj/item/storage/bag/ore,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
 "kWT" = (
@@ -8714,22 +7646,21 @@
 /obj/item/ammo_box/c45,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"kYb" = (
-/obj/machinery/washing_machine,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/vault)
 "kYv" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "kZg" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "kZn" = (
 /obj/effect/spawner/lootdrop/f13/seedspawner,
@@ -8807,11 +7738,10 @@
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
 "led" = (
-/obj/structure/chair/comfy/beige{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/obj/effect/landmark/start/f13/vaultdoctor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "leD" = (
 /obj/structure/closet{
@@ -8834,21 +7764,6 @@
 /obj/item/book/granter/trait/pa_wear,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"lfA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
-"lgm" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
 "lgD" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -8974,11 +7889,10 @@
 	},
 /area/f13/bunker)
 "lrj" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/table/wood/fancy/royalblack,
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "lrV" = (
 /obj/structure/car/rubbish2,
@@ -8987,8 +7901,14 @@
 	},
 /area/f13/wasteland)
 "lsc" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/structure/table/wood/fancy/royalblack,
+/obj/structure/showcase/machinery/tv{
+	name = "Vault-Tec Quantum Newsfeed Television"
+	},
+/obj/machinery/light,
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
+	},
 /area/f13/vault)
 "lsu" = (
 /obj/structure/table,
@@ -8996,16 +7916,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
-"lsy" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "ltr" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood{
@@ -9048,11 +7958,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"lwj" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp/green,
-/turf/open/floor/carpet/black,
-/area/f13/vault)
 "lwE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9103,11 +8008,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"lyO" = (
-/obj/structure/table,
-/obj/item/clothing/head/hardhat/cakehat,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/vault)
 "lzU" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -9153,7 +8053,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "lGv" = (
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/table,
+/obj/item/integrated_circuit_printer,
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "lGF" = (
 /obj/item/radio/intercom{
@@ -9163,12 +8066,6 @@
 	icon_state = "carpetsymbol"
 	},
 /area/f13/bunker)
-"lHv" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "lJE" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
@@ -9245,14 +8142,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"lNG" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
 "lNS" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/water,
@@ -9262,11 +8151,21 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
 "lPy" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/light,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/deliveryChute{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "lPR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9281,18 +8180,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"lQZ" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "lSd" = (
 /mob/living/simple_animal/hostile/cazador/young,
 /obj/effect/decal/cleanable/dirt{
@@ -9302,8 +8189,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "lSm" = (
-/obj/machinery/door/airlock/wood,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/obj/machinery/workbench/advanced,
+/obj/machinery/light,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "Machine Shop";
+	operating = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "lSq" = (
 /obj/structure/rack,
@@ -9364,15 +8257,11 @@
 	},
 /area/f13/bunker)
 "lYw" = (
-/obj/machinery/light,
-/obj/machinery/power/port_gen/pacman/super{
-	anchored = 1
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "lZo" = (
 /obj/machinery/light/broken{
@@ -9444,16 +8333,19 @@
 	},
 /area/f13/wasteland)
 "maN" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/chef_recipes,
-/turf/open/floor/f13/wood,
+/obj/machinery/workbench/advanced,
+/obj/structure/rack,
+/obj/machinery/light,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "Machine Shop";
+	operating = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "mbg" = (
-/obj/structure/kitchenspike,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/chair,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "mbR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9481,19 +8373,6 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/bunker)
-"mdB" = (
-/obj/effect/landmark/start/f13/vaultscientist,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"mei" = (
-/obj/machinery/computer/cargo/request{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/vault)
 "meV" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -9507,16 +8386,11 @@
 	},
 /area/f13/bunker)
 "meY" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
-"mfA" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/f13/power_armor/excavator,
-/obj/item/clothing/head/helmet/f13/power_armor/excavator,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
 "mgb" = (
 /obj/machinery/computer/communications,
@@ -9534,14 +8408,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"mgX" = (
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "mhd" = (
 /obj/structure/toilet,
 /obj/machinery/light/broken{
@@ -9584,9 +8450,10 @@
 	},
 /area/f13/bunker)
 "mkZ" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/crafting/abraxo,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "mlw" = (
 /obj/structure/stone_tile/slab,
@@ -9594,10 +8461,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "mlI" = (
-/obj/machinery/door/airlock{
-	name = "Gym"
+/obj/structure/chair/comfy/beige{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "mlO" = (
 /mob/living/simple_animal/hostile/raider/biker,
@@ -9607,21 +8477,30 @@
 	},
 /area/f13/wasteland)
 "mmy" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
+/obj/structure/table,
+/obj/item/reagent_containers/hypospray/medipen/stimpak{
+	pixel_x = 2;
+	pixel_y = 6
 	},
-/obj/structure/fermenting_barrel,
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/item/reagent_containers/hypospray/medipen/stimpak{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "mnN" = (
-/obj/machinery/door/airlock/science/glass{
-	name = "Science"
+/obj/machinery/conveyor{
+	dir = 9;
+	id = "garbage"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
+/obj/structure/fence/handrail{
+	dir = 4;
+	pixel_x = -15
+	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "moC" = (
@@ -9694,12 +8573,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"mrV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "mso" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9720,12 +8593,7 @@
 	},
 /area/f13/bunker)
 "mtg" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/vault)
 "mtw" = (
 /obj/structure/table/wood,
@@ -9739,12 +8607,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"mtC" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
 "mtM" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/dirt,
@@ -9756,16 +8618,14 @@
 	},
 /area/f13/wasteland)
 "muE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
-"mvi" = (
-/obj/machinery/door/airlock/medical{
-	name = "Morgue";
-	req_access_txt = "45; 5";
-	req_one_access_txt = ""
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/window/spawner/east,
+/obj/structure/window/spawner/west,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/floor/grass,
 /area/f13/vault)
 "mvo" = (
 /obj/structure/chair/f13chair2{
@@ -9773,24 +8633,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
-"mvs" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/vault)
-"mvR" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/pen,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 10
-	},
-/area/f13/vault)
 "mvY" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/table,
+/obj/item/storage/firstaid,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "mwn" = (
 /mob/living/simple_animal/hostile/cazador/young,
@@ -9798,12 +8647,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "mwr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/item/storage/firstaid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "mwO" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -9826,10 +8672,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "mxL" = (
-/obj/machinery/light/small{
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "mxR" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -9856,26 +8706,6 @@
 /mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"myJ" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
-"mza" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"mzm" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/vault)
-"mzt" = (
-/obj/machinery/vending/wardrobe/science_wardrobe,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "mzz" = (
 /obj/structure/closet/wardrobe,
 /obj/item/clothing/under/f13/vault{
@@ -9966,12 +8796,6 @@
 /obj/structure/chalkboard,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
-"mDJ" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/f13/vault)
 "mDK" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -9980,19 +8804,6 @@
 	icon_state = "housebase"
 	},
 /area/f13/bunker)
-"mEB" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_y = -32
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
-"mEC" = (
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
-	},
-/area/f13/vault)
 "mFc" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13{
@@ -10019,15 +8830,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "mGp" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
-	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
+/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
+/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "mGy" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -10036,14 +8844,9 @@
 	},
 /area/f13/wasteland)
 "mGB" = (
-/obj/machinery/vending/nukacolavendfull,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"mGH" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/machinery/light,
+/obj/structure/table/wood/fancy,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/vault)
 "mGR" = (
 /obj/structure/rack,
@@ -10052,13 +8855,10 @@
 	},
 /area/f13/bunker)
 "mHf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/autolathe/ammo,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 6
-	},
+/obj/structure/table,
+/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
+/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "mHn" = (
 /turf/open/indestructible/ground/outside/road{
@@ -10083,41 +8883,16 @@
 /obj/item/clothing/gloves/combat,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
-"mJM" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/vault)
 "mJU" = (
 /obj/structure/stone_tile/surrounding/cracked,
 /obj/structure/stone_tile/cracked,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "mKz" = (
-/obj/structure/closet,
-/obj/item/storage/box/gloves,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
-"mKW" = (
-/turf/open/floor/wood,
-/area/f13/vault)
-"mLP" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "mMl" = (
 /obj/machinery/shower{
@@ -10130,35 +8905,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"mML" = (
-/obj/machinery/conveyor{
-	dir = 5;
-	id = "QMLoad2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/fence/handrail{
-	dir = 4;
-	pixel_x = -15
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/vault)
-"mNt" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
-	},
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
-"mNN" = (
-/obj/effect/turf_decal/caution{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/vault)
 "mNS" = (
 /obj/effect/turf_decal/box,
 /obj/effect/decal/remains/human,
@@ -10167,9 +8913,9 @@
 /area/f13/bunker)
 "mOt" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "mPh" = (
 /obj/structure/simple_door/bunker,
@@ -10185,11 +8931,8 @@
 	},
 /area/f13/bunker)
 "mPq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating/tunnel,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
 "mPJ" = (
 /obj/item/ammo_casing/a762,
@@ -10215,20 +8958,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "mRj" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/vault)
-"mRt" = (
-/turf/open/floor/f13/wood,
-/area/f13/vault)
-"mRR" = (
-/obj/machinery/button{
-	id = 666;
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plating/f13,
 /area/f13/vault)
 "mRW" = (
 /obj/structure/debris/v3,
@@ -10289,16 +9023,20 @@
 	},
 /area/f13/bunker)
 "mTt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table/glass,
+/obj/item/reagent_containers/medspray{
+	pixel_x = -9;
+	pixel_y = 5
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/item/reagent_containers/medspray{
+	pixel_x = -6;
+	pixel_y = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = 6;
+	pixel_y = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "mTW" = (
 /obj/machinery/light,
@@ -10310,9 +9048,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "mWs" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/cafeteria,
+/obj/machinery/chem_master/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "mXf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10333,10 +9070,6 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
-"mYm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
 "mYL" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating/tunnel{
@@ -10351,10 +9084,15 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "nbF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Chemistry";
+	req_access_txt = "45;5"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "nbW" = (
 /obj/structure/rack,
@@ -10368,10 +9106,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"ncc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "ncm" = (
 /obj/structure/mirror,
 /turf/closed/wall/r_wall/f13/vault,
@@ -10393,20 +9127,6 @@
 /obj/item/trash/f13/steak,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
-"nfs" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/vault)
-"nhA" = (
-/obj/machinery/door/airlock/science/glass{
-	name = "Research Storage";
-	req_access_txt = "47"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "nhC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -10418,9 +9138,11 @@
 	},
 /area/f13/wasteland)
 "niu" = (
-/obj/structure/table,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/landmark/start/f13/vaultdoctor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "niR" = (
 /obj/structure/window/plastitanium,
@@ -10436,10 +9158,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "njb" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/chem_dispenser,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "nkf" = (
 /obj/item/stock_parts/cell/ammo/mfc,
@@ -10447,28 +9170,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"nll" = (
-/obj/machinery/door/airlock/public/glass{
-	req_access_txt = "31"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/poddoor{
-	id = 103;
-	name = "Vault Blastdoor 1"
-	},
+"nlq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
-"nlq" = (
-/obj/machinery/computer/aifixer{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "nlw" = (
 /obj/structure/rack,
@@ -10494,12 +9204,6 @@
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
-"nms" = (
-/obj/machinery/door/airlock{
-	name = "Bar Backroom"
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
 "nmQ" = (
 /obj/effect/turf_decal/arrows{
 	dir = 4
@@ -10515,10 +9219,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "noS" = (
-/obj/structure/decoration/hatch{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "npg" = (
 /obj/structure/table,
@@ -10533,10 +9237,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "nql" = (
-/obj/effect/turf_decal/loading_area{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "nqx" = (
 /mob/living/simple_animal/hostile/handy{
@@ -10566,17 +9272,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"nre" = (
-/obj/structure/table,
-/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/carpet/black,
-/area/f13/vault)
 "nrL" = (
-/obj/structure/bookcase/manuals/medical,
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/f13/wood,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "nsh" = (
 /obj/structure/debris/v3,
@@ -10616,20 +9320,23 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "nuf" = (
-/obj/machinery/vending/wardrobe/science_wardrobe,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "nug" = (
-/obj/item/storage/fancy/rollingpapers,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
-"nuz" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 30
+/obj/machinery/button/door{
+	id = "Vault East Trading Doors";
+	name = "East Trading Blast Doors";
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/vault)
+"nuz" = (
+/obj/effect/landmark/start/f13/vaultdoctor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "nuJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10639,20 +9346,10 @@
 	},
 /area/f13/underground/cave)
 "nvz" = (
-/obj/structure/flora/ausbushes,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/f13{
-	icon_state = "grass2"
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/area/f13/vault)
-"nvF" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner{
-	pixel_x = 3;
-	pixel_y = 6
-	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "nvZ" = (
 /obj/structure/stone_tile/block/burnt,
@@ -10683,13 +9380,10 @@
 	},
 /area/f13/bunker)
 "nxF" = (
-/obj/effect/turf_decal/caution{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "nxW" = (
 /obj/structure/chair/comfy/lime{
@@ -10698,14 +9392,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "nyL" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/obj/effect/landmark/start/f13/vaultdweller,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/obj/structure/cable,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "nze" = (
 /obj/effect/decal/remains/human,
@@ -10717,17 +9405,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"nBk" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/apron/chef,
-/obj/item/kitchen/knife/butcher,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/plasteel/cafeteria,
-/area/f13/vault)
-"nBr" = (
-/obj/structure/chair/right,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "nBV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -10756,22 +9433,13 @@
 	},
 /area/f13/underground/cave)
 "nDB" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
-	},
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/f13/vaultdoctor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "nDK" = (
-/turf/open/floor/plasteel/caution{
-	dir = 9
-	},
-/area/f13/vault)
-"nDM" = (
-/obj/structure/rack,
-/obj/item/storage/box/donkpockets,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/machinery/chem_heater,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "nEt" = (
 /obj/structure/rack,
@@ -10838,35 +9506,18 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"nIX" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "nIZ" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/obj/structure/dresser,
-/turf/open/floor/carpet/black,
-/area/f13/vault)
-"nJR" = (
-/obj/machinery/computer/security{
-	network = list("vault")
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/turf/open/floor/grass,
 /area/f13/vault)
 "nKa" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/obj/item/bedsheet,
+/obj/effect/landmark/start/f13/vaultengineer,
+/obj/structure/bed,
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "nKo" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -10874,24 +9525,27 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
 "nKv" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/conveyor{
+	dir = 5;
+	id = "QMLoad2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/fence/handrail{
+	dir = 4;
+	pixel_x = -15
+	},
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/caution{
-	dir = 1
-	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "nKy" = (
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/vault)
-"nLZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/sign/poster/official/help_others,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Diner"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
 "nMa" = (
 /obj/structure/chair/stool{
@@ -10924,11 +9578,10 @@
 	},
 /area/f13/bunker)
 "nOi" = (
-/obj/item/am_containment,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/vault)
 "nOA" = (
 /obj/effect/decal/waste{
@@ -10946,20 +9599,12 @@
 	},
 /area/f13/bunker)
 "nPe" = (
-/obj/machinery/light,
-/obj/structure/rack,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/conveyor/inverted{
+	dir = 8;
+	id = "garbage"
 	},
-/obj/item/stack/sheet/plasteel/twenty,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/vault)
-"nPp" = (
-/obj/machinery/light,
-/turf/open/floor/carpet/black,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "nPE" = (
 /obj/structure/rack,
@@ -10969,12 +9614,14 @@
 	},
 /area/f13/bunker)
 "nPK" = (
+/obj/effect/landmark/start/f13/vaultdweller,
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "nPL" = (
 /turf/open/floor/f13/wood{
@@ -10982,10 +9629,10 @@
 	},
 /area/f13/underground/cave)
 "nQe" = (
-/obj/machinery/door/airlock{
-	name = "Custodial Closet"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "nRJ" = (
 /obj/structure/fence{
@@ -11003,7 +9650,10 @@
 	},
 /area/f13/underground/cave)
 "nRS" = (
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "nSi" = (
 /obj/effect/decal/remains/human,
@@ -11036,13 +9686,18 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "nTV" = (
-/obj/structure/flora/ausbushes/sparsegrass{
-	pixel_x = 7;
-	pixel_y = 3
+/obj/machinery/disposal/bin{
+	name = "Machine Shop Transport"
 	},
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/box,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/vault)
 "nTZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -11061,10 +9716,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
-"nVp" = (
-/obj/structure/stacklifter,
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "nVS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance,
@@ -11076,19 +9727,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "nWY" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "nXh" = (
 /turf/open/floor/holofloor/carpet,
 /area/f13/bunker)
 "nXp" = (
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/bed,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "nXt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11125,8 +9773,14 @@
 	},
 /area/f13/bunker)
 "nZb" = (
-/obj/structure/wreck/trash/secway,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
+/obj/machinery/status_display/supply{
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "nZl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11135,8 +9789,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "nZm" = (
-/obj/structure/chair/comfy/brown,
-/turf/open/floor/f13/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
 /area/f13/vault)
 "nZs" = (
 /obj/structure/flora/wasteplant/wild_punga,
@@ -11148,11 +9806,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
 "nZA" = (
-/obj/machinery/modular_computer/console/preset/engineering,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 10
+	},
 /area/f13/vault)
 "nZS" = (
 /obj/machinery/recharge_station,
@@ -11209,9 +9871,12 @@
 	},
 /area/f13/bunker)
 "ocL" = (
-/obj/structure/sign/poster/prewar/corporate_espionage,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/f13/vault_floor/blue/corner{
+	dir = 8
 	},
 /area/f13/vault)
 "ocT" = (
@@ -11242,8 +9907,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
 "oey" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/f13/wood,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/f13/vault_floor/blue/corner,
 /area/f13/vault)
 "oeC" = (
 /obj/structure/grille,
@@ -11260,15 +9928,6 @@
 /obj/structure/sign/departments/security,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
-"ofx" = (
-/obj/machinery/workbench,
-/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
-/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
-/obj/effect/spawner/lootdrop/f13/blueprintHigh,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 9
-	},
-/area/f13/vault)
 "ogo" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -11287,21 +9946,20 @@
 	},
 /area/f13/bunker)
 "ogy" = (
-/obj/structure/bookcase/random,
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
+/obj/machinery/light,
+/obj/machinery/chem_dispenser,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "oho" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Armory";
-	req_access_txt = "19"
+/obj/machinery/conveyor/inverted,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/obj/structure/fence/handrail{
+	dir = 4;
+	pixel_x = -15
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "ohF" = (
 /obj/structure/table,
@@ -11312,22 +9970,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "ohK" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
+/obj/structure/chair/comfy/black{
+	dir = 4
 	},
-/obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -9
-	},
-/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
-/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
-/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
-"ohZ" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "oif" = (
 /obj/structure/rack,
@@ -11405,7 +10051,12 @@
 	},
 /area/f13/bunker)
 "omR" = (
-/obj/structure/plasticflaps,
+/obj/effect/turf_decal/caution{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "opj" = (
@@ -11434,16 +10085,16 @@
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
 "orV" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "osd" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
 	},
-/turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
 "osf" = (
 /obj/machinery/chem_master/primitive,
@@ -11456,35 +10107,38 @@
 	},
 /area/f13/bunker)
 "osK" = (
-/turf/closed/wall/f13/tunnel,
-/area/f13/tunnel)
-"oub" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/vault)
-"oul" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/computer/secure_data{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
-/area/f13/vault)
-"ouy" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"ouI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "rampdowntop"
 	},
+/area/f13/tunnel)
+"oub" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 8
+	},
+/area/f13/vault)
+"oul" = (
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 8
+	},
+/area/f13/vault)
+"ouy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "ouJ" = (
 /obj/effect/turf_decal/box,
@@ -11510,20 +10164,16 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "owz" = (
-/obj/structure/rack,
-/obj/machinery/button/door{
-	id = "vaultd5";
-	normaldoorcontrol = 1;
-	pixel_x = 26;
-	specialfunctions = 4
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
-"oxp" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "oyd" = (
 /obj/structure/rack{
@@ -11536,17 +10186,14 @@
 	},
 /area/f13/bunker)
 "oyX" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
-"ozB" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/door/airlock/security{
+	name = "Barracks";
+	req_access_txt = "1"
 	},
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
 "ozL" = (
 /obj/structure/window/reinforced,
@@ -11554,13 +10201,6 @@
 	icon_state = "grass2"
 	},
 /area/f13/bunker)
-"ozS" = (
-/obj/structure/chair,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/vault)
 "oAl" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -11642,14 +10282,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"oFE" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
-	},
-/turf/open/floor/carpet/black,
-/area/f13/vault)
 "oGi" = (
 /obj/item/storage/pill_bottle/chem_tin/mentats{
 	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
@@ -11665,21 +10297,6 @@
 /obj/structure/debris/v4,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
-"oHA" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "oHB" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -11760,30 +10377,22 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "oNI" = (
-/obj/structure/closet/crate/wooden,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/vault)
-"oNM" = (
-/obj/machinery/computer/cargo{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"oOg" = (
-/obj/machinery/conveyor/inverted{
-	dir = 8;
-	id = "garbage"
+"oNM" = (
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/status_display/supply{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "oOr" = (
 /turf/open/indestructible/ground/outside/road{
@@ -11847,10 +10456,10 @@
 	},
 /area/f13/underground/cave)
 "oTJ" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "oTN" = (
 /obj/structure/window/reinforced{
@@ -11873,9 +10482,9 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "oUH" = (
-/obj/structure/table,
-/obj/item/integrated_circuit_printer,
-/turf/open/floor/plasteel/darkpurple/side,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
 /area/f13/vault)
 "oVD" = (
 /obj/structure/table/wood,
@@ -11904,22 +10513,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"oWN" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
-/area/f13/vault)
-"oXi" = (
-/obj/item/storage/wallet/random,
-/obj/structure/table,
-/obj/item/crafting/wonderglue,
-/obj/item/coin/iron,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
 "oXI" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1
@@ -11934,10 +10527,10 @@
 /turf/closed/wall/f13/wood,
 /area/f13/underground/cave)
 "oYr" = (
-/turf/open/floor/plasteel/neutral,
-/area/f13/vault)
-"oYY" = (
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "oZf" = (
 /obj/structure/simple_door/bunker,
@@ -11952,11 +10545,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "oZQ" = (
-/obj/structure/chair/comfy/black,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
+/obj/structure/closet/crate/wooden,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "pau" = (
 /obj/machinery/light/small{
@@ -11993,10 +10585,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "pcc" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Generator Room";
-	req_access_txt = "31"
+/obj/effect/turf_decal/box,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
 	},
+/obj/structure/closet/crate/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "pcS" = (
@@ -12010,19 +10604,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "pet" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
+/turf/open/floor/plasteel/yellow/side{
+	dir = 5
 	},
-/obj/item/stack/sheet/plasteel/twenty,
-/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "pez" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
@@ -12044,11 +10631,17 @@
 	},
 /area/f13/bunker)
 "pfr" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Armory";
+	req_access_txt = "1"
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/cafeteria,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/vault)
 "phh" = (
 /obj/item/stock_parts/cell/ammo/mfc,
@@ -12059,17 +10652,11 @@
 	},
 /area/f13/bunker)
 "phj" = (
-/obj/structure/window/spawner/east,
-/obj/structure/window/spawner/north,
-/obj/structure/window/spawner/west,
-/obj/structure/window/spawner,
-/obj/machinery/light/floor,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/f13{
-	icon_state = "grass2"
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
 	},
 /area/f13/vault)
 "phB" = (
@@ -12078,13 +10665,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
 "phL" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera/autoname{
-	dir = 5;
-	network = list("Vault")
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 10
 	},
 /area/f13/vault)
 "phU" = (
@@ -12093,10 +10679,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "pix" = (
-/obj/effect/turf_decal/box,
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/vault)
 "piN" = (
 /obj/effect/turf_decal/delivery,
@@ -12134,29 +10723,25 @@
 	},
 /area/f13/underground/cave)
 "pjP" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/coffee,
-/obj/item/reagent_containers/food/drinks/coffee,
-/obj/item/reagent_containers/food/drinks/coffee,
-/obj/item/reagent_containers/food/drinks/coffee,
-/obj/item/reagent_containers/food/drinks/coffee,
-/obj/item/reagent_containers/food/drinks/coffee,
-/obj/item/storage/fancy/donut_box{
-	pixel_y = 15
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/structure/chair/wood/normal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/vault)
 "pjT" = (
 /obj/structure/sign/departments/examroom,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "pkw" = (
-/obj/structure/table,
-/obj/item/pizzabox/mushroom{
-	pixel_x = -10;
-	pixel_y = 12
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/table/wood/fancy,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/vault)
 "plk" = (
 /obj/item/bedsheet/blue,
@@ -12199,16 +10784,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"poG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/chair/booth{
-	dir = 4
-	},
-/obj/effect/landmark/start/f13/vaultdweller,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "ppg" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -12229,12 +10804,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "ppu" = (
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 4;
-	output_dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/obj/structure/chair/wood/normal{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/vault)
 "ppF" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -12267,11 +10843,11 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "prD" = (
-/obj/machinery/door_timer{
-	id = "vaultc2";
-	pixel_y = 32
+/obj/machinery/vending/medical,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "psl" = (
 /obj/structure/closet/crate/bin,
@@ -12279,25 +10855,22 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"psy" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "psA" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/corner{
+	dir = 8
+	},
 /area/f13/vault)
 "psL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/sign/poster/official/science{
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
-"psY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/rnd/production/protolathe,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
 "ptc" = (
 /turf/open/floor/f13{
@@ -12305,10 +10878,7 @@
 	},
 /area/f13/bunker)
 "ptn" = (
-/obj/item/bikehorn,
-/obj/structure/rack,
-/obj/item/soap,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/blue/corner,
 /area/f13/vault)
 "ptV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12318,17 +10888,10 @@
 	},
 /area/f13/bunker)
 "puo" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+/obj/structure/chair/wood/normal{
+	dir = 4
 	},
-/obj/structure/mirror{
-	pixel_x = 32
-	},
-/obj/structure/urinal{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/vault)
 "pup" = (
 /obj/effect/decal/remains/human,
@@ -12339,20 +10902,6 @@
 /mob/living/simple_animal/hostile/venus_human_trap,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
-"pvN" = (
-/obj/item/bedsheet/random,
-/obj/effect/landmark/start/f13/vaultdweller,
-/obj/structure/bed/old,
-/turf/open/floor/wood,
-/area/f13/vault)
-"pvR" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
 "pwd" = (
 /obj/effect/spawner/lootdrop/f13/seedspawner,
 /obj/effect/decal/cleanable/dirt,
@@ -12361,29 +10910,18 @@
 	},
 /area/f13/bunker)
 "pwr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/door/airlock{
-	name = "Hydroponics"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
-"pxp" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
-	},
-/obj/item/storage/box/syringes,
-/obj/structure/closet,
-/obj/item/storage/box/pillbottles,
-/obj/item/storage/box/beakers,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "pxB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
 /area/f13/vault)
 "pxN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12401,13 +10939,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "pzq" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/chair/wood/normal{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/vault)
 "pzA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12431,17 +10966,10 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "pAm" = (
-/obj/structure/table,
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/reagent_containers/glass/bottle/blackpowder,
-/obj/item/ammo_casing/c9mm,
-/obj/item/ammo_casing/c9mm,
-/obj/item/ammo_casing/c9mm,
-/obj/item/storage/fancy/heart_box,
-/obj/item/reagent_containers/glass/beaker/waterbottle/large/empty,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/vault)
 "pAL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12449,10 +10977,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "pBf" = (
-/obj/item/bedsheet/qm,
-/obj/structure/bed/old,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 9
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 6
 	},
 /area/f13/vault)
 "pBl" = (
@@ -12474,12 +11001,23 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pCA" = (
-/obj/structure/table,
-/turf/open/floor/mineral/plastitanium,
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "pEA" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/caution,
+/obj/item/circuitboard/machine/smes,
+/obj/machinery/light/broken{
+	dir = 8;
+	icon_state = "tube-broken"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "pFL" = (
 /obj/structure/simple_door/metal/ventilation,
@@ -12490,11 +11028,10 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "pHv" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
+/obj/structure/chair{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "pIl" = (
 /obj/structure/rack,
@@ -12502,14 +11039,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"pIH" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
 "pII" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -12517,19 +11046,15 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
-"pKG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "pMg" = (
-/obj/structure/chair/comfy/beige{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "pMi" = (
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
@@ -12544,15 +11069,13 @@
 	},
 /area/f13/bunker)
 "pML" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/turf/open/floor/plasteel/darkred/side,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "pOr" = (
 /obj/structure/stone_tile/slab/cracked,
@@ -12560,9 +11083,9 @@
 /area/f13/bunker)
 "pOK" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "pPC" = (
 /obj/effect/decal/cleanable/dirt{
@@ -12584,31 +11107,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
-"pQJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
-"pRc" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/benedict,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
 "pRZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
-"pSo" = (
-/obj/machinery/computer/crew{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
-/area/f13/vault)
 "pSy" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
@@ -12670,19 +11173,14 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
-"pVH" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/bed/old,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/vault)
 "pVK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "pWk" = (
-/obj/effect/turf_decal/box,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "pWp" = (
@@ -12705,17 +11203,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"pYa" = (
-/obj/effect/landmark/start/f13/overseer,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	name = "prewar lounge chair"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/vault)
 "pYM" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/cooking,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -12733,10 +11220,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "qan" = (
-/obj/structure/sign/poster/official/help_others,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/structure/table/booth,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "qau" = (
 /obj/structure/showcase/machinery/tv,
@@ -12752,8 +11240,13 @@
 	},
 /area/f13/bunker)
 "qbf" = (
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "qbU" = (
 /obj/structure/table/wood,
@@ -12790,29 +11283,17 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"qdb" = (
-/obj/effect/turf_decal/box,
-/obj/effect/spawner/lootdrop/crate_spawner,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/vault)
 "qdv" = (
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"qdC" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/flora/ausbushes/fullgrass{
-	pixel_x = -6
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/f13{
-	icon_state = "grass2"
-	},
-/area/f13/vault)
 "qfj" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/vault)
 "qfw" = (
 /obj/structure/table/wood,
 /obj/item/crafting/reloader,
@@ -12846,11 +11327,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
 "qhc" = (
-/obj/machinery/button/crematorium{
-	id = 700;
-	pixel_y = 32
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "qhp" = (
 /obj/effect/decal/remains/human,
@@ -12859,13 +11342,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "qhq" = (
-/obj/structure/table,
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_y = -30
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "qhA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12898,19 +11381,16 @@
 	},
 /area/f13/bunker)
 "qkv" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Reactor APC";
-	pixel_x = -28
+/obj/effect/turf_decal/caution{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "qkI" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/machinery/rnd/production/circuit_imprinter,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 9
+	},
 /area/f13/vault)
 "qkM" = (
 /obj/structure/toilet,
@@ -12919,19 +11399,16 @@
 	},
 /area/f13/bunker)
 "qle" = (
-/obj/structure/chair{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "qlg" = (
-/obj/machinery/light,
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/mug/tea{
-	pixel_x = 4;
-	pixel_y = 7
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/obj/structure/closet/crate/wooden,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "qlj" = (
 /obj/structure/fence{
@@ -12962,13 +11439,10 @@
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
 "qmy" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/waffles,
-/obj/item/reagent_containers/food/drinks/mug/tea{
-	pixel_x = 9;
-	pixel_y = 10
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "qnc" = (
 /obj/effect/decal/remains/robot,
@@ -13000,10 +11474,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
 "qrP" = (
-/obj/structure/chair/comfy/beige{
-	dir = 4
+/obj/structure/sign/departments/botany,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "qsb" = (
 /turf/open/floor/plasteel/bar,
@@ -13027,12 +11501,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "qsp" = (
-/obj/structure/flora/ausbushes/sparsegrass{
-	pixel_x = -10;
-	pixel_y = 7
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/machinery/door/airlock/public/glass{
+	name = "Hydroponics"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/vault)
 "qsO" = (
 /obj/machinery/door/poddoor{
 	id = "lock1"
@@ -13040,37 +11516,29 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "qtI" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "qtS" = (
 /obj/structure/sign/poster/prewar/poster61,
 /turf/closed/wall/f13/tentwall,
 /area/f13/bunker)
 "quA" = (
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
 "qvb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/mineral/plastitanium,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "qwY" = (
 /obj/structure/sign/poster/prewar/poster90,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
-"qxa" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/vault)
 "qxc" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -13102,18 +11570,15 @@
 	},
 /area/f13/bunker)
 "qyF" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "qzz" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/structure/table/wood/fancy/red,
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "qzA" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -13164,10 +11629,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "qBS" = (
-/obj/structure/bodycontainer/crematorium{
-	id = 700
+/obj/structure/ore_box,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "qCj" = (
 /obj/structure/decoration/rag{
@@ -13185,31 +11651,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "qCP" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Chief of Security";
-	req_access_txt = "19"
+/obj/structure/chair/sofa/corp/corner{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "qCV" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/structure/mirror{
-	pixel_x = -32
-	},
+/obj/structure/ore_box,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"qDg" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
-/obj/machinery/icecream_vat,
-/turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
 "qDm" = (
 /obj/structure/table/reinforced,
@@ -13231,9 +11680,9 @@
 /area/f13/bunker)
 "qEC" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "qEJ" = (
 /obj/item/toy/cards/singlecard,
@@ -13268,8 +11717,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "qHi" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/neutral,
 /area/f13/vault)
 "qHm" = (
 /obj/structure/table/wood,
@@ -13352,15 +11803,10 @@
 	},
 /area/f13/wasteland)
 "qLP" = (
-/obj/machinery/door/window/brigdoor/security/cell/northleft{
-	dir = 2;
-	id = "vaultc2";
-	name = "Cell 2"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "qMb" = (
 /obj/structure/table/reinforced,
@@ -13371,17 +11817,8 @@
 	},
 /area/f13/bunker)
 "qMj" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/drinkingglasses{
-	pixel_y = 8
-	},
-/obj/item/storage/box/drinkingglasses{
-	pixel_y = 8
-	},
-/obj/item/storage/box/drinkingglasses{
-	pixel_y = 8
-	},
-/turf/open/floor/wood,
+/obj/structure/table/reinforced,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "qMk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13414,15 +11851,11 @@
 /turf/closed/indestructible/rock,
 /area/f13/underground/cave)
 "qNK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/table/reinforced,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "qOQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13436,9 +11869,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "qPj" = (
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 4
+/obj/structure/table,
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "qPJ" = (
 /obj/structure/table/reinforced,
@@ -13459,23 +11900,14 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"qRI" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/vault)
 "qTu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre";
+	req_access_txt = "";
+	req_one_access_txt = ""
 	},
-/obj/effect/turf_decal/arrows{
-	dir = 8;
-	pixel_x = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/tunnel)
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/vault)
 "qTB" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -13498,8 +11930,15 @@
 	},
 /area/f13/underground/cave)
 "qUj" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/machinery/door/window/brigdoor/security/cell/northleft{
+	dir = 2;
+	id = "vaultc1";
+	name = "Cell 1"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
 "qVA" = (
 /obj/structure/window/plastitanium,
@@ -13512,7 +11951,7 @@
 	},
 /area/f13/bunker)
 "qVM" = (
-/obj/machinery/smartfridge/chemistry,
+/obj/structure/sign/departments/examroom,
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
@@ -13559,21 +11998,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"qWq" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "qWw" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/water,
 /area/f13/underground/cave)
-"qWZ" = (
-/obj/machinery/computer/crew,
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
-"qXt" = (
-/obj/structure/frame/machine,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "qXI" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -13595,13 +12023,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
-"raC" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "raJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -13625,10 +12046,11 @@
 	},
 /area/f13/bunker)
 "rbn" = (
-/obj/structure/sign/poster/official/report_crimes,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
+/obj/machinery/sleeper,
+/obj/machinery/light{
+	dir = 8
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "rbp" = (
 /obj/effect/decal/cleanable/blood,
@@ -13670,14 +12092,22 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "reP" = (
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/machinery/sleeper,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "rfn" = (
-/obj/machinery/computer/mech_bay_power_console{
-	dir = 1
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 5;
+	height = 7;
+	id = "supply_home";
+	name = "Cargo Bay";
+	width = 12
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/elevatorshaft,
 /area/f13/vault)
 "rfs" = (
 /obj/structure/window/reinforced{
@@ -13689,46 +12119,22 @@
 	},
 /area/f13/bunker)
 "rfO" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
+/obj/machinery/door/airlock/mining{
+	name = "CASP Bay"
 	},
-/obj/machinery/camera/autoname{
-	network = list("Vault")
-	},
-/obj/structure/rack,
-/obj/item/clothing/under/f13/vault,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/gloves/color/black,
-/obj/item/storage/belt/security,
-/obj/item/melee/classic_baton/telescopic,
-/obj/item/assembly/flash/handheld,
-/obj/item/restraints/handcuffs,
-/obj/item/gun/ballistic/automatic/pistol/n99,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/clothing/suit/armor/vest,
-/obj/item/clothing/head/helmet/riot/vaultsec,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "rgm" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
 "rgv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"rgE" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/obj/machinery/door/poddoor/shutters{
+	id = "Vault West Trading Shutters";
+	name = "Vault trade shutters"
 	},
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/yeast,
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "rgK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13745,12 +12151,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"rhl" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "rij" = (
 /obj/machinery/door/poddoor{
 	id = "lock2"
@@ -13763,21 +12163,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "rjk" = (
-/obj/machinery/door/airlock/wood{
-	id_tag = "vaultd2";
-	name = "Dorm 2"
+/obj/machinery/ore_silo{
+	desc = "An all-in-one quantum storage and transmission system for the vault's mineral distribution needs."
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/vault)
-"rjv" = (
 /obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
+	dir = 8
 	},
-/obj/machinery/vending/coffee{
-	pixel_y = 1
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
 "rjJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13786,21 +12180,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
-"rkE" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/structure/table/reinforced,
-/obj/item/trash/f13/electronic/toaster{
-	pixel_x = -1;
-	pixel_y = 11
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/f13/vault)
 "rlu" = (
-/obj/structure/chair/comfy/black,
-/turf/open/floor/f13/wood,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
 "rlS" = (
 /obj/structure/chair{
@@ -13849,15 +12234,13 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"rpl" = (
-/obj/structure/sign/poster/prewar/protectron,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
 "rpx" = (
-/obj/structure/frame/machine,
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 4;
+	output_dir = 8
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "rpZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13865,14 +12248,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "rqq" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "rrf" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 6
+/obj/structure/chair{
+	dir = 4
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "rri" = (
 /obj/structure/closet/wardrobe,
@@ -13895,13 +12280,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "rrM" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -13937,10 +12319,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "rtx" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/f13/wood,
+/obj/structure/closet,
+/obj/item/storage/box/gloves,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "rtN" = (
 /obj/structure/chair/f13chair1{
@@ -13988,15 +12375,6 @@
 /obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
-"rvm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/chair/comfy/lime{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/vault)
 "rvJ" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
@@ -14006,10 +12384,17 @@
 /turf/closed/indestructible/rock,
 /area/f13/bunker)
 "rwv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/conveyor/inverted{
+	dir = 6;
+	id = "QMLoad"
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "rwB" = (
 /turf/open/indestructible/ground/outside/desert,
@@ -14018,32 +12403,20 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"rxx" = (
-/obj/structure/chair/middle,
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "ryh" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"ryp" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/vault)
 "ryL" = (
-/obj/structure/sign/departments/chemistry,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
+/obj/effect/turf_decal/box,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
 	},
+/obj/structure/closet/crate/wooden,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "ryR" = (
 /obj/machinery/microwave,
@@ -14051,26 +12424,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
-"ryV" = (
-/obj/machinery/vending/wardrobe/engi_wardrobe,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/vault)
-"ryX" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"ryY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
 "rzp" = (
 /obj/structure/chair/stool/bar{
 	desc = "The place you sit when all hope is lost.";
@@ -14078,17 +12431,11 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
-"rzV" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 9
-	},
-/area/f13/vault)
 "rAa" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
+/obj/structure/chair/comfy/black{
+	dir = 8
 	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "rAd" = (
 /obj/effect/decal/cleanable/robot_debris/old,
@@ -14109,23 +12456,19 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "rBV" = (
-/obj/structure/chair{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/effect/landmark/start/f13/vaultsecurityofficer,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "rCd" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "rCA" = (
 /obj/machinery/light/small{
@@ -14165,27 +12508,15 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "rEj" = (
-/obj/machinery/door/airlock/science/glass{
-	name = "Science";
-	req_access_txt = "31"
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "QMLoad"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/fence/handrail{
+	dir = 4;
+	pixel_x = -15
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
-"rEO" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/obj/structure/rack,
-/obj/item/storage/toolbox/emergency,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
-"rER" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "rFg" = (
 /obj/machinery/light/small{
@@ -14200,9 +12531,10 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "rFr" = (
-/obj/effect/spawner/lootdrop/minor/twentyfive_percent_cyborg_mask,
-/obj/structure/rack,
-/obj/item/stack/crafting/electronicparts/three,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "rGw" = (
@@ -14256,24 +12588,20 @@
 	},
 /area/f13/underground/cave)
 "rIK" = (
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
-	},
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "rJC" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/machinery/plantgenes/seedvault,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "rKb" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "rKn" = (
-/obj/machinery/door/airlock/maintenance/abandoned,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "rKG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14290,10 +12618,13 @@
 	},
 /area/f13/bunker)
 "rLZ" = (
-/obj/item/storage/toolbox/electrical,
-/obj/structure/table,
-/obj/item/crafting/timer,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/machinery/computer/cargo{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "rMe" = (
 /obj/item/radio/intercom{
@@ -14311,25 +12642,11 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/underground/cave)
-"rMV" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
-/area/f13/vault)
 "rMW" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad"
+/obj/structure/table,
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/fence/handrail{
-	dir = 4;
-	pixel_x = -15
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "rOf" = (
 /obj/machinery/light,
@@ -14339,15 +12656,9 @@
 /area/f13/bunker)
 "rOy" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "rOG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14364,11 +12675,10 @@
 	},
 /area/f13/underground/cave)
 "rPm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/curtain{
-	color = "red"
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 8
 	},
-/turf/open/floor/plating/f13,
 /area/f13/vault)
 "rQl" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -14394,20 +12704,18 @@
 	},
 /area/f13/bunker)
 "rTj" = (
-/obj/effect/landmark/start/cyborg,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "rTu" = (
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "rUE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/machinery/computer/operating{
 	dir = 4
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "rUH" = (
 /obj/structure/flora/grass/wasteland,
@@ -14436,21 +12744,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "rVO" = (
-/obj/structure/table,
-/obj/item/folder/white,
-/obj/item/paper_bin,
 /obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "rVS" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "QMLoad"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/fence/handrail{
+	dir = 4;
+	pixel_x = -15
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "rYh" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14459,9 +12770,11 @@
 	},
 /area/f13/bunker)
 "sbq" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/f13/vaultscientist,
-/turf/open/floor/plasteel/dark,
+/obj/item/bedsheet/qm,
+/obj/structure/bed,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
+	},
 /area/f13/vault)
 "sbC" = (
 /obj/effect/decal/cleanable/dirt{
@@ -14482,8 +12795,10 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "sbK" = (
-/obj/structure/wreck/trash/brokenvendor,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/table,
+/obj/item/pickaxe/drill,
+/obj/item/pickaxe,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "scf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14493,15 +12808,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "sct" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"scA" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/vault)
+"scA" = (
+/obj/structure/sign/departments/medbay,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
 /area/f13/vault)
 "sdJ" = (
 /obj/structure/simple_door/house,
@@ -14560,22 +12880,14 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"sje" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
 "sjh" = (
-/obj/structure/table,
-/obj/item/crafting/resistor,
-/obj/item/crafting/resistor,
-/obj/item/crafting/resistor,
-/obj/item/crafting/buzzer,
-/obj/item/crafting/capacitor,
-/obj/item/crafting/capacitor,
-/obj/item/crafting/diode,
-/obj/item/crafting/diode,
-/obj/item/crafting/diode,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/turf_decal/caution{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "sjo" = (
 /obj/structure/flora/grass/jungle/b,
@@ -14613,14 +12925,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
-"smD" = (
-/obj/machinery/door/airlock/command{
-	name = "Bathroom"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/vault)
 "smS" = (
 /obj/item/ammo_casing/shotgun/rubbershot,
 /turf/open/floor/f13/wood{
@@ -14711,37 +13015,23 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "swg" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/freezer,
-/turf/open/floor/plasteel/cafeteria,
+/obj/effect/turf_decal/box,
+/obj/effect/spawner/lootdrop/crate_spawner,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "swN" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "Vault1"
+/obj/effect/turf_decal/box,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/tunnel)
-"swU" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "sxd" = (
 /obj/structure/debris/v4,
 /obj/structure/debris/v3,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
-"sxZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/curtain{
-	color = "red"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
-/area/f13/vault)
 "syC" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/carpet/green,
@@ -14767,11 +13057,11 @@
 	},
 /area/f13/bunker)
 "sAk" = (
-/obj/machinery/door/airlock/wood{
-	id_tag = "vaultd5";
-	name = "Dorm 5"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/obj/structure/table,
+/obj/item/pickaxe/drill,
+/obj/item/pickaxe,
+/obj/item/pickaxe/drill,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "sAG" = (
 /obj/structure/table/reinforced,
@@ -14830,25 +13120,16 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"sDf" = (
-/obj/structure/chair/comfy/lime{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/vault)
 "sDY" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/doorButtons/vaultButton,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "sEk" = (
-/obj/machinery/vending/hydroseeds,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
 "sEC" = (
 /obj/item/storage/pill_bottle/chem_tin/mentats{
@@ -14925,20 +13206,20 @@
 	},
 /area/f13/bunker)
 "sKJ" = (
-/obj/structure/chair/right{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "sLM" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "rampdowntop"
-	},
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "sLQ" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood,
+/obj/machinery/light,
+/obj/structure/table/reinforced,
+/obj/item/defibrillator,
+/obj/item/stock_parts/cell/high,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "sMY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14966,17 +13247,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "sOK" = (
-/obj/item/stack/crafting/electronicparts/three,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
-"sOY" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/clothing/gloves/color/latex/nitrile{
+	pixel_x = -5;
+	pixel_y = 1
 	},
+/obj/item/clothing/suit/apron/surgical{
+	pixel_x = 9;
+	pixel_y = 7
+	},
+/obj/item/clothing/mask/surgical{
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "sPs" = (
 /turf/open/indestructible/ground/outside/road{
@@ -15007,36 +13294,24 @@
 	},
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
-"sQV" = (
-/obj/structure/table/reinforced,
-/obj/item/crafting/coffee_pot{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/f13/vault)
 "sRp" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/turf/open/floor/plasteel/darkred/side,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "sRx" = (
 /obj/machinery/computer/robotics,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "sRQ" = (
-/turf/open/floor/plasteel/caution{
-	dir = 8
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "Vault Disposals";
+	operating = 1
 	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "sRR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15066,11 +13341,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
-"sVf" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "sVv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -15084,13 +13354,12 @@
 	},
 /area/f13/bunker)
 "sWa" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "sXK" = (
 /obj/structure/barricade/wooden,
@@ -15237,9 +13506,17 @@
 /turf/open/water,
 /area/f13/underground/cave)
 "tkj" = (
-/obj/machinery/chem_master/advanced,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin{
+	name = "Machine Shop Transport"
+	},
+/obj/effect/turf_decal/stripes/white/box,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "tku" = (
 /obj/structure/table,
@@ -15274,15 +13551,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "tlL" = (
-/obj/effect/turf_decal/box,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/vault)
-"tmY" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/black,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "tnc" = (
 /obj/effect/decal/fakelattice,
@@ -15301,24 +13576,6 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
-"tqm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "trd" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -15332,8 +13589,11 @@
 	},
 /area/f13/bunker)
 "tro" = (
-/turf/open/floor/plasteel/yellow/side{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 6
 	},
 /area/f13/vault)
 "trv" = (
@@ -15355,14 +13615,18 @@
 	},
 /area/f13/wasteland)
 "trC" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/machinery/door/poddoor/shutters{
+	id = "Vault East Trading Shutters";
+	name = "Vault trade shutters"
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "trF" = (
-/obj/structure/urinal{
-	pixel_y = 32
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "tsJ" = (
 /obj/structure/wreck/trash/machinepiletwo,
@@ -15393,11 +13657,7 @@
 	},
 /area/f13/bunker)
 "ttv" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 4
-	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/vault)
 "ttx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15409,32 +13669,30 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "ttT" = (
-/obj/machinery/computer/rdconsole/core/vault,
-/obj/structure/sign/poster/official/science{
-	pixel_y = 32
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
-	},
+/obj/machinery/disposal/bin,
+/obj/machinery/light,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "ttU" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "tut" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
-"tuv" = (
-/obj/machinery/vending/wallmed{
-	pixel_y = 30;
-	products = list(/obj/item/reagent_containers/syringe = 3, /obj/item/reagent_containers/pill/patch/styptic = 10, /obj/item/reagent_containers/pill/patch/silver_sulf = 10, /obj/item/reagent_containers/medspray/styptic = 4, /obj/item/reagent_containers/medspray/silver_sulf = 4, /obj/item/reagent_containers/pill/charcoal = 2, /obj/item/reagent_containers/medspray/sterilizine = 2)
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "tvl" = (
 /turf/open/floor/f13{
@@ -15450,8 +13708,10 @@
 	},
 /area/f13/bunker)
 "txu" = (
-/obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "txG" = (
 /obj/machinery/vending/nukacolavend,
@@ -15459,12 +13719,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"txK" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "txX" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
@@ -15474,13 +13728,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
 "tyy" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/cafeteria,
+/obj/structure/cable,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "tyO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15494,11 +13743,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"tyX" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal,
-/turf/open/floor/carpet/black,
-/area/f13/vault)
 "tzc" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt{
@@ -15524,9 +13768,9 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/radiation)
 "tAS" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/soda_cans,
-/turf/open/floor/wood,
+/obj/machinery/light,
+/obj/structure/table/reinforced,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "tCc" = (
 /obj/machinery/light/fo13colored/Red{
@@ -15536,13 +13780,6 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
-"tCl" = (
-/obj/item/twohanded/required/kirbyplants/photosynthetic,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
-/area/f13/vault)
 "tDi" = (
 /obj/structure/chair/bench,
 /obj/machinery/light{
@@ -15567,12 +13804,20 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "tEQ" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
 /area/f13/vault)
 "tFW" = (
-/obj/structure/campfire/stove,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/machinery/status_display/supply{
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
 /area/f13/vault)
 "tFY" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -15585,10 +13830,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
 "tGw" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/table,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "tGy" = (
 /obj/structure/table/reinforced/brass,
@@ -15635,35 +13878,28 @@
 /area/f13/bunker)
 "tLi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "tLN" = (
-/obj/machinery/rnd/destructive_analyzer,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 5
-	},
-/area/f13/vault)
-"tLR" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"tLS" = (
+/obj/structure/table,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/command{
-	name = "Overseer Office";
-	req_access_txt = "19"
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/vault)
+"tLR" = (
+/obj/structure/sign/departments/security,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/vault)
+"tLS" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
 /area/f13/vault)
 "tMi" = (
 /obj/structure/sink{
@@ -15695,14 +13931,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"tOo" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
 "tOU" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/radiation,
@@ -15726,12 +13954,8 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "tRn" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/neutral,
 /area/f13/vault)
 "tRH" = (
 /obj/structure/stone_tile/slab,
@@ -15767,8 +13991,14 @@
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
 "tSZ" = (
-/obj/item/gun/ballistic/automatic/toy,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Vault Trading Area";
+	req_access_txt = "31"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "tTi" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -15798,14 +14028,11 @@
 	},
 /area/f13/bunker)
 "tWv" = (
-/obj/structure/bookcase/random,
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/window/reinforced/tinted{
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/f13/wood,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/grass,
 /area/f13/vault)
 "tWN" = (
 /obj/machinery/computer/upload/ai,
@@ -15823,13 +14050,15 @@
 	},
 /area/f13/bunker)
 "tYu" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "tYR" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/structure/flora/bush,
+/turf/open/floor/grass,
 /area/f13/vault)
 "tZn" = (
 /obj/item/storage/pill_bottle/chem_tin/mentats{
@@ -15844,10 +14073,6 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"tZZ" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/vault)
 "uan" = (
 /obj/structure/table/wood/poker,
 /obj/effect/decal/cleanable/dirt,
@@ -15870,14 +14095,9 @@
 /turf/open/floor/pod,
 /area/f13/underground/cave)
 "ucK" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Generator Room";
-	req_access_txt = "31"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
 /area/f13/vault)
 "udK" = (
 /obj/structure/table/reinforced,
@@ -15895,8 +14115,12 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "uga" = (
-/obj/effect/spawner/lootdrop/minor/bowler_or_that,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/machinery/computer/cargo{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
 /area/f13/vault)
 "ugf" = (
 /obj/effect/turf_decal/box,
@@ -15906,18 +14130,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "ugB" = (
-/obj/structure/closet/secure_closet/personal,
-/turf/open/floor/plasteel/dark,
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/f13/vaultdweller,
+/turf/open/floor/plasteel/neutral,
 /area/f13/vault)
 "uhk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/wooden/planks,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/tunnel)
+/obj/structure/table/reinforced,
+/obj/item/folder/yellow,
+/obj/item/folder/yellow,
+/obj/item/folder/yellow,
+/obj/item/paper_bin,
+/obj/item/stamp,
+/obj/item/stamp/denied,
+/obj/item/pen/fourcolor,
+/turf/open/floor/plasteel/neutral,
+/area/f13/vault)
 "uhH" = (
 /obj/structure/chair{
 	dir = 8
@@ -15953,34 +14180,29 @@
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
 "ujC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "ukN" = (
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = 102;
-	name = "Window Shutters"
-	},
-/obj/item/paper_bin{
-	pixel_x = 16;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "ukU" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
 	},
-/turf/open/floor/carpet/black,
 /area/f13/vault)
 "ult" = (
-/obj/item/crafting/reloader,
-/obj/structure/table,
-/obj/item/pipe,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/machinery/button/door{
+	id = "Vault West Trading Doors";
+	name = "West Trading Blast Doors";
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "ulK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16000,21 +14222,23 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "umk" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "uni" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 8
+	},
 /area/f13/vault)
 "unX" = (
 /obj/structure/simple_door/house{
@@ -16030,11 +14254,14 @@
 	},
 /area/f13/wasteland)
 "uos" = (
-/obj/structure/janitorialcart,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/doorButtons/vaultButton,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "uoF" = (
 /obj/structure/rack,
@@ -16049,9 +14276,14 @@
 /area/f13/underground/cave)
 "ura" = (
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
+	},
 /area/f13/vault)
 "uro" = (
 /obj/structure/table,
@@ -16067,22 +14299,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
-"urV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/f13/vault)
-"usf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "usE" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/head/f13/bandit,
@@ -16099,9 +14315,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "utf" = (
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/vault)
 "utY" = (
 /obj/item/soap,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -16114,11 +14336,19 @@
 	},
 /area/f13/bunker)
 "uuz" = (
-/obj/structure/chair/e_chair,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/poddoor{
+	id = "Vault West Trading Doors";
+	name = "Vault West Trading Blastdoor"
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Vault Trading Area";
+	req_access_txt = "31"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
 "uuH" = (
 /obj/structure/debris/v3,
@@ -16126,41 +14356,42 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/underground/cave)
-"uvh" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "uvt" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_y = -30
+/obj/machinery/door/airlock/public/glass{
+	name = "Vault Trading Area";
+	req_access_txt = "31"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
-"uwM" = (
-/obj/machinery/shower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/curtain,
-/obj/structure/decoration/vent,
-/obj/item/soap,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/poddoor{
+	id = "Vault West Trading Doors";
+	name = "Vault West Trading Blastdoor"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
-"uwY" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
+"uwM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/deepfryer,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/effect/landmark/start/f13/vaultsecurityofficer,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "uym" = (
-/obj/item/wirerod,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/poddoor{
+	id = "Vault East Trading Doors";
+	name = "East Trading Blast Door"
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Vault Trading Area";
+	req_access_txt = "31"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
 "uys" = (
 /obj/structure/table/reinforced/brass,
@@ -16172,20 +14403,37 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"uyN" = (
-/obj/structure/sign/departments/examroom,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
-"uzg" = (
-/obj/machinery/door/airlock,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
 "uzC" = (
-/obj/structure/bookcase,
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/f13/wood,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "Vault West Trading Doors";
+	name = "West Trading Blast Doors";
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/machinery/button/door{
+	id = "Vault East Trading Doors";
+	name = "East Trading Blast Doors";
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/machinery/button/door{
+	id = "Vault West Trading Shutters";
+	name = "West Trading Shutters";
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/machinery/button/door{
+	id = "Vault East Trading Shutters";
+	name = "East Trading Shutters";
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "uAn" = (
 /obj/effect/decal/remains/human,
@@ -16200,17 +14448,17 @@
 	},
 /area/f13/bunker)
 "uAJ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/caution{
-	dir = 4
-	},
+/obj/structure/lattice,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/vault)
 "uBh" = (
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plating/tunnel,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/vault)
 "uBF" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/fluff/railing{
@@ -16219,13 +14467,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
 "uCu" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "uCE" = (
 /obj/structure/chair{
@@ -16239,8 +14488,7 @@
 	},
 /area/f13/bunker)
 "uCR" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "uDi" = (
 /obj/structure/toilet{
@@ -16251,12 +14499,6 @@
 	icon_state = "whitebluechess"
 	},
 /area/f13/bunker)
-"uDk" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/vault)
 "uEk" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -16349,17 +14591,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "uKd" = (
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
-"uKx" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "uLc" = (
 /obj/structure/window/reinforced{
@@ -16370,31 +14606,22 @@
 	},
 /area/f13/bunker)
 "uLr" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/rack,
-/obj/item/clothing/under/f13/vault,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/gloves/color/black,
-/obj/item/storage/belt/security,
-/obj/item/melee/classic_baton/telescopic,
-/obj/item/assembly/flash/handheld,
-/obj/item/restraints/handcuffs,
-/obj/item/gun/ballistic/automatic/pistol/n99,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/clothing/suit/armor/vest,
-/obj/item/clothing/head/helmet/riot/vaultsec,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
-/turf/open/floor/plasteel/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "uMj" = (
-/obj/structure/chair/left,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
 "uMG" = (
 /obj/structure/closet/crate{
@@ -16404,11 +14631,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
 "uNg" = (
-/obj/structure/table,
-/obj/item/crafting/board,
-/obj/item/crafting/board,
-/obj/item/crafting/sensor,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/machinery/conveyor/inverted{
+	dir = 10;
+	id = "garbage"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "uNm" = (
 /obj/effect/decal/remains/human,
@@ -16422,8 +14653,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
 "uNs" = (
-/obj/effect/spawner/lootdrop/minor/beret_or_rabbitears,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "uNI" = (
 /obj/machinery/light/broken{
@@ -16464,22 +14698,12 @@
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
-"uRn" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Overseer Office";
-	req_access_txt = "19"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
-/area/f13/vault)
 "uRv" = (
-/obj/machinery/door/airlock/science/glass{
-	name = "Science";
-	req_access_txt = "31"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "uRG" = (
 /turf/open/indestructible,
@@ -16501,11 +14725,6 @@
 	icon_state = "vault0"
 	},
 /area/f13/underground/cave)
-"uST" = (
-/obj/item/storage/bag/books,
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
-/area/f13/vault)
 "uUH" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -16534,8 +14753,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 6
+	},
 /area/f13/vault)
 "uWm" = (
 /obj/structure/rack,
@@ -16595,8 +14815,14 @@
 	},
 /area/f13/underground/cave)
 "uXu" = (
-/obj/machinery/computer/upload/borg,
-/turf/open/floor/plasteel/dark,
+/obj/structure/table,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "uXJ" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -16613,8 +14839,16 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/underground/cave)
 "uYr" = (
-/obj/machinery/processor,
-/turf/open/floor/plasteel/cafeteria,
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "Vault West Trading Shutters";
+	name = "West Trading Shutters";
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "uYC" = (
 /obj/item/stack/sheet/mineral/wood/twenty,
@@ -16630,10 +14864,8 @@
 	},
 /area/f13/bunker)
 "uZd" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
 "uZO" = (
 /obj/structure/table,
@@ -16682,10 +14914,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "veb" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "vee" = (
 /obj/structure/sign/basic{
@@ -16695,12 +14927,12 @@
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
 "veu" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
@@ -16761,16 +14993,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "viF" = (
-/obj/machinery/mineral/equipment_vendor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "viI" = (
-/obj/structure/table,
-/obj/item/book/granter/trait/chemistry{
-	name = "Chemistry for Vault Dwellers";
-	pixel_y = 8
+/obj/structure/fence/wooden{
+	dir = 1;
+	icon_state = "post_wood"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/turf/open/floor/grass,
 /area/f13/vault)
 "viL" = (
 /obj/structure/table/wood,
@@ -16796,15 +15033,15 @@
 /turf/open/floor/wood/f13/stage_tl,
 /area/f13/wasteland)
 "vkm" = (
-/obj/structure/sign/poster/official/obey,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
+/obj/structure/table/reinforced,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
 "vkw" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/f13/vaultdweller,
-/turf/open/floor/plasteel/neutral,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "vkN" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction,
@@ -16894,14 +15131,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "voz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/table,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Armory";
-	req_access_txt = "19"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "voY" = (
 /obj/structure/table/wood,
@@ -16911,12 +15146,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"vpi" = (
-/obj/structure/closet/secure_closet/freezer/fridge{
-	anchored = 1
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/f13/vault)
 "vps" = (
 /obj/structure/table/reinforced/brass,
 /turf/open/floor/f13{
@@ -16924,9 +15153,11 @@
 	},
 /area/f13/bunker)
 "vpQ" = (
-/obj/structure/closet/crate/wooden,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/turf_decal/box,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "vpS" = (
@@ -16940,10 +15171,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "vqj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/chair/comfy/beige{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "vqY" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -16958,22 +15189,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "vrE" = (
-/turf/open/floor/plasteel/elevatorshaft,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "vrV" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/underground/cave)
 "vsm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
 "vsP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16988,8 +15210,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "vts" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/departments/engineering,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "vtP" = (
@@ -17043,22 +15268,9 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
 "vwg" = (
-/obj/structure/flora/ausbushes/sparsegrass{
-	pixel_x = 20;
-	pixel_y = 3
-	},
-/mob/living/simple_animal/hostile/venus_human_trap,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
-"vwi" = (
-/obj/machinery/door/airlock/mining{
-	name = "CASP Bay"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/vault)
 "vwz" = (
 /obj/effect/decal/cleanable/robot_debris/old{
 	icon_state = "gib4"
@@ -17075,14 +15287,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "vwT" = (
-/obj/structure/guncase/shotgun,
-/obj/effect/turf_decal/bot,
-/obj/item/gun/ballistic/shotgun/police,
-/obj/item/gun/ballistic/shotgun/police,
-/obj/item/gun/ballistic/shotgun/police,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 9
+/obj/machinery/light{
+	dir = 8
 	},
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/grass,
 /area/f13/vault)
 "vyk" = (
 /obj/machinery/door/airlock/grunge/abandoned,
@@ -17107,32 +15316,27 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "vzk" = (
-/obj/machinery/computer/med_data{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
-/area/f13/vault)
-"vAu" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
-"vAC" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"vBk" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/chalkboard,
-/turf/open/floor/plasteel/darkpurple/side{
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 8
 	},
+/area/f13/vault)
+"vAu" = (
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 4
+	},
+/area/f13/vault)
+"vBk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "vBl" = (
 /obj/machinery/porta_turret/syndicate/pod,
@@ -17141,40 +15345,32 @@
 	},
 /area/f13/bunker)
 "vBm" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "vBJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
 "vBQ" = (
-/obj/structure/flora/ausbushes/sparsegrass{
-	pixel_x = 6;
-	pixel_y = -6
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"vCa" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/chair/stool/retro,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "vCD" = (
-/obj/structure/table,
-/obj/item/clothing/head/soft/black,
-/obj/item/clothing/under/color/black,
-/obj/item/clothing/shoes/wheelys,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "vault1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/tunnel)
 "vDU" = (
 /obj/structure/sign/basic{
 	color = "#FFFF00";
@@ -17201,11 +15397,11 @@
 /area/f13/bunker)
 "vGi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/ore_box,
-/obj/machinery/light,
-/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/tunnel)
+/area/f13/vault)
 "vGm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -17255,27 +15451,28 @@
 	},
 /area/f13/bunker)
 "vKe" = (
-/obj/structure/sign/warning/radiation,
-/turf/closed/wall/f13/tunnel,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
+	},
 /area/f13/tunnel)
 "vKt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/effect/landmark/start/cyborg,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
 "vKC" = (
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/structure/chair/office/dark{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = 102;
-	name = "Vault Door Security Checkpoint"
-	},
-/obj/structure/window/plastitanium,
-/obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "vKV" = (
 /obj/item/twohanded/required/kirbyplants/random,
@@ -17283,11 +15480,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "vLw" = (
-/obj/structure/table/reinforced,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "vNb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17296,34 +15492,36 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
 "vNk" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/item/book/manual/ripley_build_and_repair,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
 "vNt" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/vaultdoor{
+	name = "vault 113 door";
+	pixel_x = -32;
+	pixel_y = -32
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
 "vNy" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/caution{
-	dir = 6
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "vNY" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
-	},
-/area/f13/vault)
+/obj/machinery/holopad,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "vOa" = (
-/obj/machinery/light,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "vOB" = (
 /obj/machinery/door/airlock/grunge/abandoned,
@@ -17335,14 +15533,25 @@
 /area/f13/bunker)
 "vPd" = (
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "2-8"
 	},
-/obj/machinery/recharge_station,
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "vPj" = (
-/obj/structure/bookcase/random/adult,
-/turf/open/floor/f13/wood,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
 "vPZ" = (
 /turf/closed/wall/r_wall/f13composite{
@@ -17350,18 +15559,17 @@
 	},
 /area/f13/bunker)
 "vQS" = (
-/turf/open/floor/plasteel/cafeteria,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
 "vRu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
+/area/f13/tunnel)
 "vSA" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/gold{
@@ -17387,11 +15595,9 @@
 	},
 /area/f13/underground/cave)
 "vSG" = (
-/obj/machinery/door/airlock,
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
 	},
-/turf/open/floor/wood,
 /area/f13/vault)
 "vTt" = (
 /obj/item/storage/trash_stack,
@@ -17400,16 +15606,13 @@
 	},
 /area/f13/bunker)
 "vTu" = (
-/obj/machinery/computer/security{
-	dir = 4;
-	network = "vault"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/vault)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "vTS" = (
-/obj/machinery/microwave,
-/obj/structure/table,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/carpet/black,
 /area/f13/vault)
 "vTX" = (
 /obj/machinery/door/poddoor/preopen{
@@ -17454,21 +15657,21 @@
 	},
 /area/f13/bunker)
 "vXb" = (
-/obj/machinery/rnd/production/protolathe,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 4
 	},
+/obj/item/stamp,
+/obj/item/stamp/denied,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "vXl" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "vXw" = (
-/obj/structure/fireaxecabinet{
-	pixel_y = 30
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/grass,
 /area/f13/vault)
 "vYm" = (
 /obj/structure/window/reinforced{
@@ -17480,9 +15683,14 @@
 	},
 /area/f13/bunker)
 "vYI" = (
-/obj/machinery/vending/cola/starkist,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/tunnel)
 "vYN" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -17490,17 +15698,22 @@
 	},
 /area/f13/bunker)
 "vZl" = (
-/obj/effect/landmark/start/f13/vaultscientist,
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "wbb" = (
-/obj/structure/table,
-/obj/item/stamp/hos,
-/obj/item/gun/ballistic/shotgun/trench,
-/obj/item/ammo_box/shotgun/bean,
-/obj/item/ammo_box/shotgun/bean,
-/turf/open/floor/carpet/black,
-/area/f13/vault)
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "wbe" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -17508,6 +15721,8 @@
 	},
 /area/f13/bunker)
 "wbl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
 "wbu" = (
@@ -17581,27 +15796,32 @@
 /area/f13/bunker)
 "weS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/ore_box,
-/obj/effect/turf_decal/box,
+/obj/machinery/light,
+/obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
 "weT" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/wood,
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/item/ammo_box/c10mm/jhp,
+/obj/item/ammo_box/c10mm/jhp,
+/obj/item/ammo_box/c10mm/jhp,
+/obj/item/ammo_box/c10mm/jhp,
+/obj/item/ammo_box/magazine/m10mm_adv/simple,
+/obj/item/ammo_box/magazine/m10mm_adv/simple,
+/obj/item/ammo_box/magazine/m10mm_adv/simple,
+/obj/item/ammo_box/magazine/m10mm_adv/simple,
+/obj/item/ammo_box/magazine/m10mm_adv/simple,
+/obj/item/ammo_box/magazine/m10mm_adv/simple,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "wfi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "wfk" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
+/obj/item/multitool/uplink,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "wgj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17614,11 +15834,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
 "whC" = (
-/obj/structure/closet/toolcloset,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "whL" = (
 /obj/structure/table,
@@ -17646,8 +15863,9 @@
 	},
 /area/f13/bunker)
 "wmb" = (
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
+	},
 /area/f13/vault)
 "wmn" = (
 /obj/machinery/door/poddoor{
@@ -17656,11 +15874,10 @@
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
 "wnY" = (
-/obj/structure/sign/poster/official/foam_force_ad,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "woL" = (
 /obj/machinery/light{
 	dir = 4
@@ -17687,12 +15904,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
 "wqg" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	pixel_x = 4;
+	pixel_y = 7
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "wqk" = (
 /obj/effect/turf_decal/arrows{
@@ -17755,13 +15973,6 @@
 	icon_state = "carpetsymbol"
 	},
 /area/f13/bunker)
-"wsg" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "wsE" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden/strong,
@@ -17792,8 +16003,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "wui" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 8
+	},
 /area/f13/vault)
 "wuF" = (
 /obj/structure/chair,
@@ -17805,78 +16020,11 @@
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/rust,
 /area/f13/bunker)
-"wvt" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "wvy" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"wwg" = (
-/obj/machinery/vending/engineering,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/vault)
-"wwK" = (
-/obj/structure/window/spawner/east,
-/obj/structure/window/spawner/north,
-/obj/structure/window/spawner/west,
-/obj/structure/window/spawner,
-/obj/structure/flora/ausbushes/palebush,
-/obj/machinery/light/floor,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/f13{
-	icon_state = "grass2"
-	},
-/area/f13/vault)
-"wxc" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/vault)
 "wxj" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/underground/cave)
@@ -17889,35 +16037,6 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"wxF" = (
-/obj/machinery/door/airlock/security{
-	name = "Gatehouse";
-	req_access_txt = "1"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/vault)
-"wxR" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/gloves/color/latex/nitrile{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/item/clothing/suit/apron/surgical{
-	pixel_x = 9;
-	pixel_y = 7
-	},
-/obj/item/clothing/mask/surgical{
-	pixel_y = -4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "wym" = (
 /obj/structure/grille,
 /obj/effect/spawner/structure/window/reinforced,
@@ -17935,29 +16054,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"wyO" = (
-/obj/structure/table,
-/obj/item/reagent_containers/hypospray/medipen/stimpak{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/hypospray/medipen/stimpak{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid,
-/obj/item/storage/firstaid{
-	pixel_x = 10;
-	pixel_y = 4
-	},
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds{
-	pixel_x = 16
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
-"wyU" = (
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/vault)
 "wzj" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/mechanic,
@@ -17965,25 +16061,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"wAb" = (
-/obj/structure/rack,
-/obj/item/clothing/under/f13/vault,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/gloves/color/black,
-/obj/item/storage/belt/security,
-/obj/item/melee/classic_baton/telescopic,
-/obj/item/assembly/flash/handheld,
-/obj/item/restraints/handcuffs,
-/obj/item/gun/ballistic/automatic/pistol/n99,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/clothing/suit/armor/vest,
-/obj/item/clothing/head/helmet/riot/vaultsec,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "wAv" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 4;
@@ -17999,21 +16076,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "wAT" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet/black,
-/area/f13/vault)
-"wBi" = (
-/obj/structure/table,
-/obj/machinery/light,
-/obj/item/storage/book/bible{
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/vault)
-"wBx" = (
-/turf/open/floor/plasteel/darkpurple/corner{
-	dir = 1
-	},
+/obj/item/storage/box/syringes,
+/obj/structure/closet,
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/beakers,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "wBB" = (
 /obj/structure/chair/office/light{
@@ -18022,13 +16089,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/carpet/black,
 /area/f13/bunker)
-"wBX" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
 "wCl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/mineral/wood/twenty,
@@ -18036,14 +16096,6 @@
 /area/f13/underground/cave)
 "wCN" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/vault)
-"wDy" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced,
-/obj/machinery/dish_drive{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "wEk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18070,14 +16122,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"wFZ" = (
-/obj/structure/flora/ausbushes,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/f13{
-	icon_state = "grass2"
-	},
-/area/f13/vault)
 "wGC" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -18089,25 +16133,6 @@
 	icon_state = "grass2"
 	},
 /area/f13/bunker)
-"wGO" = (
-/obj/structure/table,
-/obj/item/papercutter{
-	pixel_x = 3;
-	pixel_y = 11
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/vault)
-"wHl" = (
-/obj/machinery/door/window/brigdoor/security/cell/northleft{
-	dir = 2;
-	id = "vaultc1";
-	name = "Cell 1"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/vault)
 "wHR" = (
 /obj/structure/rack,
 /obj/item/kitchen/knife/butcher,
@@ -18116,13 +16141,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"wIv" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
-/obj/machinery/vending/wardrobe/chef_wardrobe,
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/vault)
 "wJj" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -18146,13 +16164,14 @@
 /obj/item/toy/cards/singlecard,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
-"wMC" = (
-/obj/structure/bookcase/manuals/research_and_development,
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/f13/wood,
-/area/f13/vault)
 "wNg" = (
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "wNj" = (
 /obj/structure/chair/f13chair2{
@@ -18161,14 +16180,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
-"wNQ" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/f13/vault)
 "wOA" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase/lawyer,
@@ -18176,10 +16187,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"wPe" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "wPz" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
@@ -18196,7 +16203,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/bunker)
 "wQi" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "wQm" = (
 /turf/open/floor/plasteel/dark/corner{
@@ -18252,10 +16262,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/bunker)
 "wTv" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
+/obj/structure/chair/comfy/brown{
+	dir = 8
 	},
+/obj/effect/landmark/start/f13/vaultdweller,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "wTV" = (
@@ -18284,13 +16294,12 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "wUX" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "Vault Disposals";
+	operating = 1
 	},
-/turf/open/floor/plasteel/caution{
-	dir = 8
-	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "wVn" = (
 /turf/open/floor/f13{
@@ -18299,10 +16308,11 @@
 	},
 /area/f13/bunker)
 "wVY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "Vault Room 4";
+	name = "Living Quarters"
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "wWu" = (
 /turf/open/floor/plasteel/dark/side{
@@ -18310,15 +16320,8 @@
 	},
 /area/f13/bunker)
 "wWE" = (
-/obj/effect/turf_decal/bot,
-/obj/item/gun/energy/laser/wattz,
-/obj/item/gun/energy/laser/wattz,
-/obj/item/gun/energy/laser/wattz,
-/obj/item/gun/energy/laser/wattz,
-/obj/structure/rack,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/f13,
 /area/f13/vault)
 "wWN" = (
 /obj/structure/chair/comfy/shuttle{
@@ -18327,32 +16330,11 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
-"wXu" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "wYe" = (
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
 "wYZ" = (
-/obj/structure/rack,
-/obj/machinery/button/door{
-	id = "vaultd6";
-	normaldoorcontrol = 1;
-	pixel_x = 26;
-	specialfunctions = 4
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
-"wZw" = (
-/obj/structure/table,
-/obj/item/stock_parts/cell/high,
-/obj/item/defibrillator,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/turf/open/floor/plasteel/elevatorshaft,
 /area/f13/vault)
 "wZH" = (
 /obj/effect/turf_decal/caution/stand_clear{
@@ -18378,15 +16360,13 @@
 	},
 /area/f13/bunker)
 "xaZ" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/chair{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "xbb" = (
 /obj/structure/simple_door/metal/ventilation,
@@ -18447,12 +16427,8 @@
 	},
 /area/f13/wasteland)
 "xfH" = (
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/floor/grass,
 /area/f13/vault)
 "xgd" = (
 /obj/structure/simple_door/wood,
@@ -18474,32 +16450,15 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "xiS" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 30
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"xjk" = (
-/obj/structure/toilet{
+/obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "xle" = (
 /obj/effect/turf_decal/arrows,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"xly" = (
-/obj/structure/table/optable,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "xlz" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -18509,18 +16468,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
-"xmF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "xmG" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant{
 	color = null;
@@ -18533,17 +16480,15 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "xnc" = (
-/obj/machinery/sleeper,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/light,
 /area/f13/vault)
 "xnX" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/cans,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "xop" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/turf/closed/indestructible/rock,
 /area/f13/tunnel)
 "xos" = (
 /obj/structure/table/wood/fancy/green,
@@ -18567,7 +16512,7 @@
 /area/f13/bunker)
 "xpD" = (
 /turf/closed/wall/f13/tunnel,
-/area/f13/caves)
+/area/f13/tunnel)
 "xpJ" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
@@ -18611,16 +16556,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "xrO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/departments/botany,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
-"xrR" = (
-/obj/structure/table,
-/obj/item/ship_in_a_bottle,
-/turf/open/floor/carpet/black,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
 "xsv" = (
 /obj/structure/table/wood,
@@ -18644,13 +16580,8 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/vault)
 "xtf" = (
-/obj/structure/table,
-/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
-/obj/item/reagent_containers/hypospray/medipen/stimpak/super{
-	pixel_x = -10;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/obj/structure/table/booth,
+/turf/open/floor/wood/f13/oak,
 /area/f13/vault)
 "xtU" = (
 /obj/machinery/door/airlock/grunge/abandoned,
@@ -18667,14 +16598,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "xuQ" = (
-/obj/machinery/door/airlock{
-	name = "Restrooms"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "xuR" = (
-/obj/structure/closet,
-/turf/open/floor/mineral/plastitanium,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/computer/terminal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "xvC" = (
 /obj/structure/reagent_dispensers/barrel/two,
@@ -18684,12 +16622,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "xwn" = (
-/obj/machinery/biogenerator,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
 "xwX" = (
 /obj/machinery/door/airlock/grunge/abandoned,
@@ -18703,52 +16636,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"xxh" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"xxD" = (
-/obj/effect/turf_decal/arrows{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/vault)
 "xyb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
-"xyU" = (
-/obj/structure/rack,
-/obj/machinery/button/door{
-	id = "vaultd4";
-	normaldoorcontrol = 1;
-	pixel_x = 26;
-	specialfunctions = 4
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
 "xzA" = (
-/obj/machinery/door/airlock/command{
-	name = "Overseer's Quarters";
-	req_access_txt = "19"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/turf/open/floor/grass,
 /area/f13/vault)
 "xzE" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "xzP" = (
 /obj/structure/table,
@@ -18817,10 +16716,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"xBO" = (
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "xCj" = (
 /obj/structure/sign/departments/medbay,
 /turf/closed/indestructible/vaultdoor,
@@ -18838,15 +16733,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
-"xEJ" = (
-/obj/structure/cable,
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/darkpurple/side,
-/area/f13/vault)
 "xEN" = (
 /obj/item/ammo_casing/c9mm,
 /obj/effect/decal/cleanable/dirt,
@@ -18883,13 +16769,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"xHP" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/obj/effect/landmark/start/f13/vaultdweller,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "xID" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/vault/v113,
@@ -18948,23 +16827,14 @@
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
 "xLW" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/bot,
-/obj/item/storage/belt/military/assault,
-/obj/item/clothing/suit/armor/f13/combat/swat,
-/obj/item/clothing/mask/gas/sechailer/swat,
-/obj/item/clothing/head/helmet/f13/combat/swat,
-/obj/item/clothing/glasses/legiongoggles,
-/obj/structure/window/reinforced,
-/obj/item/grenade/chem_grenade/teargas,
-/obj/machinery/door/window/brigdoor{
-	dir = 8;
-	req_access_txt = "1"
+/obj/structure/table/reinforced,
+/obj/item/paper/guides/jobs/engi/solars{
+	info = "<h1>Welcome</h1><p>At Vault-Tec, your survival is our number one priority, enclosed within is a notice on your Casp System.</p><p>Thank you for joining in Vault-Tec's mandatory testing of the brand new C.A.S.P. system! The CASP, or Computerized Auto-Synthesis Protofabricator, is a new high tech design using a simple 'points' system to create anything you need! Simply feed the requested high priority items orany day to day crates and metals to synthesize points.</p><p>That's all there is to it!</p>";
+	name = "paper- 'Your very first C.A.S.P. system!'"
 	},
-/obj/item/grenade/flashbang,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
-	},
+/obj/item/stamp/qm,
+/obj/machinery/light,
+/turf/open/floor/plasteel/neutral,
 /area/f13/vault)
 "xMf" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18983,18 +16853,10 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
-"xMF" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/vault)
 "xND" = (
-/obj/machinery/vending/wardrobe/bar_wardrobe,
-/turf/open/floor/wood,
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "xNP" = (
 /obj/effect/decal/cleanable/blood/gibs{
@@ -19067,21 +16929,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "xSr" = (
-/obj/machinery/workbench/advanced,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "xSD" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/flora/ausbushes/fullgrass{
-	pixel_x = -13
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/f13{
-	icon_state = "grass2"
-	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "xSK" = (
 /obj/item/stock_parts/cell/ammo/mfc,
@@ -19092,17 +16950,7 @@
 	},
 /area/f13/bunker)
 "xSY" = (
-/obj/structure/cable,
-/obj/structure/table/booth,
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "xTC" = (
 /obj/structure/chair/wood/modern{
@@ -19168,10 +17016,13 @@
 	},
 /area/f13/bunker)
 "xYZ" = (
-/obj/structure/sign/warning/radiation/rad_area,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security{
+	dir = 1;
+	network = list("vault")
 	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "yaD" = (
 /obj/structure/chair,
@@ -19183,10 +17034,10 @@
 	},
 /area/f13/bunker)
 "yaI" = (
-/obj/machinery/door/airlock/mining{
-	name = "CASP Bay"
+/obj/machinery/computer/arcade,
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "yaU" = (
 /obj/structure/debris/v3,
@@ -19196,19 +17047,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"ybF" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/structure/mirror{
-	pixel_x = -32
-	},
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "ybP" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/fluff/railing/corner{
@@ -19232,23 +17070,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "ycC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"ycR" = (
-/obj/structure/closet/crate/bin,
 /obj/machinery/light{
-	dir = 4
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "ydK" = (
 /mob/living/simple_animal/hostile/gecko,
@@ -19276,14 +17101,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "yfl" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay"
+/obj/machinery/door/airlock/public/glass{
+	name = "Vault Trading Area";
+	req_access_txt = "31"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "yfz" = (
 /obj/effect/decal/remains/human,
@@ -19331,13 +17153,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"yjg" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/landmark/start/f13/vaultsecurityofficer,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/vault)
 "yjO" = (
 /obj/machinery/light{
 	dir = 1
@@ -19346,20 +17161,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
-"ykh" = (
-/obj/structure/sign/poster/official/do_not_question,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
 "ykl" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"yks" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
 "yku" = (
 /obj/structure/girder/reinforced,
 /obj/structure/barricade/wooden/planks,
@@ -20514,6 +18319,7 @@ bsh
 bsh
 bsh
 bsh
+soK
 bsh
 bsh
 bsh
@@ -20521,9 +18327,8 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
+soK
+soK
 bsh
 bsh
 bsh
@@ -20730,6 +18535,8 @@ bsh
 bsh
 bsh
 bsh
+soK
+soK
 bsh
 bsh
 bsh
@@ -20759,19 +18566,17 @@ bsh
 bsh
 bsh
 bsh
+soK
+soK
+bsh
+soK
 bsh
 bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
+soK
+soK
 bsh
 bsh
 bsh
@@ -20975,6 +18780,20 @@ bsh
 bsh
 bsh
 bsh
+soK
+soK
+soK
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+soK
+soK
 bsh
 bsh
 bsh
@@ -21002,6 +18821,8 @@ bsh
 bsh
 bsh
 bsh
+soK
+soK
 bsh
 bsh
 bsh
@@ -21011,24 +18832,8 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
+soK
+soK
 bsh
 bsh
 bsh
@@ -21282,6 +19087,9 @@ bsh
 bsh
 bsh
 bsh
+soK
+soK
+soK
 bsh
 bsh
 bsh
@@ -21297,13 +19105,10 @@ bsh
 bsh
 bsh
 bsh
+soK
+soK
 bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
+soK
 bsh
 bsh
 bsh
@@ -21480,12 +19285,46 @@ bsh
 bsh
 bsh
 bsh
+soK
+soK
 bsh
 bsh
 bsh
 bsh
 bsh
 bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+mAN
+mAN
+xsH
+xsH
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
 bsh
 bsh
 bsh
@@ -21501,47 +19340,13 @@ bsh
 soK
 soK
 bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-bsh
-bsh
-bsh
-bsh
 soK
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
-bsh
 soK
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
+soK
+soK
 bsh
 bsh
 bsh
@@ -21737,54 +19542,6 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-soK
-soK
-soK
-soK
-bsh
-bsh
-bsh
-bsh
-bsh
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
 soK
 bsh
 bsh
@@ -21810,7 +19567,55 @@ bsh
 bsh
 bsh
 bsh
+mAN
+mAN
+xsH
+xsH
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
 bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+soK
+soK
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+soK
+soK
+soK
+soK
 bsh
 bsh
 bsh
@@ -21993,6 +19798,68 @@ bsh
 bsh
 bsh
 bsh
+soK
+soK
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+soK
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+mAN
+mAN
+xsH
+xsH
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -22011,71 +19878,9 @@ bsh
 bsh
 bsh
 soK
-soK
-soK
-soK
-bsh
-bsh
-bsh
-bsh
-bsh
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
 bsh
 bsh
 soK
-soK
-bsh
-soK
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
 bsh
 bsh
 bsh
@@ -22250,6 +20055,7 @@ bsh
 bsh
 bsh
 bsh
+soK
 bsh
 bsh
 bsh
@@ -22268,33 +20074,30 @@ bsh
 bsh
 bsh
 soK
-soK
-soK
-soK
+bsh
+bsh
 bsh
 bsh
 bsh
 bsh
 mAN
 mAN
-mAN
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
+xsH
+xsH
 mAN
 mAN
 mAN
-bsh
-bsh
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+xsH
+xsH
+xsH
+mAN
+mAN
 bsh
 bsh
 bsh
@@ -22317,6 +20120,8 @@ bsh
 bsh
 bsh
 bsh
+bsh
+bsh
 soK
 bsh
 bsh
@@ -22330,7 +20135,7 @@ bsh
 bsh
 bsh
 bsh
-bsh
+soK
 bsh
 bsh
 bsh
@@ -22507,26 +20312,26 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
 soK
-soK
-soK
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -22534,21 +20339,21 @@ bsh
 bsh
 mAN
 mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-mAN
-mAN
+xsH
+xsH
+xsH
+xsH
 mAN
 bsh
 bsh
@@ -22558,12 +20363,6 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
-soK
-soK
 soK
 soK
 bsh
@@ -22589,6 +20388,12 @@ bsh
 bsh
 bsh
 bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+soK
 bsh
 bsh
 bsh
@@ -22772,56 +20577,56 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-mAN
-mAN
-mAN
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-mAN
-mAN
-mAN
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
 soK
 soK
-soK
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+mAN
+mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+mAN
+xsH
+xsH
+xsH
+xsH
+mAN
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -23028,15 +20833,15 @@ bsh
 bsh
 bsh
 bsh
+soK
+soK
 bsh
 bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
+soK
+soK
 bsh
 bsh
 bsh
@@ -23048,23 +20853,23 @@ bsh
 mAN
 mAN
 mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-mAN
-mAN
-mAN
-mAN
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
 mAN
 mAN
@@ -23285,7 +21090,7 @@ bsh
 bsh
 bsh
 bsh
-bsh
+soK
 bsh
 bsh
 bsh
@@ -23304,24 +21109,24 @@ bsh
 mAN
 mAN
 mAN
+vrE
+gog
+vrE
+vrE
+vrE
+gog
+vrE
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
-mAN
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-mAN
-mAN
-mAN
-mAN
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
 mAN
 mAN
@@ -23363,7 +21168,7 @@ bsh
 bsh
 bsh
 bsh
-bsh
+soK
 bsh
 bsh
 bsh
@@ -23560,26 +21365,26 @@ bsh
 mAN
 mAN
 mAN
-mAN
-mAN
-mAN
+xsH
+fNo
+fNo
 vrE
 vrE
 vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
-vrE
+eDB
+eDB
 mAN
 mAN
 mAN
 mAN
 mAN
+mAN
+xsH
+mAN
+xsH
+mAN
+mAN
+xsH
 mAN
 mAN
 mAN
@@ -23615,14 +21420,14 @@ bsh
 bsh
 bsh
 bsh
+soK
+soK
 bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
+soK
+soK
 bsh
 bsh
 heT
@@ -23815,10 +21620,8 @@ bsh
 bsh
 mAN
 mAN
+xsH
 mAN
-nvz
-aFT
-gCQ
 mAN
 vrE
 vrE
@@ -23826,18 +21629,20 @@ vrE
 vrE
 vrE
 vrE
-iEF
-vrE
-vrE
-vrE
-vrE
 vrE
 mAN
-kPN
-bZy
-bZy
-bZy
-boj
+mAN
+mAN
+mAN
+mAN
+mAN
+xsH
+mAN
+xsH
+mAN
+mAN
+xsH
+mAN
 mAN
 mAN
 mAN
@@ -23846,7 +21651,7 @@ bsh
 bsh
 bsh
 bsh
-soK
+bsh
 bsh
 bsh
 bsh
@@ -23873,7 +21678,7 @@ bsh
 bsh
 bsh
 bsh
-bsh
+soK
 bsh
 bsh
 bsh
@@ -24071,41 +21876,41 @@ bsh
 bsh
 mAN
 mAN
+xsH
+xsH
 mAN
 mAN
 gPT
-wFZ
 gPT
-mAN
-mAN
-mML
-kjM
-ddk
+vrE
+vrE
+vrE
 eDB
-oNM
 eDB
-aWc
+mAN
+yaI
+wmb
 bDq
 rMW
-jQh
-mAN
-mAN
-bZy
-bZy
-bZy
-bZy
-dnh
-mAN
-mAN
+wmb
+lrj
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
 bsh
 bsh
 bsh
 bsh
 bsh
-soK
-soK
-soK
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -24130,7 +21935,7 @@ bsh
 bsh
 bsh
 bsh
-bsh
+soK
 bsh
 bsh
 bsh
@@ -24325,44 +22130,44 @@ bsh
 bsh
 mAN
 mAN
+xsH
+xsH
 mAN
 mAN
 mAN
 mAN
 mAN
-rER
-rER
-rER
-mAN
-mAN
-jRl
-iHy
+vrE
 nxF
-mNN
-ivA
-mNN
+vrE
+vrE
+vrE
 nxF
-iHy
-nxF
-jvp
+vrE
 mAN
-wnY
-bZy
-bZy
-bZy
-bZy
-dqe
-mAN
-mAN
-mAN
+iJz
+wmb
+jGA
+rMW
+wmb
+lsc
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 bsh
 bsh
 bsh
 bsh
 bsh
 bsh
-soK
-soK
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -24389,7 +22194,7 @@ bsh
 bsh
 bsh
 bsh
-bsh
+soK
 bsh
 bsh
 bsh
@@ -24582,53 +22387,44 @@ bsh
 bsh
 mAN
 mAN
+xsH
+xsH
 mAN
 mAN
 mAN
 mAN
-pBf
-tro
-kNp
-gAV
-bAG
-mAN
-oOg
-kcN
-oNI
-vpQ
-wQi
-gBW
-isM
-kcN
-wQi
-eET
-mAN
-mAN
-ult
-bZy
-bZy
-bZy
-bZy
 mAN
 mAN
 mAN
+vrE
+vrE
+vrE
+mAN
+mAN
+mAN
+yaI
+wmb
+jIZ
+rMW
+wmb
+lrj
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 bsh
 bsh
 bsh
 bsh
 bsh
 bsh
-soK
-soK
-soK
-soK
-soK
 bsh
 bsh
-bsh
-bsh
-soK
-soK
 bsh
 bsh
 bsh
@@ -24638,6 +22434,15 @@ bsh
 bsh
 soK
 soK
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+soK
+soK
 soK
 bsh
 bsh
@@ -24646,7 +22451,7 @@ bsh
 bsh
 bsh
 bsh
-bsh
+soK
 bsh
 bsh
 bsh
@@ -24839,47 +22644,47 @@ bsh
 mAN
 mAN
 mAN
+xsH
+xsH
 mAN
 mAN
-gUw
 mAN
-rIK
-oYr
-vkw
-jQF
-byY
-dXb
-pix
-wQi
+kcN
+kcN
+kcN
 pWk
-eLb
+kcN
+kcN
+kcN
+pWk
+kcN
 kcN
 wmb
-gDy
-wQi
-kcN
-cTy
+wmb
+wmb
+wmb
+wmb
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
-mAN
-pAm
-kRm
-bZy
-gHu
-bZy
-mAN
-mAN
-mAN
-mAN
 bsh
 bsh
 bsh
 bsh
 bsh
 bsh
-soK
-soK
-soK
-soK
+bsh
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -24903,7 +22708,7 @@ bsh
 bsh
 bsh
 bsh
-bsh
+soK
 bsh
 bsh
 bsh
@@ -25093,20 +22898,16 @@ bsh
 bsh
 bsh
 bsh
+xsH
 mAN
 mAN
+xsH
+xsH
 mAN
-goo
-gUw
-gUw
 mAN
-iSF
-oYr
-gLY
-gvL
-byY
-dXb
-eBf
+xsH
+kcN
+kcN
 kcN
 wQi
 kcN
@@ -25114,21 +22915,48 @@ kcN
 kcN
 wQi
 kcN
-wQi
-ryX
-mAN
-mAN
-vCD
-bZy
-ktW
-pOK
-bZy
+kcN
+wmb
+wmb
+wmb
+wmb
+wmb
 mAN
 mAN
 mAN
 mAN
 mAN
 mAN
+mAN
+mAN
+mAN
+xsH
+mAN
+mAN
+mAN
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -25138,29 +22966,6 @@ bsh
 bsh
 bsh
 soK
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
 bsh
 bsh
 bsh
@@ -25335,6 +23140,9 @@ bsh
 bsh
 bsh
 bsh
+soK
+soK
+soK
 bsh
 bsh
 bsh
@@ -25347,39 +23155,36 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
+xsH
+mAN
+mAN
+xsH
 mAN
 mAN
 mAN
-bZy
-bZy
-bZy
 mAN
-nDB
+mAN
 wVY
-wVY
-wVY
-rwv
-vwi
-wfi
-mLP
-wfi
-eiz
-lHv
-wQi
+mAN
+mAN
+vSG
 kcN
-wQi
-kcN
-qdb
+ttv
 mAN
 mAN
-bgX
-bZy
-bZy
+mAN
+yaI
+wmb
+jMv
+rMW
+wmb
 lrj
-bZy
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
 mAN
 mAN
 mAN
@@ -25591,10 +23396,10 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
+soK
+soK
+soK
+soK
 bsh
 bsh
 bsh
@@ -25607,40 +23412,40 @@ bsh
 bsh
 bsh
 mAN
+xsH
+xsH
+xsH
 mAN
+xsH
+xsH
+xsH
 mAN
-bZy
-bZy
-bZy
-bZy
-dxB
-bAR
 jQj
-sOY
-jQj
-rrf
+vrE
+vrE
 mAN
-bcr
-crs
-jBD
-nql
-nyL
+vSG
 kcN
-jBD
-kcN
-wQi
-pWk
+ttv
 mAN
 mAN
-uga
-bZy
-bZy
-dDP
-psL
-iba
-myJ
-eEX
-enq
+mAN
+iJz
+wmb
+jGA
+rMW
+wmb
+lsc
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+xsH
 mAN
 mAN
 mAN
@@ -25849,6 +23654,8 @@ bsh
 bsh
 bsh
 bsh
+soK
+soK
 bsh
 bsh
 bsh
@@ -25858,48 +23665,46 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
 mAN
 mAN
 mAN
+xsH
+xsH
+xsH
+xsH
+mAN
+xsH
+xsH
+xsH
+mAN
+epr
+nxF
+fPm
+mAN
+dbn
+kcN
+hkd
 mAN
 mAN
 mAN
-myJ
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-omR
-gDI
 yaI
+wmb
+jPB
+rMW
+wmb
+lrj
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-pOK
-uNs
-mAN
-mAN
+xsH
+xsH
+xsH
 mAN
 mAN
 mAN
@@ -25910,8 +23715,8 @@ bsh
 bsh
 bsh
 bsh
-soK
-soK
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -26117,47 +23922,47 @@ bsh
 bsh
 mAN
 mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+mAN
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
 mAN
 mAN
-mAN
-mAN
-mAN
-bZy
-mAN
-eUX
-jyl
+vSG
+kcN
 ttv
 mAN
-eUX
-jyl
-ttv
-mAN
-eUX
-jyl
-ttv
-mAN
-hkd
-tlL
-iJa
-mAN
-ttv
-jyl
-eUX
-mAN
-ttv
-jyl
-eUX
-mAN
-ttv
-jyl
-eUX
-mAN
-eZM
 mAN
 mAN
-hvB
-rFr
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+xsH
+xsH
+xsH
+mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
 mAN
 mAN
@@ -26167,14 +23972,14 @@ bsh
 bsh
 bsh
 bsh
-soK
-soK
-soK
-soK
 bsh
 bsh
 bsh
-soK
+bsh
+bsh
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -26372,50 +24177,50 @@ bsh
 bsh
 bsh
 mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+mAN
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
 mAN
 mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-eZM
-mAN
-mtC
-mKW
-swU
-mAN
-mtC
-mKW
-swU
-mAN
-mtC
-mKW
-swU
-mAN
-xxD
-fPm
-fgs
-mAN
-swU
-mKW
-gVz
-mAN
-swU
-mKW
-gVz
-mAN
-swU
-mKW
-gVz
-mAN
-dDP
-eEX
-mAN
-wTv
+vSG
 kcN
-nuf
+ttv
+mAN
+mAN
+mAN
+mAN
+mAN
+jPS
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+xsH
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
 mAN
 mAN
 bsh
@@ -26427,7 +24232,7 @@ bsh
 bsh
 bsh
 bsh
-soK
+bsh
 bsh
 bsh
 bsh
@@ -26628,51 +24433,51 @@ bsh
 bsh
 bsh
 bsh
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+mAN
+mAN
+xsH
 mAN
 mAN
 mAN
-mRt
-mRt
-mRt
-mRt
-mRt
-mRt
-mRt
 mAN
-pvN
-mKW
-jip
 mAN
-pvN
-mKW
-bqE
 mAN
-pvN
-mKW
-jbc
 mAN
-xxD
-mei
-fgs
 mAN
-xyU
-mKW
-pvN
 mAN
-owz
-mKW
-pvN
+vSG
+kcN
+ttv
+mAN
+mAN
+tGw
+tGw
+xSY
+xSY
+xSY
+tGw
+tGw
+mAN
 mAN
 wYZ
-mKW
-pvN
-mAN
-gLi
-cmu
-ayT
-wfi
-lHv
-gia
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
 mAN
 mAN
 mAN
@@ -26885,53 +24690,53 @@ bsh
 bsh
 bsh
 bsh
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
 mAN
-jMv
-mRt
-mRt
-gIc
-vNY
-mRt
-iWv
-mAN
+xsH
 mAN
 mAN
 gJk
-mAN
-mAN
-mAN
+eiz
+eiz
+eql
 rjk
 mAN
 mAN
-mAN
+dbn
 bBo
+hkd
 mAN
 mAN
-rqq
 kml
 rqq
+xSY
+xSY
+xSY
+kFl
+lGv
 mAN
 mAN
-ivB
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
 mAN
-mAN
-mAN
-sAk
-mAN
-mAN
-mAN
-big
-mAN
-mAN
-mAN
-pOK
-mAN
-gGe
-hKr
-psy
-mAN
-mAN
+xsH
 mAN
 mAN
 mAN
@@ -27142,53 +24947,53 @@ bsh
 bsh
 bsh
 mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
 mAN
-mRt
-mRt
-fGA
-tWv
-mRt
-mRt
-kqn
 mAN
-dAJ
-kcN
+xsH
+mAN
+mAN
 ciO
-kcN
-mJM
-kcN
-ciO
-kcN
-ciO
-kcN
-ciO
-kcN
-mJM
-kcN
-mzm
-kcN
-mJM
-kcN
-ciO
-kcN
-ciO
-kcN
-ciO
-kcN
-mJM
-kcN
-ciO
-kcN
-dAJ
-mAN
-pOK
+xSY
+xSY
+evR
+fiJ
 mAN
 mAN
-nhA
+vSG
+qle
+ttv
 mAN
 mAN
+tGw
+tGw
+xSY
+xSY
+xSY
+tGw
+tGw
 mAN
+mAN
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+mAN
+xsH
 mAN
 mAN
 mAN
@@ -27199,8 +25004,8 @@ bsh
 bsh
 bsh
 bsh
-soK
-soK
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -27398,56 +25203,56 @@ bsh
 bsh
 bsh
 bsh
-mAN
-mAN
-mRt
-mRt
-gIc
-uzC
-gjf
-mRt
-nZm
-imP
-mAN
-dAJ
-ciO
-kcN
-ciO
-kcN
-ciO
-kcN
-oub
-kcN
-ciO
-kcN
-ciO
-kcN
-ciO
-hKr
-ciO
-kcN
-ciO
-kcN
-ciO
-kcN
-oub
-kcN
-ciO
-kcN
-ciO
-kcN
-ciO
-dAJ
-mAN
-pOK
-mAN
-mzt
-hKr
-raC
-dre
+xsH
+xsH
+xsH
+xsH
 mAN
 mAN
 mAN
+mAN
+mAN
+mAN
+xsH
+mAN
+mAN
+giH
+xSY
+xSY
+eBf
+fjt
+mAN
+mAN
+vSG
+qle
+ttv
+mAN
+mAN
+xsH
+xsH
+xSY
+xSY
+xSY
+mAN
+xsH
+mAN
+mAN
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+mAN
+xsH
+xsH
+xsH
 mAN
 mAN
 mAN
@@ -27456,8 +25261,8 @@ mAN
 bsh
 bsh
 bsh
-soK
-soK
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -27655,57 +25460,57 @@ bsh
 bsh
 bsh
 mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
-mAN
-mRt
-gIc
-mRt
-wMC
-gjf
-mRt
-nZm
-sLQ
-mAN
-dAJ
 qkI
 giH
-jvO
-tZZ
+xSY
+xSY
+eHf
+fjH
 mAN
 mAN
+vSG
+qle
+ttv
+mAN
+xsH
+xsH
+xsH
+jef
+jPX
+ktW
+kHJ
+lPy
 mAN
 mAN
-eOI
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
 mAN
-mAN
-mAN
-kcN
-hKr
-kcN
-mAN
-mAN
-mAN
-eOI
-mAN
-mAN
-mAN
-mAN
-ivy
-jvO
-kYb
-qkI
-dAJ
-mAN
-pOK
-rpl
-dGU
-igH
-mdB
-rfn
-mAN
-mAN
-mAN
-mAN
+xsH
+xsH
+xsH
+xsH
 mAN
 mAN
 mAN
@@ -27714,8 +25519,8 @@ mAN
 bsh
 bsh
 bsh
-soK
-soK
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -27911,68 +25716,68 @@ bsh
 bsh
 bsh
 bsh
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
-mAN
-oZQ
-qmy
-aGJ
-mRt
-nrL
-gjf
-mRt
-nZm
-maN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
+dCI
+dSf
+xSY
+xSY
+eJD
 uZd
-psL
-psL
-psL
-psL
-psL
-fDJ
-wfi
-wwK
-wfi
-fDJ
-psL
-psL
-myJ
-psL
-psL
-eEX
 mAN
 mAN
+dbn
+qle
+hkd
+mAN
+xsH
+xsH
+xsH
+xSY
+vLw
+fjN
+xsH
+xsH
+xsH
+mAN
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
 mAN
 mAN
-mAN
-mAN
-mAN
-pOK
-mAN
-qXt
-igH
-kVE
-cBA
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
 mAN
 mAN
 mAN
 bsh
 bsh
-soK
-soK
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -28168,60 +25973,60 @@ bsh
 bsh
 bsh
 mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
-mAN
-dhm
-rtx
-aGJ
-mRt
-uzC
-gjf
-mRt
-nZm
-vNk
-mAN
-mAN
-mAN
-wBX
-uKx
-uKx
-uKx
+dDP
+xSY
+xSY
+xSY
+xSY
 meY
 mAN
 mAN
+vSG
+qle
+ttv
 mAN
+xsH
+xsH
+iOq
+jip
+jQF
+kuf
+kNp
+xsH
+xsH
 mAN
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
+rfn
+wYZ
+wYZ
+wYZ
+wYZ
+wYZ
 mAN
-mAN
-kcN
-hKr
-kcN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-uKd
-bZy
-bZy
-eZM
-bZy
-bZy
-oXi
-mAN
-pOK
-mAN
-aIu
-hKr
-vAC
-kcN
-mAN
-mAN
+tWv
+tYR
 vwT
-mwr
-phL
-anY
+xsH
+xsH
+xsH
 mAN
 mAN
 mAN
@@ -28422,63 +26227,63 @@ bsh
 bsh
 bsh
 bsh
-bsh
 mAN
 mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
 mAN
-mRt
-mRt
-mRt
-mRt
-hBK
-ogy
-mRt
-gIc
-oey
-mAN
-bZy
-bZy
 qtI
-myJ
-myJ
+xSY
+xSY
+xSY
+fjN
+xSY
+goo
+vSG
+qle
+ttv
 mAN
-mAN
-mAN
-qkI
-enm
-cEU
+xsH
+iuD
 kcN
 kcN
+edM
+ipO
 kcN
-hKr
-kcN
-kcN
-kcN
-cEU
-enm
-qkI
+iuD
+xsH
 mAN
 mAN
-mAN
-mAN
-mAN
+nKv
+oho
 uNg
-bZy
+qhc
 rLZ
-mAN
-pOK
-mAN
-mAN
+qhc
+rwv
+rEj
+rVS
 mnN
 mAN
 mAN
-mAN
-mAN
+tLS
+ucK
 hrW
-kaO
-tEQ
-pML
+xsH
+xsH
+xsH
 mAN
 mAN
 mAN
@@ -28679,63 +26484,63 @@ bsh
 bsh
 bsh
 bsh
-bsh
 mAN
+xsH
+xsH
+xsH
 mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
-mRt
-mRt
-gIc
-vNY
-mRt
-vNY
-mRt
-mRt
-mRt
-mRt
-aeH
-uKx
 psL
 dGy
-mAN
-mAN
-mAN
+xSY
+xSY
+eLb
 kfJ
-wfi
-wfi
+fTs
+gvo
 rrt
-wfi
-wfi
-wfi
-wfi
+gLY
+ttv
+mAN
+xsH
 dYn
-wfi
-wfi
-wfi
-wfi
-wfi
-wfi
-aTC
+hUS
 kcN
+edM
+ipO
+kPN
+lSm
+xsH
 mAN
 mAN
-mAN
+nPe
+omR
 sjh
-bZy
+qkv
 ayN
-mAN
-pOK
-mAN
-rzV
+qkv
+sjh
+omR
+sjh
 iYZ
-vBk
-agM
-mvR
+mAN
 mAN
 wWE
-kaO
-tEQ
-sRp
+wWE
+wWE
+xsH
+xsH
+xsH
 mAN
 mAN
 mAN
@@ -28936,69 +26741,69 @@ bsh
 bsh
 bsh
 bsh
-bsh
+mAN
+xsH
+xsH
+xsH
+xsH
+mAN
+xsH
+mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+mAN
+dHs
+xSY
+xSY
+xSY
+vLw
+fpn
+mAN
+xsH
+dbn
+wNg
+hkd
+xsH
+xsH
+xuQ
+kcN
+kcN
+jVD
+ipO
+kcN
+xuQ
+xsH
 mAN
 mAN
-mAN
-mRt
-vNY
-mRt
-mRt
-vNY
-mRt
-mRt
-gIc
-mRt
-mRt
-mAN
-bZy
-bZy
-mAN
-mAN
-xxh
-kcN
-hKr
-kcN
-kcN
-hKr
-kcN
-kcN
-kcN
-tLR
-kcN
-kcN
-kcN
-kcN
-kcN
-kcN
-kcN
-hKr
-kcN
-kcN
 jPN
+kcN
+oZQ
+qlg
+uCR
+pcc
+pcc
+kcN
+uCR
+sct
 mAN
-mAN
-eZM
-mAN
-mAN
-pOK
-mAN
-mEC
-oxp
-iJz
 sbq
 oUH
-mAN
+uga
 eDF
-orV
-jef
-cnH
-iVH
-gBD
-hQl
+xsH
+xsH
+mAN
 mAN
 xsH
 xsH
+mAN
+xsH
+mAN
 bsh
 bsh
 bsh
@@ -29193,69 +26998,69 @@ bsh
 bsh
 bsh
 bsh
-bsh
 mAN
+xsH
+akq
+xwn
+xwn
+bAR
+bUN
+xrO
+xrO
+xrO
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
+dOD
+xSY
+xSY
+xSY
+vLw
+fyM
 mAN
-kMR
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-bZy
-bZy
-mAN
-kbR
+xsH
+vSG
+wNg
+ttv
+xsH
+xsH
+xsH
+iSF
 kcN
+kaO
+ipO
+kQV
+mAN
+xsH
+mAN
+mAN
+nQe
+uCR
+pcc
+pcc
 kcN
-hKr
+pcc
+ryL
+uCR
 kcN
-kcN
-hKr
+iYZ
 mAN
-mAN
-mAN
-mAN
-mAN
-xuQ
-mAN
-mAN
-mAN
-mAN
-kcN
-hKr
-kcN
-kcN
-kcN
-sVf
-mAN
-bZy
-uZd
-psL
-meY
-mAN
-fIu
-oxp
-ahh
-ahh
-icY
-mAN
+tEQ
+ihv
+ugB
 tRn
-ahh
-ahh
-ahh
-ahh
-vNt
-dCI
+xsH
+xsH
+mAN
+mAN
+mAN
+mAN
 mAN
 xsH
-xsH
+mAN
 bsh
 bsh
 bsh
@@ -29450,69 +27255,69 @@ bsh
 bsh
 bsh
 bsh
-bsh
+mAN
+xsH
+alO
+xwn
+xwn
+xwn
+caQ
+xrO
+xrO
+xrO
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
 mAN
-mAN
-mRt
-gIc
-mRt
-uST
-mAN
-qDg
-kQV
-mbg
-mbg
-wIv
-mAN
-bZy
-mAN
-mAN
-kcN
-kcN
-kcN
-hKr
-kcN
-eOI
-vSG
-mAN
-mAN
-jVD
-wyU
-xuQ
-wyU
-wyU
-xuQ
-ipO
-mAN
-mAN
-veb
-wfi
-wfi
-wfi
-lHv
-mAN
-mAN
-pOK
-bZy
-mAN
-ocL
-mEC
-oxp
+dTR
+eiF
+eiF
 eRf
-ahh
+fGA
+mAN
+xsH
+vSG
+wNg
+ttv
+xsH
+xsH
+xuQ
+kcN
+kcN
+kcm
+ipO
+kcN
+lYw
+mAN
+mAN
+mAN
+nRS
+kcN
+uCR
+kcN
+kcN
+kcN
+uCR
+kcN
+uCR
+sct
+mAN
+tFW
 ihv
-mAN
+uhk
 xLW
-xLW
-xLW
-xLW
-tYu
-cve
-mHf
-mAN
 xsH
 xsH
+mAN
+mAN
+mAN
+mAN
+mAN
+xsH
+mAN
 bsh
 bsh
 bsh
@@ -29707,69 +27512,69 @@ bsh
 bsh
 bsh
 bsh
-bsh
 mAN
-mAN
-mAN
-iWv
-mRt
+xsH
+anY
+xwn
+xwn
+anY
 rlu
-fcb
-mAN
-kgh
-cUJ
-lGv
-lGv
-qbf
-eZM
-bZy
-mAN
-psA
-kcN
-kcN
-kcN
-hKr
+xrO
+xrO
+xrO
 mAN
 mAN
-deZ
-iYd
 mAN
-jVD
-dnj
 mAN
+mAN
+mAN
+mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+vSG
+wNg
+ttv
+xsH
+xsH
+ivA
 hUS
-dnj
-mAN
-mAN
-mAN
-mAN
-mAN
 kcN
-kcN
-kcN
-hKr
-eVu
+edM
+ipO
+kPN
+maN
 mAN
+mAN
+mAN
+nTV
+orV
+xSr
+qmy
 pOK
-bZy
-mAN
-ofx
-wBx
-oxp
+uCR
+kcN
+uCR
+kcN
+swg
 mAN
 pxB
 qHi
-mAN
-mAN
-mAN
-mAN
-gNy
-oho
-voz
-gNy
-mAN
+ihv
+ihv
 xsH
 xsH
+xsH
+mAN
+mAN
+mAN
+mAN
+xsH
+mAN
 bsh
 bsh
 bsh
@@ -29963,71 +27768,71 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
 mAN
 mAN
 mAN
+aCL
 vPj
 vPj
 vPj
-vPj
-mAN
-uwY
-fjN
-wxc
-cyk
-elo
+cbv
+cve
+cKF
+xrO
 mAN
 mAN
 mAN
-kfJ
-wfi
-wfi
-wfi
-scA
 mAN
-fpn
+mAN
+mAN
+mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 dbn
-dYV
-mAN
-dTR
-wyU
-mAN
-puo
-wyU
-xuQ
+wNg
+hkd
+xsH
+xsH
+iuD
+kcN
+kcN
+edM
 ipO
+kcN
+iuD
+xsH
 mAN
 mAN
-ykh
-kcN
-kcN
-kcN
-hKr
+nZb
+led
 uCR
-mAN
+kcN
 nPK
-eEX
-mAN
 xSr
-ahh
-oxp
+qmy
+xSr
+qmy
+swN
 eYz
 pet
 dog
-mAN
-kcN
-kcN
-mAN
-gWz
-nKy
-faZ
-rVS
+ukU
+ukU
+xsH
+xsH
 mAN
 mAN
 xsH
 xsH
+mAN
+mAN
+mAN
+mAN
 bsh
 bsh
 bsh
@@ -30220,71 +28025,71 @@ bsh
 bsh
 bsh
 bsh
-bsh
 mAN
 mAN
 mAN
+aFT
+xwn
+xwn
+aFT
+cnH
+xrO
+vQS
+xrO
 mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-swg
-mAN
-mAN
-mAN
-kcN
+xsH
+xsH
 hKr
-kcN
-kcN
-kcN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-wTv
-kcN
 hKr
-kcN
-qkI
+dxB
+hKr
+hKr
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+vSG
+wNg
+ttv
 mAN
-pOK
+xsH
+xsH
+xsH
+wWE
+keC
+kvA
+xsH
+xsH
+xsH
 mAN
+mAN
+nZm
+mAN
+mAN
+xsH
+qyF
+rfO
+rBV
 vXb
-ahh
-oxp
-vZl
-ahh
-nRS
+rBV
 mAN
-kfJ
-wfi
-wxF
-fbt
-vqj
-rCd
-gYe
+mAN
+mAN
+mAN
 mAN
 mAN
 xsH
 xsH
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
 bsh
 bsh
 bsh
@@ -30477,71 +28282,72 @@ bsh
 bsh
 bsh
 bsh
-bsh
 mAN
+xsH
 mAN
-mAN
-sje
-mNt
-ohZ
+aGJ
+xwn
+xwn
+xwn
 qUj
+xrO
+vQS
+xrO
 mAN
-rgE
-nBk
-tyy
-emC
+xsH
 mOt
-sQV
-rkE
-mAN
+xSY
+xSY
+xSY
+xSY
+xSY
+xsH
+xsH
+jvs
 kcN
-hKr
 kcN
 kcN
-mAN
-mAN
-vTu
-kmR
-mAN
-fYY
-vBm
-fyg
-mfA
-mAN
+kcN
+wNg
+kcN
+oul
+oul
+oul
 wui
 oul
 vzk
 iyf
 uni
 rPm
-gdh
-iHk
+rPm
+rPm
+rPm
+nZA
+osd
+phj
+xsH
+qBS
 kcN
 kcN
-hKr
 kcN
-xHP
-mAN
-pOK
-mAN
-ttT
-vZl
-njb
-mrV
-sWa
-xEJ
-mAN
-veu
 kcN
-mAN
-mAN
-mAN
-enx
-mAN
+kcN
+sRp
 mAN
 mAN
 xsH
 xsH
+xsH
+xsH
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+xsH
+mAN
 bsh
 bsh
 bsh
@@ -30549,8 +28355,7 @@ bsh
 bsh
 bsh
 bsh
-rog
-rog
+bsh
 bsh
 bsh
 bsh
@@ -30734,81 +28539,81 @@ bsh
 bsh
 bsh
 bsh
-bsh
 mAN
-mAN
-mAN
+xsH
+xsH
+akq
 xwn
-kLr
-kLr
+xwn
+bAR
 sEk
-mAN
-vpi
+xrO
 vQS
-vQS
-vQS
-mOt
-vQS
-mRR
-mAN
+xrO
+xsH
+xsH
+vLw
+xSY
 tGw
-hKr
+tGw
+tGw
+xSY
+xsH
+xsH
+mkZ
 kcN
 kcN
-dXb
-kuf
 fPP
-fPP
-mAN
-vPd
-kNH
-cAz
-dRs
-mAN
-dBY
-oYY
-oYY
-oYY
-dBY
-rPm
 xSD
-iHk
+vPd
+xSD
+xSD
+xSD
+xSD
+xSD
+xSD
+kkF
+xSD
+xSD
+xSD
+xSD
+xSD
+xSD
+ocL
+oub
+phL
+mAN
+qCV
 kcN
 kcN
-hKr
 kcN
-iaE
-mAN
-pOK
-mAN
-mGp
-ahh
-ahh
-ahh
-oxp
-fTs
-mAN
-hKr
 kcN
+kcN
+uRv
 mAN
-nJR
-buU
-faZ
+kcN
+kcN
+pWk
+mAN
+ukN
+ukN
+bYw
+uYr
 bYw
 ukN
+ukN
 mAN
-xsH
-xsH
-xsH
+mAN
+mAN
 bsh
 bsh
 bsh
 bsh
 bsh
 bsh
-rog
-rog
-fud
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -30991,83 +28796,83 @@ bsh
 bsh
 bsh
 bsh
-bsh
+mAN
+xsH
+xsH
+xsH
+xsH
 mAN
 mAN
 mAN
-iQu
-kLr
-kLr
-rpx
+xrO
+vQS
+xrO
 mAN
-hYq
-vQS
-uYr
-vQS
-urV
-vQS
-vQS
-aNW
-kcN
-hKr
-kcN
-kcN
+xsH
+vLw
+veb
+xSY
+xSY
+xSY
+veb
+xsH
+xsH
 jvs
-mDJ
-fPP
-nPp
-mAN
-aer
-vKt
-nlq
-mAN
-mAN
-oYY
-oYY
-oYY
-oYY
-dBY
-rPm
-fNo
-iHk
 kcN
 kcN
-hKr
+wNg
 kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+ouy
+pix
 gts
-mAN
-pOK
-mAN
+xSr
+xSr
+xSr
 tLN
 qPj
-qPj
-qPj
-rUE
-caQ
+xSr
+sWa
 mAN
-hKr
+kcN
+kcN
+kcN
+uuz
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
 kcN
 mAN
-sDY
-yjg
-jDJ
-xMF
-kCt
 mAN
-xsH
-xsH
-xsH
+mAN
 bsh
 bsh
 bsh
 bsh
-osK
-osK
-hCj
-gLD
-qTu
-osK
-xpD
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 soK
 soK
 soK
@@ -31248,83 +29053,83 @@ bsh
 bsh
 bsh
 bsh
-bsh
 mAN
-mAN
-mAN
+xsH
+aaC
+vTS
 iKK
-kLr
-kLr
-kLr
-jaY
+boj
+mAN
+mAN
+xrO
 vQS
-vQS
-mWs
-alO
+xrO
+mAN
+mAN
 pfr
-aSm
-vQS
-bhU
-kcN
-hKr
-kcN
-kcN
 mAN
-gQo
-fPP
-fPP
 mAN
-uXu
-oxp
-kKj
 mAN
-geI
-oYY
-nfs
+mAN
+mAN
+xsH
+mAN
+xsH
+xsH
+kcN
+wNg
+kcN
+kcN
 viI
-oYY
+viI
+viI
+geI
+viI
+viI
+viI
+viI
 btc
-mAN
-iHk
-mAN
-nuz
-rTj
-hKr
+viI
 kcN
-qkI
+kcN
+kcN
+kcN
+wNg
+pjP
 mAN
-rKn
-mAN
-iuD
-ppu
-viF
+qCV
+kcN
+kcN
+kcN
+kcN
+kcN
 uRv
-rEj
 mAN
-gNy
-hKr
-gNy
-xYZ
+tYu
+kcN
+ult
+uvt
+kcN
+kcN
+kcN
+vKC
+kcN
+kcN
+kcN
 mAN
-vKC
-vKC
-vKC
 mAN
-xYZ
-xsH
-xsH
-xsH
-irT
-aim
-aim
-aim
-vKe
-mct
-mct
-mct
-mct
-cZs
-xpD
+mAN
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 soK
 bsh
 soK
@@ -31505,83 +29310,83 @@ bsh
 bsh
 bsh
 bsh
-bsh
 mAN
+xsH
+vTS
+vTS
+vTS
+vTS
+bCL
 mAN
+xrO
+vQS
+xrO
 mAN
-iKK
-kLr
-kLr
-uvt
-mAN
-vQS
-wNQ
-vQS
-vQS
-mOt
-vQS
-vQS
-wDy
-kcN
+xSY
+vLw
 ycC
-wfi
-wfi
+xSY
+xSY
+xSY
+ycC
+ekD
+enq
 qCP
-eHf
-bEK
-kmR
 mAN
-mAN
-gRF
-mAN
-mAN
-tuv
-oYY
+kcN
+wNg
+kcN
+tLS
+xzA
 xfH
-bjK
-sDf
-dBY
-sxZ
-rMV
+hHq
+xzA
+xzA
+xfH
+xzA
+xzA
+hHq
+xzA
+xzA
 kcN
 kcN
 kcN
-hKr
+wNg
+pkw
+mAN
+qBS
 kcN
 kcN
-cEU
-hKr
+rFr
+sbK
+sAk
+uRv
+mAN
 kcN
-cEU
 kcN
-kcN
-kcN
-hKr
-enm
-cEU
-hKr
-kFl
-sLM
+mAN
+mAN
+mAN
 umk
 cHe
 rgv
 gmz
-umk
-aZd
-xsH
-fhA
-eWF
-fjH
-wbl
-mct
-mct
-keC
-xop
-mct
-xop
-mct
-weS
-xpD
+vpQ
+yfl
+mAN
+mAN
+mAN
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+rog
+rog
+rog
+bsh
+bsh
 bsh
 soK
 bsh
@@ -31762,83 +29567,83 @@ bsh
 bsh
 bsh
 bsh
-bsh
 mAN
 mAN
+vTS
+vTS
+vTS
+vTS
+vTS
 mAN
-pvR
-kLr
-kLr
-ggN
+xrO
+vQS
+xrO
 mAN
-uzg
-mAN
-yks
-kGC
+xSY
 vLw
-pRc
+xSY
+xSY
+xSY
+xSY
+xSY
+xSY
+xSY
+eWF
 mAN
-mAN
-kcN
-hKr
-kcN
-qkI
-mAN
-mAN
-kFE
-mAN
-mAN
-tCl
-oWN
-bIM
-uRn
-qxa
-fJN
-pYa
-fHg
-rvm
-akt
+mkZ
+wNg
+xzA
+xzA
+xzA
+xzA
+vXw
 tLS
-fJp
-wfi
-wfi
-ffQ
-oHA
-wfi
-wfi
-wfi
-dYn
-wfi
-wfi
-wfi
-wfi
-wfi
-xmF
-wfi
-wfi
+xzA
+xzA
+xzA
+xzA
+xzA
+tLS
+xzA
+xzA
+kcN
+kcN
+wNg
+ppu
+mAN
+mAN
+rpx
+wWE
+rIK
+wWE
+wWE
+nZm
+mAN
+kcN
+kcN
 cTl
-nll
-ouI
+pWk
+sLM
 tLi
-lsy
-pKG
-hwO
-mgX
-lfA
+tLi
+tLi
+tLi
+tLi
+tLi
 eQq
-vRu
-ouI
-jPS
-mct
-ekD
-mct
-kkF
-xop
-mct
-mct
-xop
-vGi
-xpD
+mAN
+xsH
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+rog
+rog
+rog
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -32019,80 +29824,80 @@ bsh
 bsh
 bsh
 bsh
-bsh
 mAN
 mAN
-mAN
-iKK
-kLr
-kLr
-kLr
-xrO
-qWq
-hpM
-qWq
-cEv
-vCa
-cEv
-qWq
-cmt
-kcN
-hKr
-kcN
-mza
-mAN
-eJD
-ukU
-oFE
-mAN
-mAN
-xzA
-mAN
-mAN
-vXw
-uDk
-oYY
-hnN
-sDf
-dBY
-sxZ
-rMV
-kcN
-kcN
-kcN
-hKr
-kcN
-kcN
-vAC
-kcN
-kcN
-egw
-kcN
-kcN
-kcN
-hKr
-kcN
-fiJ
-kcN
-kFl
-sLM
-kot
-fwu
-bQQ
-nIX
-akw
-pQJ
+vTS
+qzz
+qzz
+vTS
+vTS
 xsH
+xrO
+vQS
+hpM
+mAN
+qtI
+vLw
+xSY
+cmt
+cmt
+cmt
+xSY
+xSY
+xSY
+fbt
+xsH
+kcN
+wNg
+xzA
+xfH
+xzA
+dfX
+vXw
+vXw
+xzA
+jyl
+jWr
+dfX
+vXw
+xzA
+xzA
+xzA
+kcN
+kcN
+wNg
+psA
+rPm
+uni
+rPm
+rPm
+rPm
+rPm
+rPm
+tkj
+tLR
+kcN
+kcN
+cTl
+kcN
+sLM
+tLi
+tLi
+tLi
+tLi
+tLi
+tLi
+vBk
 fhA
-dnA
+xsH
 hpf
-mct
 xop
-mct
+xop
+xop
 drg
 mct
 mct
-xop
+mct
 mct
 kWC
 xpD
@@ -32276,82 +30081,82 @@ bsh
 bsh
 bsh
 bsh
-bsh
 mAN
 mAN
-mAN
-iKK
-kLr
-lgm
-cyG
-bKE
-usf
-usf
-usf
-usf
-tqm
-usf
-usf
-nLZ
+vTS
+vTS
+qzz
+bqE
+vTS
+xsH
+xrO
+vQS
+xrO
+dai
+xSY
+vLw
 wfi
-lQZ
-fdN
-dRB
-mAN
-nre
-wbb
-fPP
-mAN
-icB
-ryp
-grY
-mAN
-gAH
-uDk
-akP
-wGO
-oYY
-btc
-mAN
-iHk
-mAN
-nuz
-rTj
-hKr
+wfi
+wfi
+wfi
+wfi
+xSY
+xSY
+xSY
+wWE
 kcN
-qkI
-mAN
-eZM
-mAN
-mAN
-iHk
-dAl
-vAu
+wNg
+xzA
+xzA
+xzA
+grY
+hQl
+gAH
+tLS
+tLS
+xzA
+vXw
+xzA
+xfH
+xzA
+tLS
+kcN
+kcN
+wNg
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+ipO
 yfl
-mAN
-mAN
+kcN
+kcN
 dvm
-mAN
+kcN
 xYZ
-mAN
-mAN
-mAN
-mAN
-mAN
-xYZ
-xsH
-xsH
+tLi
+uKd
+veu
+uKd
+tLi
+tLi
+tLi
+vGi
 xsH
 irT
 aim
-aim
-aim
+mct
+mct
 vKe
+kUP
 mct
-xop
+kUP
 mct
-mct
-kWC
+wbl
 xpD
 soK
 bsh
@@ -32533,82 +30338,82 @@ bsh
 bsh
 bsh
 bsh
-bsh
 mAN
 mAN
-mAN
-iKK
-kLr
-exl
-kLr
-dUD
-qWq
-qWq
-qWq
-qWq
-kZg
-qWq
-qWq
-muE
-kcN
-hKr
-fdN
-qhq
-mAN
+hzJ
+aIS
+bcr
+bqE
+vTS
+cpp
+xrO
+cSA
+cZs
 gQo
-glT
-nPp
-mAN
+deX
+kZg
+dnj
+dqe
+muE
+dOF
+dnj
+deX
+qhq
+deX
+gQo
+xSr
+gvL
+xzA
 jWr
 dVu
 bEK
-mAN
-mAN
-uDk
-oYY
-oYY
-oYY
-dBY
-rPm
-fzF
-iHk
+hQR
+ixG
+iTR
+xzA
+jyl
+xzA
+tLS
+xzA
+xzA
+xzA
 kcN
 kcN
-hKr
-kcN
-xHP
-mAN
-bZy
-mAN
-bTC
-fGz
-hbL
-wrr
-hoz
+owz
+xSD
+xSD
+xSD
+xSD
+xSD
+xSD
+xSD
+xSD
+tlL
+tSZ
 xaZ
-mAN
-bZy
-txu
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-xsH
-xsH
-bsh
-bsh
-bsh
-bsh
+xSr
+uos
+uwM
+uzC
+uBh
+uLr
+uLr
+uLr
+uBh
+uBh
+vBm
+vKt
+vNt
+vNY
+mct
+vTu
+mct
 osK
-osK
-uhk
-uhk
 kUP
-osK
+mct
+mct
+kUP
+weS
 xpD
 bsh
 soK
@@ -32790,83 +30595,83 @@ bsh
 bsh
 bsh
 bsh
-bsh
 mAN
 mAN
-mAN
+vTS
+vTS
 qzz
-kLr
-exl
-cSA
+bqE
+vTS
 mAN
-bsw
-qWq
-qWq
-qWq
-kZg
-qWq
-qWq
-mAN
+xrO
+xrO
+vQS
+dai
+xSY
+vLw
+wfi
+wfi
+wfi
+wfi
+wfi
+xSY
+vLw
+xSY
+wWE
 kcN
-hKr
-kcN
-txK
-mAN
-kCB
-fPP
-fPP
-mAN
-lwj
-fPP
-ryp
+wNg
+xzA
+tLS
+xzA
+xzA
 nIZ
-mAN
-psY
-oYY
-oYY
-oYY
-dBY
-rPm
-kBU
-iHk
+iDb
+xzA
+dVu
+xzA
+xfH
+xzA
+tLS
+xzA
+xzA
 kcN
 kcN
-hKr
+wNg
 kcN
-hmE
-mAN
-bZy
-mAN
-gBg
-fGz
-rVO
-wrr
-hoz
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+ipO
+yfl
 qle
-mAN
-bZy
-bZy
+kcN
+ura
+kcN
 kfq
-nDM
-bZy
-bZy
-mAN
-mAN
-mAN
-mAN
+tLi
+uNs
+viF
+uNs
+tLi
+tLi
+vBQ
+vNk
 xsH
-xsH
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-cNF
-ifg
-ifg
-bsh
-bsh
+vRu
+mct
+kUP
+mct
+vYI
+mct
+mct
+kUP
+mct
+wnY
+xpD
 bsh
 bsh
 soK
@@ -33047,83 +30852,83 @@ bsh
 bsh
 bsh
 bsh
-bsh
 mAN
 mAN
+aer
+aJe
+qzz
+vTS
+vTS
 mAN
-iKK
-kLr
-exl
-lsc
+xrO
+xrO
+vQS
 mAN
-nBr
-bzV
-fTR
-qWq
-poG
-qWq
-bZY
-mAN
+dfc
+vLw
+xSY
 xiS
-hKr
-kcN
-kcN
-mAN
-mAN
-fPP
-hJD
-mAN
-tyX
-mDJ
-dlX
-fPP
-mAN
-bnK
-pSo
-grW
-dfX
-wui
-rPm
-qdC
-iHk
-kcN
-kcN
-hKr
-kcN
-gts
-mAN
-bZy
-mAN
-mAN
-vAu
-mAN
-vAu
-yfl
-mAN
-mAN
-bZy
-iXy
-mAN
-dCj
-bZy
-bZy
-mAN
-mAN
-mAN
-mAN
+xiS
+xiS
+xSY
+xSY
+vLw
+feS
 xsH
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-rog
-ifg
-ifg
-bsh
-bsh
+kcN
+wNg
+xzA
+xzA
+xzA
+dlX
+xzA
+xzA
+tLS
+xzA
+tLS
+dfX
+xzA
+xzA
+xzA
+xzA
+kcN
+kcN
+wNg
+ptn
+vAu
+iaE
+vAu
+vAu
+vAu
+vAu
+vAu
+tro
+mAN
+qle
+kcN
+utf
+kcN
+sLM
+tLi
+tLi
+tLi
+tLi
+tLi
+tLi
+vBk
+fhA
+xsH
+hpf
+xop
+xop
+xop
+drg
+mct
+kUP
+mct
+mct
+wnY
+xpD
 bsh
 soK
 bsh
@@ -33304,83 +31109,83 @@ bsh
 bsh
 bsh
 bsh
-bsh
 mAN
 mAN
+vTS
+vTS
+vTS
+vTS
+vTS
 mAN
-iQu
-kLr
-exl
-lsc
-mAN
-rxx
+xrO
+xrO
 aLh
-feS
-qWq
-gAT
-usf
+mAN
+qtI
+vLw
 xSY
-mAN
-kcN
-hKr
-kcN
-kcN
-kcN
-mAN
-mAN
-mAN
-mAN
-xrR
-ktL
-fPP
-bzb
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-wTv
-kcN
-hKr
-kcN
-qkI
-mAN
-bZy
-mAN
-wyO
-ieI
-lNG
-ieI
-ryY
-led
-mAN
-mxL
-bZy
-mAN
-mAN
-mAN
-eZM
-mAN
-mAN
-mAN
-mAN
+xSY
+xSY
+xSY
+xSY
+xSY
+vLw
+eWF
 xsH
+mkZ
+wNg
+xzA
+xzA
+xzA
+tLS
+xzA
+xzA
+xzA
+xzA
+xzA
+jWr
+xzA
+tLS
+xzA
+xzA
+kcN
+kcN
+wNg
+puo
+mAN
+mAN
+wWE
+wWE
+wWE
+wWE
+wWE
+mAN
+mAN
+led
+kcN
+mxL
+wQi
+sLM
+tLi
+tLi
+tLi
+tLi
+tLi
+tLi
+mAN
+mAN
+mAN
 bsh
 bsh
-soK
 bsh
 bsh
-bsh
-bsh
-rog
-rog
-rog
-bsh
-bsh
+xpD
+xpD
+vZl
+vZl
+wbb
+xpD
+xpD
 soK
 bsh
 bsh
@@ -33561,72 +31366,72 @@ bsh
 bsh
 bsh
 bsh
-bsh
 mAN
-mAN
-mAN
-mAN
-mYm
+xsH
+vTS
+vTS
+vTS
+vTS
 pwr
 mAN
-mAN
+cyk
 uMj
 quA
-sKJ
-qWq
-fky
-qWq
-fky
 mAN
-mAN
+xSY
+vLw
 veb
-wfi
-wfi
-wfi
-lHv
+xSY
+xSY
+xSY
+veb
+elo
+enx
+ffQ
 mAN
-mAN
-mAN
-mAN
-mAN
-smD
-mAN
-mAN
-myJ
-myJ
-myJ
-myJ
-bZy
-bZy
-eZM
+kcN
+wNg
+kcN
+xzA
+xzA
+xzA
+hHq
+xzA
+xzA
+xzA
+xzA
+tLS
+hHq
+xzA
+xzA
 kcN
 kcN
 kcN
-hKr
+wNg
 mGB
 mAN
-mAN
-bZy
-mAN
+qEC
+vrE
 ohK
-ieI
-ieI
-ieI
-ryY
-qlg
+ohK
+ohK
+vrE
+ttT
 mAN
-bZy
-bZy
-eZM
-myJ
-bZy
+kcN
+kcN
+mAN
+mAN
+mAN
+uCu
+uXu
 trC
+voz
+vts
+yfl
 mAN
 mAN
 mAN
-xsH
-xsH
-bsh
 bsh
 bsh
 bsh
@@ -33635,7 +31440,7 @@ bsh
 bsh
 rog
 rog
-bsh
+rog
 bsh
 bsh
 bsh
@@ -33818,72 +31623,72 @@ bsh
 bsh
 bsh
 bsh
-bsh
 mAN
-mAN
-mAN
+xsH
+aaC
+vTS
 bSU
 bzn
-iGj
-mmy
-mAN
-rjv
-qWq
-qWq
-qWq
-qWq
-qWq
-vYI
 mAN
 mAN
-psA
-kcN
-kcN
-kcN
-hKr
+cyG
+vQS
+cyG
 mAN
 mAN
-mAN
-mAN
-dIN
-aJI
-aJI
-mAN
-myJ
-myJ
-myJ
-bZy
-bZy
-mAN
-mAN
-kcN
-kcN
-kcN
-hKr
-mGB
-mAN
-myJ
-bZy
-mAN
-xtf
-bRz
-fWM
-fWM
-fyM
-led
-mAN
-nug
-bZy
-mAN
-mAN
-eZM
+dhm
 mAN
 mAN
 mAN
 mAN
 xsH
-bsh
-bsh
+mAN
+xsH
+xsH
+mAN
+kcN
+wNg
+kcN
+kcN
+viI
+viI
+hZN
+viI
+viI
+jAa
+viI
+viI
+viI
+viI
+kcN
+kcN
+kcN
+kcN
+wNg
+pzq
+qrP
+vrE
+vrE
+xtf
+xtf
+xtf
+vrE
+vrE
+mAN
+tYu
+kcN
+nug
+uym
+kcN
+kcN
+kcN
+vkw
+kcN
+kcN
+kcN
+mAN
+mAN
+mAN
 bsh
 bsh
 bsh
@@ -33892,7 +31697,7 @@ bsh
 bsh
 rog
 rog
-bsh
+rog
 bsh
 bsh
 bsh
@@ -34075,72 +31880,72 @@ bsh
 bsh
 bsh
 bsh
-bsh
-mAN
-mAN
-mAN
-ehx
-qyF
-kLr
-gvo
-mAN
-oyX
-qWq
-qWq
-eDn
-eDn
-eDn
-cpR
-mAN
-mAN
-mAN
-kcN
-kcN
-kcN
-hKr
-kcN
-mAN
-mAN
-mAN
-agt
-aJI
-uwM
-mAN
-myJ
-myJ
-bZy
-tSZ
-mAN
-eOI
-kfJ
-wfi
-wfi
-wfi
-scA
-mAN
-mAN
-bZy
-mAN
-qan
-ieI
-ryY
-ieI
-ieI
-ieI
-jAa
-mAN
-myJ
-bZy
-mAN
-mxL
-bZy
-ptn
-mAN
-mAN
 mAN
 xsH
-bsh
-bsh
+mAN
+aSm
+xsH
+mAN
+mAN
+mAN
+mAN
+oyX
+mAN
+mAN
+mAN
+vLw
+dnA
+cpR
+dAl
+dAl
+dWA
+xsH
+xsH
+jvs
+kcN
+kcN
+wNg
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+oNI
+pAm
+qsp
+qLP
+qLP
+qan
+qan
+qan
+qLP
+tyy
+mAN
+kcN
+kcN
+kcN
+uym
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+kcN
+mAN
+mAN
+mAN
 bsh
 bsh
 bsh
@@ -34332,73 +32137,73 @@ bsh
 bsh
 bsh
 bsh
-bsh
-mAN
-mAN
-mAN
-mAN
-mAN
-eZM
-mAN
-mAN
-fYo
-cCZ
-mKW
-tAS
-nvF
-grL
-mAN
-mAN
-mAN
-mAN
-hys
-kcN
-kcN
-hKr
-kcN
-kcN
-kcN
-fvZ
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-kcN
-hKr
-kcN
-kcN
-kcN
-eBU
-mAN
-bZy
-bZy
-mAN
-rAa
-ieI
-ryY
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-sbK
-mAN
-bZy
-bZy
-cNv
-mAN
-mAN
 mAN
 xsH
+aeH
+vrE
+vrE
+bxc
+mAN
+mAN
+cCZ
+fYo
+cCZ
+xsH
+xsH
+vLw
+xSY
+xSY
+xSY
+xSY
+xSY
+xsH
+xsH
+mkZ
+kcN
+kcN
+gyP
+xSD
+fvZ
+xSD
+xSD
+xSD
+xSD
+xSD
+xSD
+xSD
+xSD
+xSD
+xSD
+xSD
+xSD
+nlq
+oey
+eBU
+pBf
+mAN
+qMj
+vrE
+rAa
+rAa
+rAa
+vrE
+qMj
+mAN
+kcN
+kcN
+rFr
+mAN
+ukN
+ukN
+bYw
+cNv
+bYw
+ukN
+ukN
+mAN
+mAN
+mAN
 bsh
-bsh
-soK
 bsh
 bsh
 bsh
@@ -34406,7 +32211,7 @@ bsh
 bsh
 rog
 rog
-rog
+bsh
 bsh
 bsh
 bsh
@@ -34582,9 +32387,7 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
+bsh
 bsh
 bsh
 bsh
@@ -34593,77 +32396,79 @@ bsh
 bsh
 mAN
 mAN
+agt
+vrE
+vrE
+vrE
 mAN
-cYq
-hzJ
-jIZ
-lyO
 mAN
-dNC
-mKW
-mKW
-mKW
-mEB
-mAN
-eZw
+vTS
+fYo
+vTS
+xsH
+xsH
+vLw
+xSY
+dre
+tGw
 xND
-mAN
-mAN
-ycR
-kcN
-hKr
-kcN
+xSY
+xsH
+xsH
+jvs
 kcN
 kcN
 kcN
 kcN
+wNg
 kcN
-kcN
-kcN
-kcN
-kcN
-kcN
-kcN
-kcN
-kcN
-hKr
-kcN
-kcN
+vAu
+iaE
+vAu
+vAu
+vAu
+iaE
+vAu
+iaE
+vAu
+vAu
+vAu
+nql
 uWi
 mAN
 mAN
-bZy
 mAN
-mAN
-mAN
-ieI
-ryY
-dXp
-wrr
-kSv
-mvY
-mAN
-mAN
-mAN
-mAN
-eZM
-kfq
-mAN
+qNK
+vrE
+vrE
+vrE
+vrE
+vrE
+tAS
 mAN
 mAN
 xsH
 xsH
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
 bsh
 bsh
-soK
 bsh
 bsh
 bsh
 bsh
 bsh
-rog
 hov
-rog
+bsh
 bsh
 bsh
 bsh
@@ -34839,9 +32644,7 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
+bsh
 bsh
 bsh
 bsh
@@ -34850,75 +32653,77 @@ bsh
 bsh
 mAN
 mAN
-mAN
+agM
+vrE
+bgX
 kol
+mAN
+mAN
 hzJ
-hzJ
-hzJ
-mAN
-kbq
-mKW
-mKW
-mKW
-mKW
-nms
-mKW
-gVz
-mAN
-mAN
+fYo
+vTS
+xsH
+xsH
+dnh
+xSY
+xSY
+xSY
+xSY
+xSY
+xsH
 mAN
 mAN
-veb
-wfi
-wfi
-wfi
-wfi
-wfi
-wfi
-wfi
-rrt
-wfi
-wfi
-wfi
-wfi
-wfi
-wfi
-scA
+mAN
+mAN
+mAN
+kcN
+wNg
 kcN
 mAN
+wWE
+wWE
+wWE
+wWE
+mAN
+kCt
 mAN
 mAN
-bZy
-bZy
-mAN
-wZw
-lNG
-ieI
-ryY
-mAN
-dWA
-dWA
-dSc
+scA
+wWE
+nrL
+whC
 mAN
 mAN
-tFW
-bZy
-bZy
-qrP
+mAN
+mAN
+xnc
+xSY
+xSY
+xSY
+xnc
+mAN
+mAN
+xsH
+xsH
+mAN
+xsH
+xsH
+xsH
+mAN
+mAN
 mAN
 mAN
 mAN
 xsH
-bsh
-bsh
-bsh
-soK
-bsh
+xsH
 bsh
 bsh
 bsh
 bsh
-rog
+bsh
+bsh
+bsh
+bsh
 rog
 rog
 bsh
@@ -35096,72 +32901,74 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
+soK
+soK
+soK
 bsh
 bsh
-bsh
-bsh
+mAN
+mAN
 xsH
-mAN
-mAN
-hzJ
-hzJ
-hzJ
+aTC
+xsH
+xsH
+xsH
+xsH
 vTS
-mAN
-fgt
-qMj
-huM
-bCL
+fYo
+vTS
+xsH
+xsH
+xsH
 tut
-mAN
+drs
 weT
-weT
+dSc
+ehx
+xsH
 mAN
-ugB
-ugB
-mAN
-mlI
-mAN
-qkI
-kTc
-vAC
+sRQ
 kcN
+bBo
+mAN
 kcN
+wNg
 kcN
-hKr
+mAN
+iba
+iEF
+iEF
+iEF
+pWk
 kcN
-kcN
-kcN
-vAC
-kTc
-qkI
+mAN
+mAN
+mbg
+wrr
+hoz
+wrr
+wrr
+pCA
+mAN
+mAN
+xnc
+xSY
+rJC
+xSY
+xnc
+mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
 mAN
 mAN
-sbK
-bZy
-bZy
-mAN
-mAN
-aci
-ieI
-ieI
-ryY
-mAN
-iHk
-iHk
-iHk
-mAN
-mAN
-gIv
-bZy
-bZy
-niu
 mAN
 mAN
 xsH
@@ -35174,8 +32981,6 @@ bsh
 bsh
 bsh
 bsh
-bsh
-cNF
 rog
 rog
 bsh
@@ -35353,80 +33158,80 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
+bsh
+bsh
+soK
+soK
+soK
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
+mAN
+xsH
+aWo
+bhU
+bAG
+xsH
+xsH
+cBA
+cUJ
+cBA
 xsH
 mAN
 mAN
 mAN
-eZM
 mAN
 mAN
 mAN
 mAN
+xsH
 mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-ahh
-ahh
-cmp
-ahh
-mAN
-mAN
-mAN
-mAN
-nQe
-mAN
+sRQ
+kcN
+fTR
+gAV
+gHu
+gUw
+kcN
+wWE
 wTv
-hKr
-wPe
+wTv
+wTv
+wTv
+kcN
+kEr
 mAN
 mAN
-mAN
-mAN
-mAN
-mAN
-bZy
-bZy
+mbg
+wrr
+hiL
 txu
-bZy
-bZy
-bZy
+oNM
+pHv
+mAN
 mAN
 xnc
-ieI
-ieI
-kEV
-uyN
-hbE
-wrr
-wrr
-kHJ
-mAN
-pkw
-hHq
-bZy
-pMg
+xSY
+rKb
+xSY
+xnc
 mAN
 mAN
+xsH
+xsH
+xsH
+xsH
+mAN
+mAN
+mAN
+xsH
+mAN
+mAN
+xsH
 xsH
 bsh
 bsh
 bsh
-soK
-soK
 bsh
 bsh
 bsh
@@ -35610,67 +33415,69 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
 bsh
 bsh
 bsh
+bsh
+bsh
+mAN
+mAN
+xsH
+xsH
 xsH
 mAN
 mAN
-bZy
-bZy
-bZy
-bZy
-bZy
-bZy
 mAN
-bZy
 mAN
-gog
-bxc
-gog
 mAN
-ahh
-ahh
-ahh
-ahh
-ahh
 mAN
+xsH
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+sRQ
+kcN
+fZC
 mAN
 mkZ
-mGH
 wNg
-mAN
+gXl
+wWE
 kcN
-phj
 kcN
-eZM
-bZy
-bZy
-bZy
-myJ
-bZy
-bZy
+kcN
+kcN
+kcN
+kcN
 mAN
 mAN
-mAN
-mAN
-bZy
-mAN
-ieI
-ieI
-ieI
-ryY
-gLW
-hhp
-cKF
 wrr
-xly
+wrr
+wrr
+wrr
+hoz
+wrr
+mAN
+mAN
+xnc
+xSY
+xSY
+xSY
+xnc
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
 mAN
 mAN
 mAN
@@ -35682,15 +33489,13 @@ xsH
 bsh
 bsh
 bsh
-soK
-soK
 bsh
 bsh
 bsh
 bsh
 rog
 cNF
-jPX
+cNF
 bsh
 bsh
 bsh
@@ -35867,67 +33672,70 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
 bsh
 bsh
-soK
+bsh
+bsh
+bsh
+mAN
+mAN
+xsH
+bjy
+xsH
 xsH
 mAN
 mAN
-bZy
-bZy
-nug
-bZy
-myJ
-bZy
-bZy
-bZy
-mAN
-eqF
-eqF
-eqF
-mAN
-ahh
-nVp
-ahh
-nVp
-gyP
 mAN
 mAN
-fjt
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+sRQ
+kcN
+ggN
+mAN
+kcN
 wNg
-uos
-mAN
-kcN
-hKr
 kcN
 mAN
+kcN
+iGj
+iGj
+iGj
+kcN
+kEu
 mAN
 mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-uuz
-dSf
-mAN
-bZy
-mAN
-ieI
-ozB
-xzE
-pIH
-mAN
-mKz
-oHB
+mlI
 wrr
-hQR
+wrr
+wrr
+hoz
+gPM
+mAN
+mAN
+xnc
+xSY
+xzE
+xSY
+xnc
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
 mAN
 mAN
 mAN
@@ -35937,9 +33745,6 @@ xsH
 xsH
 bsh
 bsh
-bsh
-bsh
-soK
 soK
 bsh
 bsh
@@ -36124,77 +33929,77 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
 bsh
 bsh
 bsh
+bsh
+bsh
+mAN
+mAN
+mAN
 xsH
 xsH
-mAN
-mAN
-mAN
-bZy
-bZy
-mAN
-mAN
-mAN
-bZy
-mAN
-hCt
-hCt
-hCt
-uzg
-ahh
-fKi
-ahh
-fKi
-ahh
+xsH
 mAN
 mAN
 mAN
 mAN
 mAN
-rbn
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+sRQ
 kcN
-hKr
+ghE
+mAN
 kcN
+wNg
+kcN
+mAN
 mPq
-ozS
-pCA
-osd
-rER
+mPq
+mPq
+mPq
+vsm
+mAN
+mAN
+mAN
 wqg
-nKy
-mAN
-cpp
-gkf
-mAN
-bZy
-mAN
-ieI
-ryY
+wrr
+wrr
+wrr
+hoz
+wrr
 mAN
 mAN
+xnc
+xSY
+rKn
+xSY
+xnc
 mAN
 mAN
-jGA
-rKb
-wxR
+mAN
+mAN
+mAN
+mAN
+mAN
 mAN
 mAN
 mAN
 xsH
 xsH
 xsH
-bsh
-bsh
-bsh
-bsh
+xsH
 bsh
 bsh
 bsh
@@ -36381,9 +34186,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -36391,53 +34193,59 @@ bsh
 bsh
 bsh
 bsh
+bsh
+mAN
+mAN
+mAN
+mAN
+xsH
 xsH
 mAN
 mAN
-nZb
-bZy
-bZy
-bZy
-drs
-mAN
-bZy
-mAN
-aiI
-akq
-aiI
-mAN
-ahh
-ahh
-qEC
-ahh
-ahh
 mAN
 mAN
-qkv
-dVW
-lYw
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+sRQ
+kcN
+giK
 mAN
 kcN
-hKr
+edM
 kcN
-mPq
+mAN
 vsm
-qvb
-qvb
-wHl
+vsm
+vsm
+vsm
+vsm
+mAN
+mAN
+mAN
 vqj
-mTt
-hWj
-oTJ
+wrr
+wrr
+wrr
 hiL
+oNM
 mAN
-bZy
 mAN
-ieI
-ryY
-ncc
-pxp
-gSY
+xnc
+xSY
+veb
+xSY
+xnc
+xsH
+mAN
+mAN
 mAN
 mAN
 mAN
@@ -36446,11 +34254,8 @@ mAN
 xsH
 xsH
 xsH
-bsh
-bsh
-bsh
-bsh
-bsh
+xsH
+xsH
 bsh
 bsh
 bsh
@@ -36638,9 +34443,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -36648,16 +34450,7 @@ bsh
 bsh
 bsh
 bsh
-xsH
-xsH
-mAN
-mAN
-bZy
-bZy
-bZy
-bZy
-bZy
-bZy
+bsh
 mAN
 mAN
 mAN
@@ -36670,55 +34463,67 @@ mAN
 mAN
 mAN
 mAN
-cnA
-bHb
-gXl
-ucK
-wfi
-dmO
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+sRQ
 kcN
-mPq
-pVH
-igB
-igB
-rER
+gjf
+xsH
+mkZ
+edM
+gXl
+mAN
+icJ
+vsm
+vsm
+vsm
+vsm
+mAN
+mAN
+mAN
 nKy
 faZ
-mAN
+nuf
 xuR
 igB
+pMg
 mAN
-bZy
 mAN
-pHv
-uCu
-qNK
-ura
-wrr
-rJC
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 mAN
 mAN
 mAN
 xsH
 xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 bsh
 bsh
 bsh
 bsh
 bsh
 bsh
-soK
-soK
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-dai
 rog
 rog
-bsh
+rog
+rog
+rog
 bsh
 bsh
 bsh
@@ -36895,9 +34700,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -36906,75 +34708,78 @@ bsh
 bsh
 bsh
 bsh
+bsh
+bsh
+mAN
 xsH
-xsH
-mAN
-mAN
-bZy
-sOK
-uym
 mAN
 mAN
 mAN
 mAN
-bZy
 mAN
-nDK
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+sRQ
 wUX
-sRQ
-aIS
-sRQ
-sRQ
 wUX
-kvA
-wwg
-edM
-wCN
-vts
+mAN
 kcN
-hKr
-wPe
-vkm
+edM
+kcN
 mAN
+imP
+vsm
+iVn
+vkm
+kqn
 mAN
 mAN
 mAN
 iAZ
-faZ
+vOa
+nuz
+vOa
+nWY
+gkv
+qvb
+mAN
+wrr
+rCd
+wrr
+wrr
+wrr
 mAN
 mAN
 mAN
-mAN
-myJ
-mAN
-ieI
-ryY
-qVM
-hoz
-fGz
-tkj
 mAN
 xsH
 xsH
 xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 bsh
 bsh
 bsh
 bsh
 bsh
 bsh
+rog
+rog
+rog
+rog
 bsh
-bsh
-bsh
-bsh
-soK
-soK
-soK
-bsh
-bsh
-cNF
-cNF
-cNF
 bsh
 bsh
 bsh
@@ -37152,9 +34957,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -37164,75 +34966,78 @@ bsh
 bsh
 bsh
 bsh
+bsh
+bsh
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
 xsH
 xsH
+xsH
+xsH
+xsH
 mAN
-bZy
-bZy
-bZy
 mAN
-bZy
-drs
-bZy
-bZy
 mAN
-hiN
-nbF
-nbF
-nbF
-iOq
-byI
-byI
-pEA
-nZA
-edM
-wCN
-pcc
-kcN
-hKr
-kcN
-mPq
-ozS
-pCA
-osd
-rER
-nKy
-faZ
 mAN
-cCQ
+mAN
+xsH
+gWz
+hmE
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mmy
+vOa
+vOa
+vOa
 nWY
-mAN
-bZy
-mAN
-ieI
-ryY
-ryL
-wXu
+gkv
+vOa
+qTu
+wrr
+wrr
+wrr
+wrr
 gPM
-xBO
 mAN
+mAN
+mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 xsH
 bsh
 bsh
-soK
 bsh
 bsh
 bsh
 bsh
 bsh
+rog
+rog
+rog
+rog
 bsh
-bsh
-bsh
-bsh
-soK
-soK
-soK
-bsh
-bsh
-bsh
-cNF
-cNF
-cNF
 bsh
 bsh
 bsh
@@ -37409,9 +35214,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -37422,74 +35224,77 @@ bsh
 bsh
 bsh
 bsh
+bsh
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
 xsH
 xsH
-mAN
+xsH
 bZy
-bZy
-myJ
-bZy
-bZy
-bZy
-bZy
-mAN
-iTR
 eOH
-eOH
-eOH
+bZy
 ujC
-bnB
+mtg
 wfk
 pEA
 whC
+gYe
 wCN
-tYR
+hys
 mAN
-nuz
-hKr
-kcN
-mPq
-vsm
-qvb
-qvb
-qLP
-vqj
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mvY
 rOy
+rOy
+rOy
+rOy
+pML
+vOa
 mAN
-qWZ
-ahh
-mAN
-bZy
-mAN
-ieI
-ryY
-mAN
-mAN
+rrf
+rrf
+rrf
+rrf
+sDY
 mAN
 mAN
 xsH
 xsH
-bsh
-bsh
-soK
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-soK
-soK
-soK
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 bsh
 bsh
 bsh
-cNF
-cNF
-cNF
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+rog
+rog
+rog
+rog
 bsh
 bsh
 bsh
@@ -37666,9 +35471,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -37680,71 +35482,74 @@ bsh
 bsh
 bsh
 bsh
+bsh
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
 xsH
 xsH
+bZy
+bZy
+uAJ
+uAJ
+bZy
+uAJ
+bZy
+whC
+hbE
+huM
+hBK
 mAN
 mAN
 mAN
-bZy
-bZy
-bZy
-bZy
 mAN
-iTR
-eOH
-eOH
-eOH
-aaK
-pzq
-bxu
-dOF
-mvs
-wCN
-wCN
-dXb
-kcN
-hKr
-kcN
-mPq
-pVH
-igB
-igB
-rER
-nKy
+mAN
+mAN
+mAN
+mAN
+mwr
+vOa
+vOa
+vOa
+vOa
+gkv
 vOa
 mAN
-fuq
-ahh
-mAN
-bZy
-mAN
-mvi
-gCv
+wWE
+wWE
+wWE
+wWE
+wWE
 mAN
 mAN
-mAN
-mAN
-mAN
-bsh
-bsh
-bsh
-soK
-soK
-soK
-soK
-bsh
-bsh
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 bsh
 bsh
 bsh
 bsh
-soK
-soK
-soK
 bsh
 bsh
 bsh
 bsh
+bsh
+bsh
+rog
+rog
 rog
 rog
 bsh
@@ -37923,9 +35728,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -37938,64 +35740,66 @@ bsh
 bsh
 bsh
 bsh
-xsH
-xsH
-xsH
 mAN
 mAN
-bZy
-bZy
-bZy
 mAN
-iTR
-eOH
-eOH
-eOH
-ujC
-lPy
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+xsH
+xsH
+bZy
+bZy
+uAJ
 mtg
-pEA
-wCN
-wCN
-wCN
-dXb
-kcN
-hKr
-kcN
-gNy
+bZy
+mtg
+gBg
+whC
+hcp
+hvB
+hBO
+mAN
+mAN
+mAN
+mAN
 mAN
 mAN
 mAN
 mAN
 prD
-faZ
-mAN
-kaB
-ahh
-mAN
-bZy
-mAN
+vOa
+vOa
+vOa
+vOa
+gkv
+qvb
+qVM
+rtx
 wrr
-wvt
 aJx
-aJx
+wrr
+sKJ
 mAN
 mAN
-mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 bsh
 bsh
 bsh
-soK
-soK
-soK
-soK
-soK
-soK
-soK
-soK
 bsh
 bsh
-soK
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -38005,6 +35809,7 @@ rog
 rog
 rog
 rog
+bsh
 bsh
 soK
 soK
@@ -38180,9 +35985,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -38196,72 +35998,75 @@ bsh
 bsh
 bsh
 bsh
-bsh
-xsH
-xsH
-xsH
 mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+xsH
+xsH
 bZy
 bZy
-mAN
-nKv
-fcq
-fcq
 fcq
 nOi
 jwW
 byI
-pEA
+gBD
 blH
-edM
 wCN
-dXb
-kcN
-veb
-wfi
+wCN
+wCN
+mAN
 hWj
-vqj
-dOD
-vqj
 hWj
-vqj
-fdI
+hWj
+mAN
+mAN
+mAN
+mAN
+mGp
+vOa
 fkA
-mrV
-rhl
-mAN
-bZy
+rOy
+rOy
+qbf
+rOy
 adZ
+txu
+oNM
+rTj
 wrr
-hoz
-wrr
-mvY
+sLQ
 mAN
-mAN
-mAN
+xsH
+xsH
+xsH
+xsH
+xsH
 bsh
 bsh
 bsh
 bsh
 bsh
 bsh
-soK
-soK
-soK
-soK
-soK
-soK
-soK
 bsh
 bsh
 bsh
 bsh
 bsh
 bsh
-dai
+bsh
+bsh
+pVj
+pVj
 rog
 rog
-kEu
+bsh
 bsh
 bsh
 bsh
@@ -38437,9 +36242,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -38453,49 +36255,55 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-xsH
-xsH
 mAN
 mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+xsH
+xsH
+xsH
 bZy
-mAN
-hZN
-uAJ
-ghE
-jPB
-ghE
-ghE
+bZy
+bZy
+bZy
+bZy
 uAJ
 vNy
-ewu
-edM
-nPe
-mAN
-kcN
-kcN
-kcN
-bUN
-nKy
-mRj
-nKy
-bUN
-nKy
-faZ
-bEV
-ahh
-oxp
-mAN
+whC
+hhp
+wCN
+wCN
+itA
+bZy
+bZy
 bZy
 mAN
-wsg
+mAN
+mAN
+mAN
+mHf
+vOa
+gkv
+vOa
+vOa
+vOa
+vOa
+mAN
+wrr
 hoz
-aJx
-aJx
+rUE
+wrr
+sOK
 mAN
-mAN
-mAN
+xsH
+xsH
+xsH
+xsH
 bsh
 bsh
 bsh
@@ -38511,13 +36319,10 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
-rog
-rog
 pVj
+pVj
+rog
+rog
 bsh
 bsh
 soK
@@ -38694,9 +36499,11 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
+bsh
+bsh
+bsh
+soK
+soK
 bsh
 bsh
 bsh
@@ -38705,55 +36512,53 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
 xsH
-mAN
-mAN
+xsH
+xsH
+xsH
+xsH
 bZy
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-ryV
+bZy
+mtg
+bZy
+bZy
+gkf
+bZy
+whC
 iwF
-reP
+wCN
+hCj
 mAN
-wTv
-kcN
-wPe
-gNy
-mAN
-mAN
+iJa
+iJa
+hWj
 mAN
 mAN
-nKy
-faZ
 mAN
-rfO
-oxp
 mAN
-bZy
+vOa
+vOa
+gkv
 mAN
-epr
+wWE
+qfj
+mAN
+mAN
+mAN
 oHB
+rVO
 wrr
-wrr
 mAN
-mAN
-mAN
-bsh
+xsH
+xsH
+xsH
 bsh
 bsh
 bsh
@@ -38785,9 +36590,9 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
 heT
 heT
 heT
@@ -38951,9 +36756,10 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
+bsh
+bsh
+bsh
+soK
 bsh
 bsh
 bsh
@@ -38964,52 +36770,52 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
 xsH
+xsH
+xsH
+xsH
+bZy
+emC
+uAJ
+bZy
+fIu
+bZy
+gDI
+whC
+hiN
+wCN
+hCt
 mAN
 mAN
-bZy
-bZy
-bZy
-bZy
-bZy
-myJ
-bZy
-bZy
-bZy
 mAN
 mAN
 mAN
 mAN
 mAN
-kcN
-kcN
-kcN
-mPq
-ixG
-wqg
-aaC
-pjP
-nKy
+mAN
+mKz
 vOa
+gkv
 mAN
-uLr
-oxp
-mAN
-bZy
-mAN
-mAN
-kcm
-mAN
-mAN
-mAN
-mAN
-mAN
+oTJ
+vOa
+nXp
+rbn
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 bsh
 bsh
 bsh
@@ -39027,11 +36833,10 @@ bsh
 bsh
 bsh
 bsh
-jFN
 rog
 rog
 rog
-bsh
+rog
 bsh
 bsh
 bsh
@@ -39042,9 +36847,9 @@ soK
 soK
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
 heT
 heT
 heT
@@ -39208,9 +37013,9 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
+bsh
+bsh
+soK
 bsh
 bsh
 bsh
@@ -39224,48 +37029,48 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+xsH
+mAN
+mAN
+mAN
+mAN
+hxx
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+fkA
+rOy
+nvz
+xsH
+vOa
+vOa
+vOa
+vOa
 xsH
 xsH
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-bZy
-bZy
-bZy
-bZy
-bZy
-bZy
-eZM
-kcN
-kcN
-kcN
-mPq
-dHs
-vqj
-vqj
-vqj
-vqj
-qRI
-mAN
-wAb
-oxp
-mAN
-bZy
-mAN
-qhc
-dfc
-dfc
-kEr
-mAN
-mAN
+xsH
+xsH
+xsH
+xsH
 mAN
 bsh
 bsh
@@ -39285,8 +37090,9 @@ bsh
 bsh
 bsh
 rog
-pVj
-dai
+rog
+rog
+rog
 bsh
 bsh
 bsh
@@ -39299,9 +37105,8 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
 heT
 heT
 heT
@@ -39465,14 +37270,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-bsh
-bsh
-bsh
-bsh
-bsh
 bsh
 bsh
 soK
@@ -39485,65 +37282,52 @@ bsh
 bsh
 bsh
 bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+mAN
+xsH
+mAN
+mAN
 xsH
 xsH
 mAN
 mAN
 mAN
 mAN
+xsH
+mAN
+xsH
+gIv
+vTS
+vTS
+vTS
+gIv
 mAN
 mAN
 mAN
 mAN
 mAN
-bZy
-bZy
-bZy
-bZy
-mAN
-kcN
-qkI
-kcN
-mPq
-rBV
-nKy
-mRj
-nKy
-nKy
-nKy
-mAN
-eiF
-uvh
-mAN
-bZy
-mAN
-qBS
-dfc
-dfc
-wBi
 mAN
 mAN
-mAN
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-rog
-rog
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-rog
-rog
-rog
+gkv
+vOa
+vOa
+xsH
+vOa
+vOa
+vOa
+vOa
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
 bsh
 bsh
 bsh
@@ -39556,9 +37340,30 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+cNF
+cNF
+cNF
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 heT
 heT
@@ -39722,9 +37527,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -39732,33 +37534,36 @@ bsh
 bsh
 bsh
 bsh
-soK
 bsh
-soK
-soK
-soK
-soK
-soK
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
 bsh
 xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
+mAN
+mAN
 xsH
 xsH
 xsH
 mAN
-rEO
-tOo
-bZy
 mAN
 mAN
+xsH
+mAN
+xsH
+vTS
+vTS
+vTS
+vTS
+vTS
 mAN
 mAN
 mAN
@@ -39767,29 +37572,30 @@ mAN
 mAN
 mAN
 gkv
-gkv
+vOa
+vOa
 mAN
-mAN
-mAN
-mAN
+oYr
+vOa
 nXp
-mAN
-dfc
-dfc
-dfc
-dfc
-mAN
-mAN
-mAN
+reP
+xsH
+xsH
+xsH
+xsH
+xsH
 bsh
 bsh
 bsh
 bsh
 bsh
-rog
-qfj
-fZC
-rog
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -39804,7 +37610,6 @@ bsh
 bsh
 bsh
 bsh
-bsh
 soK
 soK
 soK
@@ -39813,9 +37618,9 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
 heT
 heT
 heT
@@ -39979,9 +37784,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -39990,12 +37792,6 @@ bsh
 bsh
 bsh
 bsh
-bsh
-soK
-soK
-soK
-soK
-soK
 bsh
 bsh
 bsh
@@ -40009,34 +37805,55 @@ bsh
 bsh
 bsh
 xsH
+mAN
+mAN
+xsH
+xsH
 xsH
 xsH
 mAN
 mAN
-bZy
+xsH
 mAN
-nKa
-bxc
+xsH
+gLD
+vTS
+pwr
+vTS
 nKa
 mAN
-ybF
-qCV
-mAN
-iDb
-fPP
-fPP
-tmY
-mAN
-mAN
-bZy
-bZy
 mAN
 mAN
 mAN
 mAN
 mAN
 mAN
+mRj
+nbF
+wWE
 mAN
+mAN
+mAN
+mAN
+xsH
+mAN
+mAN
+mAN
+mAN
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -40044,19 +37861,8 @@ bsh
 bsh
 bsh
 rog
-vwg
 rog
-qfj
-giK
-nTV
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-cNF
-cNF
+rog
 bsh
 bsh
 bsh
@@ -40064,15 +37870,14 @@ bsh
 bsh
 bsh
 bsh
-soK
 bsh
 bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
 heT
 heT
 dgR
@@ -40236,23 +38041,12 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-soK
-soK
-soK
-soK
-soK
 bsh
 bsh
 bsh
@@ -40270,66 +38064,77 @@ bsh
 xsH
 mAN
 mAN
-myJ
+xsH
+mAN
+xsH
+xsH
+xsH
+mAN
+xsH
+xsH
+xsH
+mAN
+mAN
+xsH
+xsH
+mAN
 mAN
 eqF
-aJe
-eqF
-mAN
 trF
-kcN
+trF
+trF
 bje
-fPP
-fPP
-fPP
+wrr
+hoz
+wrr
 wAT
 mAN
-bZy
-bZy
-bZy
 mAN
 mAN
 mAN
+xsH
 mAN
 mAN
-mAN
-mAN
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
 bsh
 bsh
 rog
-aWo
+pVj
 rog
-bjy
-dai
-cNF
-iVn
 rog
 bsh
 bsh
 bsh
 bsh
 bsh
-rog
-cNF
-cNF
 bsh
 bsh
 bsh
 bsh
 bsh
 bsh
-soK
 bsh
 bsh
 bsh
-bsh
-bsh
-heT
-heT
-heT
 heT
 mBf
 jON
@@ -40493,23 +38298,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-soK
-soK
-soK
-soK
-soK
 bsh
 bsh
 bsh
@@ -40524,31 +38312,44 @@ bsh
 bsh
 bsh
 bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+mAN
+mAN
 xsH
 mAN
 mAN
-bZy
+xsH
+xsH
+xsH
+xsH
+xsH
+mAN
+xsH
+xsH
+mAN
+mAN
+mAN
 mAN
 noS
-hCt
-noS
-lSm
-vAC
-kcN
-mAN
-eql
-fPP
-fPP
-wAT
-mAN
-bZy
-bZy
+wrr
+wrr
+wrr
+kRm
+wrr
+hiL
+txu
+nyL
 mAN
 mAN
-mAN
-mAN
-mAN
-mAN
+xsH
+xsH
+xsH
 mAN
 bsh
 bsh
@@ -40556,37 +38357,41 @@ bsh
 bsh
 bsh
 bsh
-vBQ
-evR
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 rog
 rog
 rog
-bsh
-rog
-qfj
 rog
 bsh
 bsh
 bsh
 bsh
-rog
-rog
-rog
-bsh
-bsh
-bsh
-bsh
-soK
-soK
-soK
 bsh
 bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 jON
 mBf
@@ -40750,23 +38555,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-soK
-soK
-soK
-soK
-soK
 bsh
 bsh
 bsh
@@ -40781,28 +38569,58 @@ bsh
 bsh
 bsh
 bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+xsH
 xsH
 mAN
 mAN
-bZy
 mAN
-aiI
-hcp
-aiI
-mAN
-mAN
-lSm
-mAN
-fPP
-fPP
-fPP
-icJ
-mAN
-bZy
+xsH
+xsH
 mAN
 mAN
 mAN
 mAN
+noS
+wrr
+wrr
+wrr
+kRm
+wrr
+mTt
+wrr
+wrr
+mWs
+xsH
+xsH
+xsH
+xsH
+mAN
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -40814,19 +38632,6 @@ bsh
 bsh
 rog
 rog
-qfj
-qsp
-bsh
-bsh
-bsh
-bsh
-rog
-rog
-sct
-bsh
-bsh
-bsh
-bsh
 rog
 rog
 bsh
@@ -40835,15 +38640,15 @@ bsh
 bsh
 bsh
 bsh
-soK
 bsh
 bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
 heT
 jON
 jON
@@ -41007,9 +38812,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -41020,15 +38822,6 @@ bsh
 bsh
 bsh
 bsh
-soK
-soK
-bsh
-soK
-soK
-soK
-soK
-soK
-soK
 bsh
 bsh
 bsh
@@ -41038,27 +38831,40 @@ bsh
 bsh
 bsh
 bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+mAN
+mAN
+mAN
+mAN
+xsH
+mAN
+mAN
+mAN
+xsH
+mAN
+mAN
+mAN
+mAN
+mAN
+noS
+wrr
+wrr
+wrr
+kRm
+wrr
+dBr
+wrr
+nDB
+ogy
+xsH
+xsH
 xsH
 xsH
 mAN
-bZy
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-xjk
-mAN
-itA
-dBr
-itA
-dBr
-mAN
-nXp
-mAN
-mAN
-mAN
 bsh
 bsh
 bsh
@@ -41069,38 +38875,37 @@ bsh
 bsh
 bsh
 bsh
-rog
-hxx
-rog
-utf
 bsh
 bsh
 bsh
 bsh
 bsh
 bsh
-sct
-bsh
-bsh
-bsh
-bsh
-rog
-hov
-rog
 bsh
 bsh
 bsh
 bsh
 bsh
-soK
+cNF
+cNF
+cNF
 bsh
 bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 jON
 jON
@@ -41264,9 +39069,9 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -41281,11 +39086,6 @@ soK
 soK
 bsh
 bsh
-soK
-soK
-soK
-soK
-soK
 bsh
 bsh
 bsh
@@ -41294,56 +39094,37 @@ bsh
 bsh
 bsh
 bsh
-bsh
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+xsH
+mAN
+mAN
+mAN
+mAN
+mAN
+noS
+wrr
+wrr
+wrr
+kRm
+wrr
+wrr
+niu
+wrr
+nDK
 xsH
 xsH
-mAN
-bZy
-bZy
-bZy
-bZy
-bZy
-bZy
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-nXp
-mAN
+xsH
 mAN
 mAN
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-rog
-qfj
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-cNF
-cNF
-bsh
-bsh
-bsh
-rog
-rog
-rog
 bsh
 bsh
 bsh
@@ -41355,9 +39136,33 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+bsh
+rog
+rog
+rog
+cNF
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 jON
 jON
@@ -41521,9 +39326,10 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -41546,61 +39352,35 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
+mAN
+mAN
+mAN
+xsH
+mAN
+mAN
 xsH
 mAN
 mAN
 mAN
 mAN
 mAN
+noS
+wrr
+wrr
+wrr
+kRm
 mAN
-bZy
-myJ
-myJ
-bZy
-nXp
-bZy
-bZy
-bZy
-bZy
-bZy
+mWs
+njb
+nDK
+xsH
+xsH
+mAN
 mAN
 mAN
 mAN
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-osK
-osK
-hBO
-osK
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-cNF
-bsh
-bsh
-bsh
-rog
-aCL
-rog
 bsh
 bsh
 bsh
@@ -41612,9 +39392,34 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+bsh
+rog
+rog
+pVj
+rog
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 jON
 jON
@@ -41778,9 +39583,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -41789,47 +39591,6 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-xsH
-xsH
-xsH
-xsH
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-mAN
-xsH
-mAN
 bsh
 bsh
 bsh
@@ -41840,18 +39601,56 @@ bsh
 soK
 bsh
 bsh
-osK
-deX
-deX
-osK
 bsh
 bsh
 bsh
-soK
-soK
 bsh
 bsh
-cNF
+bsh
+bsh
+bsh
+bsh
+mAN
+mAN
+xsH
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+xsH
+iVH
+wrr
+wrr
+wrr
+kSv
+xsH
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -41861,17 +39660,23 @@ rog
 bsh
 bsh
 bsh
-soK
-soK
 bsh
 bsh
 bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 mBf
 mBf
@@ -42035,9 +39840,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -42066,14 +39868,21 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
+mAN
+mAN
+mAN
 xsH
+mAN
+mAN
+mAN
+mAN
+mAN
 xsH
-xsH
-xsH
-xsH
+noS
+wrr
+wrr
+wrr
+kRm
 xsH
 mAN
 mAN
@@ -42082,10 +39891,6 @@ mAN
 mAN
 mAN
 mAN
-mAN
-xsH
-xsH
-xsH
 bsh
 bsh
 bsh
@@ -42094,31 +39899,19 @@ bsh
 bsh
 bsh
 bsh
-soK
-bsh
-bsh
-osK
-deX
-uBh
-osK
 bsh
 bsh
 bsh
-soK
-soK
 bsh
 bsh
-sct
+bsh
+bsh
+bsh
+bsh
 bsh
 bsh
 rog
 rog
-rog
-ouy
-bsh
-bsh
-bsh
-soK
 bsh
 bsh
 bsh
@@ -42126,9 +39919,21 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 heT
 heT
@@ -42292,61 +40097,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
 bsh
 bsh
 bsh
@@ -42354,27 +40104,70 @@ bsh
 soK
 bsh
 bsh
-osK
-swN
-deX
-osK
 bsh
 bsh
 bsh
-soK
 bsh
-soK
 bsh
-cbv
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+mAN
+xsH
+xsH
+mAN
+mAN
+mAN
+mAN
+mAN
+xsH
+noS
+wrr
+wrr
+wrr
+kRm
+xsH
+mAN
+mAN
+mAN
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 rog
-rog
-rog
-rog
-rog
-bsh
-bsh
-bsh
-soK
 bsh
 bsh
 bsh
@@ -42383,9 +40176,21 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 heT
 heT
@@ -42549,84 +40354,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-soK
-bsh
-bsh
-osK
-osK
-osK
-osK
-bsh
-bsh
-bsh
-soK
-bsh
-soK
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
 bsh
 bsh
 bsh
@@ -42640,9 +40367,87 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+mAN
+xsH
+xsH
+mAN
+mAN
+mAN
+mAN
+xsH
+xsH
+noS
+wrr
+wrr
+wrr
+kRm
+xsH
+mAN
+mAN
+mAN
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+rog
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 heT
 mBf
@@ -42806,9 +40611,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -42838,6 +40640,24 @@ bsh
 bsh
 bsh
 bsh
+mAN
+xsH
+xsH
+mAN
+mAN
+mAN
+xsH
+xsH
+mAN
+iXy
+jDJ
+jDJ
+jDJ
+kTc
+xsH
+xsH
+mAN
+mAN
 bsh
 bsh
 bsh
@@ -42861,11 +40681,11 @@ bsh
 bsh
 bsh
 bsh
+rog
 bsh
 bsh
 bsh
 bsh
-soK
 bsh
 bsh
 bsh
@@ -42875,9 +40695,7 @@ bsh
 bsh
 bsh
 bsh
-soK
 bsh
-soK
 bsh
 bsh
 bsh
@@ -42887,19 +40705,6 @@ bsh
 bsh
 bsh
 bsh
-soK
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-heT
-heT
-heT
 heT
 heT
 mBf
@@ -43063,44 +40868,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
 bsh
 bsh
 bsh
@@ -43123,27 +40890,33 @@ bsh
 bsh
 bsh
 soK
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
 soK
-bsh
+soK
 soK
 bsh
 bsh
 bsh
 bsh
 bsh
+xsH
+mAN
+mAN
+mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+mAN
 bsh
 bsh
 bsh
-soK
 bsh
 bsh
 bsh
@@ -43154,9 +40927,41 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+rog
+rog
+rog
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 heT
 wUe
@@ -43320,43 +41125,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
 bsh
 bsh
 bsh
@@ -43380,6 +41148,43 @@ bsh
 bsh
 bsh
 soK
+bsh
+soK
+bsh
+bsh
+bsh
+bsh
+bsh
+mAN
+mAN
+mAN
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+xsH
+mAN
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+soK
 soK
 bsh
 bsh
@@ -43389,17 +41194,9 @@ bsh
 bsh
 bsh
 bsh
-soK
-soK
-soK
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-soK
+rog
+rog
+rog
 bsh
 bsh
 bsh
@@ -43411,9 +41208,17 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 heT
 wUe
@@ -43577,9 +41382,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -43612,16 +41414,19 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
+mAN
 bsh
 bsh
 bsh
@@ -43646,18 +41451,10 @@ bsh
 bsh
 bsh
 bsh
-soK
-soK
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-soK
-soK
-bsh
+rog
+rog
+rog
+rog
 bsh
 bsh
 bsh
@@ -43668,9 +41465,17 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 heT
 wUe
@@ -43834,9 +41639,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -43865,9 +41667,6 @@ bsh
 bsh
 bsh
 bsh
-soK
-soK
-soK
 bsh
 bsh
 bsh
@@ -43894,17 +41693,6 @@ bsh
 bsh
 bsh
 bsh
-soK
-soK
-bsh
-bsh
-soK
-soK
-soK
-soK
-soK
-soK
-soK
 bsh
 bsh
 bsh
@@ -43912,7 +41700,19 @@ bsh
 bsh
 bsh
 soK
-soK
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+vwg
+vwg
+jLk
+jLk
+jLk
+vwg
 bsh
 bsh
 bsh
@@ -43925,9 +41725,14 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 heT
 mBf
@@ -44091,9 +41896,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -44112,23 +41914,6 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-soK
-soK
-bsh
-soK
-soK
-soK
-soK
 bsh
 bsh
 bsh
@@ -44143,17 +41928,20 @@ bsh
 bsh
 bsh
 soK
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
+soK
 bsh
 soK
 soK
+soK
+soK
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -44176,15 +41964,32 @@ bsh
 bsh
 bsh
 bsh
+vwg
+jLk
+jLk
+jLk
+jLk
+vwg
 bsh
 bsh
 bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 heT
 ieZ
@@ -44348,9 +42153,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -44358,9 +42160,12 @@ bsh
 bsh
 bsh
 bsh
+soK
+soK
 bsh
 bsh
 bsh
+soK
 bsh
 bsh
 bsh
@@ -44410,13 +42215,18 @@ bsh
 bsh
 bsh
 bsh
-soK
-soK
-soK
-soK
-soK
-soK
-soK
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+vwg
+jLk
+vCD
+jLk
+jLk
+vwg
 bsh
 bsh
 bsh
@@ -44437,11 +42247,6 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-heT
-heT
-heT
 heT
 heT
 gBL
@@ -44605,20 +42410,20 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
 bsh
 bsh
+soK
+soK
+soK
 bsh
 bsh
 bsh
 bsh
-bsh
-bsh
+soK
+soK
 bsh
 bsh
 bsh
@@ -44675,6 +42480,10 @@ bsh
 bsh
 bsh
 bsh
+jLk
+jLk
+jLk
+vwg
 bsh
 bsh
 bsh
@@ -44695,10 +42504,6 @@ bsh
 bsh
 bsh
 bsh
-bsh
-heT
-heT
-heT
 heT
 heT
 tfw
@@ -44862,9 +42667,12 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
+bsh
+bsh
+soK
+bsh
+soK
+soK
 bsh
 bsh
 bsh
@@ -44872,10 +42680,7 @@ bsh
 bsh
 bsh
 bsh
-bsh
-bsh
-bsh
-bsh
+soK
 bsh
 bsh
 bsh
@@ -44934,6 +42739,8 @@ bsh
 bsh
 bsh
 bsh
+jLk
+vwg
 bsh
 bsh
 bsh
@@ -44953,9 +42760,7 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
 heT
 heT
 mBf
@@ -45119,11 +42924,11 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
+bsh
+bsh
+soK
 bsh
 bsh
 bsh
@@ -45210,9 +43015,9 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
 heT
 heT
 wUe
@@ -45376,11 +43181,11 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
+bsh
+bsh
+soK
 bsh
 bsh
 bsh
@@ -45467,9 +43272,9 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
 heT
 heT
 wUe
@@ -45633,9 +43438,9 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -45724,9 +43529,9 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
 heT
 heT
 wUe
@@ -45890,9 +43695,9 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -45981,9 +43786,9 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
 heT
 heT
 mBf
@@ -46147,9 +43952,9 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -46238,9 +44043,9 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
 heT
 heT
 mBf
@@ -46404,45 +44209,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-soK
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-bsh
-soK
-soK
-soK
 bsh
 bsh
 bsh
@@ -46479,6 +44245,9 @@ bsh
 bsh
 bsh
 bsh
+soK
+soK
+soK
 bsh
 bsh
 bsh
@@ -46495,9 +44264,45 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+soK
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 heT
 mBf
@@ -46661,9 +44466,9 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
+bsh
+bsh
+bsh
 bsh
 bsh
 bsh
@@ -46752,9 +44557,9 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
 heT
 heT
 mBf
@@ -46918,9 +44723,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -47009,9 +44811,12 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 heT
 mBf
@@ -47175,9 +44980,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -47266,9 +45068,12 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 heT
 mBf
@@ -47432,9 +45237,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -47523,9 +45325,12 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 heT
 mBf
@@ -47689,9 +45494,6 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
 bsh
 bsh
 bsh
@@ -47780,9 +45582,12 @@ bsh
 bsh
 bsh
 bsh
-heT
-heT
-heT
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
 heT
 heT
 mBf

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -531,9 +531,9 @@
 	},
 /area/f13/wasteland)
 "alI" = (
-/obj/structure/simple_door/house{
-	icon_state = "glassclosing"
-	},
+/obj/item/twohanded/required/kirbyplants/dead,
+/obj/item/reagent_containers/pill/fixer,
+/obj/item/reagent_containers/pill/insulin,
 /turf/open/floor/wood,
 /area/f13/building)
 "alJ" = (
@@ -712,8 +712,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/building)
 "apt" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/inside/mountain,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "apw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1014,13 +1013,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"awc" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
-/obj/item/pen/fountain,
-/turf/open/floor/wood,
-/area/f13/building)
 "awj" = (
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife,
@@ -1291,10 +1283,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/red,
 /area/f13/building)
-"aDU" = (
-/obj/machinery/vending/cola/red,
-/turf/open/floor/wood,
-/area/f13/building)
 "aDX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office/dark{
@@ -1361,10 +1349,6 @@
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/building)
-"aGH" = (
-/obj/structure/sign/poster/official/high_class_martini,
-/turf/closed/wall/rust,
 /area/f13/building)
 "aGS" = (
 /obj/effect/decal/cleanable/dirt{
@@ -1704,14 +1688,6 @@
 /obj/item/stack/sheet/glass,
 /obj/item/stack/sheet/glass,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/building)
-"aOM" = (
-/obj/structure/chair{
-	dir = 1;
-	icon_state = "chair"
-	},
-/obj/machinery/light,
-/turf/open/floor/wood,
 /area/f13/building)
 "aOO" = (
 /obj/item/caution{
@@ -2947,16 +2923,6 @@
 	icon_state = "verticalinnermain2bottom"
 	},
 /area/f13/wasteland)
-"buj" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Private"
-	},
-/obj/item/storage/keys_set,
-/obj/item/storage/keys_set,
-/turf/open/floor/wood,
-/area/f13/building)
 "buu" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -4670,8 +4636,10 @@
 	},
 /area/f13/wasteland)
 "coQ" = (
-/obj/machinery/smartfridge/drying_rack,
-/turf/open/indestructible/ground/inside/mountain,
+/turf/closed/wall/f13/store{
+	desc = "A pre-War wall made of solid concrete.";
+	name = "concrete wall"
+	},
 /area/f13/tunnel)
 "coW" = (
 /obj/structure/chair/wood{
@@ -5069,24 +5037,6 @@
 	color = "#363636"
 	},
 /turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"cBz" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey{
-	pixel_x = 6;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/food/drinks/bottle/whiskey{
-	pixel_x = -6;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/food/drinks/bottle/absinthe{
-	pixel_x = -6
-	},
-/obj/item/reagent_containers/food/drinks/bottle/absinthe{
-	pixel_x = 6
-	},
-/turf/open/floor/wood,
 /area/f13/building)
 "cBC" = (
 /obj/structure/sign/poster/official/obey{
@@ -5522,9 +5472,6 @@
 	},
 /obj/item/reagent_containers/pill/patch/turbo{
 	layer = 2.4
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/f13/building)
@@ -6687,15 +6634,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/clinic)
-"dot" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/obj/structure/sign/poster/official/soft_cap_pop_art{
-	pixel_y = -32
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "doB" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood{
@@ -6833,12 +6771,6 @@
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
-/area/f13/building)
-"dsl" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
 /area/f13/building)
 "dsn" = (
 /obj/structure/curtain{
@@ -8431,6 +8363,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"eis" = (
+/obj/machinery/door/airlock/grunge/abandoned{
+	name = "Abandoned Bunker"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "eiB" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/item/reagent_containers/food/drinks/beer/light{
@@ -8708,12 +8646,6 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
-"eoy" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/f13/building)
 "eoA" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light,
@@ -8767,10 +8699,6 @@
 	icon_state = "verticalrightborderlefttop"
 	},
 /area/f13/wasteland)
-"epP" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood,
-/area/f13/building)
 "epT" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8887,11 +8815,6 @@
 	color = "000000"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"etu" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/kitchen/fork,
-/turf/open/floor/carpet/red,
 /area/f13/building)
 "etG" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -9217,6 +9140,14 @@
 /obj/structure/table/wood/fancy/royalblack,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"eBy" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "vault1";
+	name = "Old Ladder"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "eBB" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/brews,
 /turf/open/floor/f13{
@@ -10528,12 +10459,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"feM" = (
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowbrokenvertical"
-	},
-/turf/open/floor/wood,
-/area/f13/building)
 "feR" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -10626,10 +10551,7 @@
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
-/obj/structure/chair/office{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/wood,
 /area/f13/building)
 "fgG" = (
 /obj/machinery/computer/operating,
@@ -10788,7 +10710,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fkD" = (
-/obj/machinery/computer/communications,
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/wood,
 /area/f13/building)
 "fkF" = (
@@ -10864,7 +10787,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "fmN" = (
-/obj/structure/filingcabinet/employment,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/f13/building)
 "fmP" = (
@@ -11118,12 +11043,6 @@
 /area/f13/bar)
 "ftu" = (
 /obj/structure/dresser,
-/turf/open/floor/carpet/red,
-/area/f13/building)
-"ftw" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/trash/plate,
-/obj/item/kitchen/fork,
 /turf/open/floor/carpet/red,
 /area/f13/building)
 "ftz" = (
@@ -12503,14 +12422,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
 "gdJ" = (
-/obj/structure/showcase/machinery/microwave,
-/obj/structure/table,
-/obj/structure/sign/poster/prewar/poster89{
-	pixel_y = 27
-	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/f13/building)
 "gdN" = (
@@ -14040,12 +13952,11 @@
 	},
 /area/f13/building)
 "gPd" = (
-/obj/item/storage/fancy/rollingpapers,
-/obj/item/storage/fancy/rollingpapers,
-/obj/item/storage/fancy/rollingpapers,
-/obj/item/lighter,
 /obj/structure/rack,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/item/storage/fancy/rollingpapers,
+/obj/item/storage/fancy/rollingpapers,
+/obj/item/storage/fancy/rollingpapers,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "gPg" = (
 /obj/structure/table/reinforced,
@@ -14130,13 +14041,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"gRu" = (
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_x = 30
-	},
-/turf/open/floor/wood,
-/area/f13/building)
 "gRU" = (
 /obj/structure/rack,
 /obj/item/storage/backpack,
@@ -14177,12 +14081,6 @@
 "gSG" = (
 /obj/structure/chair/comfy/plywood,
 /turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"gSH" = (
-/obj/item/storage/secure/safe{
-	pixel_x = -21
-	},
-/turf/open/floor/wood,
 /area/f13/building)
 "gSS" = (
 /obj/structure/barricade/wooden,
@@ -15404,10 +15302,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"hsZ" = (
-/obj/machinery/light,
-/turf/open/floor/wood,
-/area/f13/building)
 "htf" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -15642,10 +15536,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"hyH" = (
-/obj/machinery/vending/games,
-/turf/open/floor/wood,
-/area/f13/building)
 "hyU" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Armory";
@@ -15905,12 +15795,6 @@
 	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland)
-"hGe" = (
-/obj/structure/showcase/machinery/tv{
-	name = "Pre-war television"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "hGf" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 4
@@ -16330,13 +16214,6 @@
 /obj/structure/stacklifter,
 /turf/open/floor/f13,
 /area/f13/building)
-"hPE" = (
-/obj/structure/chair{
-	dir = 1;
-	icon_state = "chair"
-	},
-/turf/open/floor/wood,
-/area/f13/building)
 "hPL" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder,
@@ -16532,10 +16409,6 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building)
-"hUw" = (
-/obj/structure/simple_door/metal/store,
-/turf/open/floor/wood,
 /area/f13/building)
 "hUK" = (
 /obj/structure/table/wood/settler,
@@ -16758,11 +16631,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "iam" = (
-/obj/structure/showcase/machinery/tv{
-	name = "Pre-war television"
-	},
-/obj/structure/sign/poster/prewar/poster90{
-	pixel_y = 27
+/obj/structure/table/wood,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/pen,
+/obj/item/pen,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1{
+	layer = 2.1
 	},
 /turf/open/floor/wood,
 /area/f13/building)
@@ -18231,14 +18108,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "iLD" = (
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
 /obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/cultivator,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "iLI" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -18927,12 +18802,6 @@
 	},
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood/f13/oak,
-/area/f13/building)
-"iZI" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/wood,
 /area/f13/building)
 "iZJ" = (
 /obj/structure/rack,
@@ -19832,10 +19701,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"jtO" = (
-/obj/structure/chair,
-/turf/open/floor/wood,
-/area/f13/building)
 "juc" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -20415,12 +20280,9 @@
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
 "jJa" = (
-/obj/structure/showcase/machinery/tv{
-	name = "Pre-war television"
-	},
-/obj/structure/sign/poster/prewar/poster89{
-	pixel_y = 27
-	},
+/obj/structure/table/wood,
+/obj/item/phone,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/wood,
 /area/f13/building)
 "jJb" = (
@@ -21556,8 +21418,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building)
 "khy" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/glass/fifty,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
 /turf/open/floor/wood,
 /area/f13/building)
 "khB" = (
@@ -21766,10 +21628,6 @@
 /obj/item/circuitboard/machine/chem_dispenser,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/building)
-"kor" = (
-/obj/structure/sign/poster/official/anniversary_vintage_reprint,
-/turf/closed/wall/rust,
 /area/f13/building)
 "kow" = (
 /obj/effect/turf_decal/stripes/line{
@@ -22144,10 +22002,6 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
-"kyx" = (
-/obj/structure/sign/poster/official/help_others,
-/turf/closed/wall/rust,
-/area/f13/building)
 "kyT" = (
 /obj/structure/chair/sofa/corp/corner,
 /obj/effect/decal/cleanable/dirt,
@@ -22278,11 +22132,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/building)
-"kCh" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/bundle/f13/huntingshotgun,
-/turf/open/floor/wood,
 /area/f13/building)
 "kCs" = (
 /obj/item/ammo_casing/a50MG,
@@ -22601,12 +22450,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
-"kKu" = (
-/obj/structure/table/wood/settler,
-/obj/item/flashlight/lamp,
-/obj/item/stack/f13Cash/random/med,
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "kLc" = (
 /obj/effect/decal/cleanable/shreds{
 	pixel_x = -6;
@@ -24457,12 +24300,6 @@
 /obj/structure/bonfire,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"lKi" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "lKl" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/chem_dispenser/drinks,
@@ -24935,14 +24772,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
-"lVi" = (
-/obj/effect/landmark/start/f13/radio,
-/obj/structure/bed/pod,
-/obj/item/bedsheet{
-	icon_state = "sheethos"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "lVn" = (
 /obj/item/clothing/under/f13/rag,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25044,15 +24873,6 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/bar)
-"lYE" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/trash/plate,
-/obj/item/kitchen/fork,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "lYF" = (
 /obj/structure/closet/cardboard,
 /obj/item/storage/briefcase,
@@ -25287,12 +25107,6 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/building)
-"mer" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
 /area/f13/building)
 "mfg" = (
 /obj/structure/rack,
@@ -25878,10 +25692,6 @@
 "mtV" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"muh" = (
-/obj/structure/sign/poster/official/cohiba_robusto_ad,
-/turf/closed/wall/rust,
 /area/f13/building)
 "muk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -27897,6 +27707,10 @@
 /obj/item/seeds/poppy/broc,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
+"nzZ" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "nAh" = (
 /obj/machinery/light/small,
 /turf/open/water,
@@ -28932,12 +28746,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"nZH" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/f13/building)
 "nZJ" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -29224,12 +29032,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"oiJ" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/wood,
 /area/f13/building)
 "ojl" = (
 /obj/structure/table/reinforced,
@@ -29597,10 +29399,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"osk" = (
-/obj/structure/chair/f13chair1,
-/turf/open/floor/wood,
-/area/f13/building)
 "osm" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -29975,12 +29773,6 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building)
-"oCc" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/wood,
 /area/f13/building)
 "oCi" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -31254,7 +31046,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "pir" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/f13/building)
 "pis" = (
@@ -33051,6 +32845,9 @@
 	color = "000000"
 	},
 /obj/structure/simple_door/interior,
+/obj/machinery/door/poddoor/shutters{
+	id = "mayor"
+	},
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/building)
 "pXx" = (
@@ -33196,6 +32993,11 @@
 /obj/structure/flora/junglebush/c,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"qaV" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "qbe" = (
 /obj/structure/sink{
 	dir = 8;
@@ -33845,12 +33647,6 @@
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
-"qsS" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "qsX" = (
 /obj/machinery/vending/medical{
 	req_access = null
@@ -34136,8 +33932,10 @@
 	},
 /area/f13/building)
 "qAU" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/metal/fifty,
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	name = "prewar lounge chair"
+	},
 /turf/open/floor/wood,
 /area/f13/building)
 "qBa" = (
@@ -34521,12 +34319,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"qKf" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "qKu" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -35478,11 +35270,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"rhP" = (
-/obj/structure/displaycase/trophy,
-/obj/item/reagent_containers/food/drinks/trophy/silver_cup,
-/turf/open/floor/wood,
-/area/f13/building)
 "rhT" = (
 /obj/structure/simple_door/interior,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -35598,14 +35385,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"rkR" = (
-/obj/structure/displaycase/trophy,
-/obj/item/reagent_containers/food/drinks/trophy/gold_cup,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/f13/building)
 "rkZ" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -35956,10 +35735,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/legion)
-"rvm" = (
-/obj/structure/showcase/cyborg/old,
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "rvr" = (
 /turf/open/floor/wood,
 /area/f13/building)
@@ -36678,11 +36453,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
-"rPC" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
-/turf/open/floor/wood,
-/area/f13/building)
 "rPI" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bottle/blackpowder,
@@ -37269,11 +37039,11 @@
 	},
 /area/f13/caves)
 "sfP" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/plastic/fifty,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/structure/table/wood,
+/obj/item/pen/fountain,
+/obj/item/pen/fountain,
+/obj/item/pen/fountain,
+/obj/item/pen/fountain,
 /turf/open/floor/wood,
 /area/f13/building)
 "sgd" = (
@@ -37735,10 +37505,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/village)
-"sqv" = (
-/obj/machinery/autolathe,
-/turf/open/floor/wood,
-/area/f13/building)
 "sqx" = (
 /obj/structure/dresser,
 /obj/item/warpaint_bowl,
@@ -37968,17 +37734,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"sva" = (
-/obj/item/storage/trash_stack,
+"svA" = (
+/mob/living/simple_animal/hostile/cazador/young,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+	dir = 4;
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
-"svA" = (
-/obj/structure/sign/poster/contraband/red_rum,
-/turf/closed/wall/rust,
-/area/f13/building)
 "svF" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -38295,16 +38057,6 @@
 /obj/item/kitchen/knife/butcher,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"sFJ" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/obj/structure/sign/poster/official/obey{
-	pixel_y = -32
-	},
-/obj/machinery/light,
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "sGg" = (
 /obj/structure/chair/bench,
 /obj/structure/flora/grass/wasteland{
@@ -40772,9 +40524,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland)
 "tOU" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/cardboard/fifty,
-/turf/open/floor/wood,
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/chapel{
+	dir = 5
+	},
 /area/f13/building)
 "tOV" = (
 /obj/structure/barricade/wooden,
@@ -41093,11 +40846,6 @@
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
-"tVL" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/trash/plate,
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "tVQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -41160,10 +40908,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
-"tXu" = (
-/obj/structure/table,
-/turf/open/floor/wood,
-/area/f13/building)
 "tXv" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
@@ -41206,10 +40950,6 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
-"tYw" = (
-/obj/machinery/vending/cola,
-/turf/open/floor/wood,
-/area/f13/building)
 "tYJ" = (
 /obj/structure/chair/wood,
 /mob/living/simple_animal/hostile/ghoul/reaver,
@@ -41226,10 +40966,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"tZe" = (
-/obj/structure/window/fulltile/store,
-/turf/open/floor/wood,
-/area/f13/building)
 "tZs" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -41852,10 +41588,6 @@
 /obj/structure/decoration/rag,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"uoe" = (
-/obj/structure/sign/poster/official/fruit_bowl,
-/turf/closed/wall/rust,
-/area/f13/building)
 "uom" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -42537,38 +42269,10 @@
 /turf/open/floor/carpet,
 /area/f13/building)
 "uDk" = (
-/obj/structure/table/wood/settler,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/obj/item/key,
-/turf/open/floor/wood,
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/chapel{
+	dir = 1
+	},
 /area/f13/building)
 "uDt" = (
 /obj/effect/decal/cleanable/dirt{
@@ -42739,11 +42443,6 @@
 	},
 /turf/open/floor/wood/f13/stage_br,
 /area/f13/wasteland)
-"uGg" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/wood,
-/area/f13/building)
 "uGn" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowhorizontal"
@@ -43759,13 +43458,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/building)
-"vdG" = (
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_x = -30
-	},
-/turf/open/floor/wood,
-/area/f13/building)
 "vej" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
@@ -44297,29 +43989,6 @@
 	icon_state = "outermaincornerouter"
 	},
 /area/f13/wasteland)
-"vqS" = (
-/obj/structure/closet/cabinet/anchored,
-/obj/item/clothing/neck/tie/blue,
-/obj/item/clothing/neck/tie/red,
-/obj/item/clothing/neck/tie/horrible,
-/obj/item/clothing/neck/tie/black,
-/obj/item/clothing/under/suit/black,
-/obj/item/clothing/under/suit/black/skirt,
-/obj/item/clothing/under/suit/black_really,
-/obj/item/clothing/under/suit/burgundy,
-/obj/item/clothing/under/suit/charcoal,
-/obj/item/clothing/under/suit/checkered,
-/obj/item/clothing/under/suit/green,
-/obj/item/clothing/under/suit/navy,
-/obj/item/clothing/under/suit/polychromic,
-/obj/item/clothing/under/suit/red,
-/obj/item/clothing/under/suit/sl,
-/obj/item/clothing/under/suit/tan,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/head/fedora,
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "vrB" = (
 /obj/item/trash/f13/electronic/toaster{
 	pixel_x = -5;
@@ -46319,10 +45988,6 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood)
-"wsO" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood,
-/area/f13/building)
 "wsR" = (
 /obj/structure/filingcabinet/employment,
 /obj/effect/decal/cleanable/dirt,
@@ -47205,12 +46870,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"wNh" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "wNn" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -47559,12 +47218,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"wTx" = (
-/obj/structure/table/wood/settler,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
-/turf/open/floor/wood,
-/area/f13/building)
 "wTA" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
@@ -47595,12 +47248,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"wUa" = (
-/obj/structure/table/wood,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/turf/open/floor/wood,
-/area/f13/building)
 "wUc" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -47841,11 +47488,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"wZf" = (
-/obj/structure/displaycase/trophy,
-/obj/item/reagent_containers/food/drinks/trophy/bronze_cup,
-/turf/open/floor/wood,
-/area/f13/building)
 "wZi" = (
 /obj/structure/weightlifter,
 /turf/open/floor/wood/f13/oak,
@@ -47871,13 +47513,6 @@
 	},
 /turf/open/floor/wood/f13/old/ruinedstraightsouth,
 /area/f13/wasteland)
-"xaf" = (
-/obj/machinery/vending/boozeomat,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/f13/building)
 "xaj" = (
 /obj/structure/debris/v4,
 /turf/closed/wall/r_wall/rust,
@@ -48126,7 +47761,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xft" = (
-/obj/structure/chair/comfy/shuttle,
+/obj/structure/table/wood,
+/obj/item/papercutter,
 /turf/open/floor/wood,
 /area/f13/building)
 "xfy" = (
@@ -48616,9 +48252,6 @@
 /area/f13/building)
 "xqa" = (
 /obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/open/floor/wood,
 /area/f13/building)
 "xql" = (
@@ -49435,15 +49068,15 @@
 	},
 /area/f13/wasteland)
 "xJv" = (
-/obj/structure/table/wood/poker,
-/obj/item/radio/intercom{
-	name = "radio station intercom";
-	pixel_y = 30
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/button/door{
+	id = "mayor";
+	pixel_x = 1;
+	pixel_y = 36
 	},
-/turf/open/floor/wood/f13/carpet,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "xJz" = (
 /obj/structure/window/fulltile/house{
@@ -49705,12 +49338,6 @@
 /obj/item/candle/infinite,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xPb" = (
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowbroken"
-	},
-/turf/open/floor/wood,
-/area/f13/building)
 "xPd" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -49794,6 +49421,11 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"xSf" = (
+/obj/structure/rack,
+/obj/item/cultivator,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "xSl" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 8;
@@ -50048,15 +49680,6 @@
 	icon_state = "horizontaltopbordertop2right"
 	},
 /area/f13/wasteland)
-"xYM" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "xYN" = (
 /obj/structure/chair{
 	dir = 4
@@ -50340,23 +49963,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/legion)
-"yec" = (
-/obj/structure/table,
-/obj/item/paper/crumpled/ruins,
-/obj/item/paper/crumpled/ruins,
-/obj/item/paper/crumpled/ruins,
-/obj/item/paper/crumpled/ruins,
-/obj/item/paper/crumpled/ruins,
-/obj/item/paper/crumpled/ruins,
-/obj/item/paper/crumpled/ruins,
-/obj/item/paper/crumpled/ruins,
-/obj/item/paper/crumpled/ruins,
-/obj/item/paper/crumpled/ruins,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/f13/building)
 "yeh" = (
 /obj/machinery/vending/nukacolavend,
 /obj/effect/decal/cleanable/dirt,
@@ -51888,12 +51494,12 @@ gbL
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+coQ
+coQ
+coQ
+coQ
+coQ
+coQ
 gcK
 gcK
 gcK
@@ -52145,12 +51751,12 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-mwp
-mwp
-wEs
-mwp
+coQ
+gPd
+apt
+nzZ
+nzZ
+coQ
 gcK
 gcK
 gcK
@@ -52402,12 +52008,12 @@ gcK
 gcK
 gcK
 gcK
-gcK
-mwp
+coQ
+iLD
 apt
-mwp
 apt
-mwp
+apt
+coQ
 gcK
 gcK
 mwp
@@ -52659,12 +52265,12 @@ gcK
 gcK
 gcK
 gcK
-mwp
-mwp
+coQ
+eBy
 apt
-mwp
 apt
-mwp
+apt
+coQ
 mwp
 mwp
 mwp
@@ -52916,12 +52522,12 @@ gcK
 gcK
 gcK
 gcK
-mwp
-mwp
-mwp
-mwp
-mwp
-mwp
+gcK
+apt
+apt
+apt
+apt
+eis
 mwp
 uYx
 mwp
@@ -53173,12 +52779,12 @@ gbL
 gbL
 gcK
 gcK
-mwp
-mwp
+gcK
+gcK
+qaV
 apt
-mwp
 apt
-mwp
+coQ
 mwp
 mwp
 mwp
@@ -53430,12 +53036,12 @@ gbL
 gbL
 gcK
 gcK
-mwp
-mwp
-apt
-mwp
-apt
-mwp
+gcK
+gcK
+gcK
+gcK
+xSf
+gcK
 gcK
 gcK
 gcK
@@ -53689,10 +53295,10 @@ gcK
 gcK
 gcK
 gcK
-iLD
-gPd
-mwp
-coQ
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -75788,7 +75394,7 @@ sYX
 nMs
 sYX
 pzh
-ozq
+xJv
 ozq
 sYX
 daU
@@ -88385,7 +87991,7 @@ mfD
 mfD
 mfD
 mfD
-sva
+mfD
 mfD
 mfD
 mfD
@@ -88637,18 +88243,18 @@ gjP
 gjP
 fyf
 fyf
-kEI
-kEI
-kEI
-kEI
-kEI
-kEI
-kEI
-kEI
-kEI
-kEI
-kEI
-kEI
+fyf
+fyf
+fyf
+fyf
+fyf
+sND
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 jNE
 tFP
@@ -88893,19 +88499,19 @@ uRJ
 uRJ
 srw
 fyf
-sND
-kEI
-fkD
-oiJ
-rvr
-osk
-yec
-tZe
-vdG
-oCc
-oCc
-vdG
-kEI
+fyf
+fyf
+bBK
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 vfY
 jNE
@@ -89151,18 +88757,18 @@ uRJ
 srw
 fyf
 fyf
-kEI
-gdJ
-rvr
-rvr
-osk
-tXu
-tZe
-jtO
-rPC
-tXu
-aOM
-kEI
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+sND
+fyf
 fyf
 jNE
 tOR
@@ -89408,18 +89014,18 @@ uRJ
 gjP
 fyf
 fyf
-kEI
-iam
-rvr
-rvr
-osk
-awc
-tZe
-jtO
-tXu
-rPC
-hPE
-kEI
+fyf
+fyf
+tOH
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fqa
 gbG
@@ -89664,19 +89270,19 @@ uRJ
 uRJ
 srw
 fyf
-tOH
-kEI
-jJa
-rvr
-rvr
-rvr
-rvr
-hUw
-gRu
-eoy
-eoy
-gRu
-kEI
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 jPo
 ugm
@@ -89922,18 +89528,18 @@ wSw
 srw
 fyf
 fyf
-kEI
-kEI
-kEI
-kEI
-vCc
-kEI
-kEI
-kEI
+fyf
+fyf
+fyf
+hAC
+fyf
+qOV
+cWG
+cWG
 svA
-kor
-kEI
-kEI
+fyf
+fyf
+fyf
 fyf
 jNE
 tEW
@@ -90179,18 +89785,18 @@ nHE
 srw
 fyf
 fyf
-jJb
-kEI
-rhP
-xPb
-rvr
-rvr
-wNh
-wNh
-xYM
-wNh
-lKi
-kEI
+fyf
+fyf
+fyf
+fyf
+qOV
+daU
+mvv
+mvv
+bpD
+fyf
+fyf
+fyf
 fyf
 jNE
 jNE
@@ -90435,19 +90041,19 @@ jnX
 gjP
 gjP
 fyf
-tOH
 fyf
-kEI
-rkR
-xPb
-rvr
-rvr
-rvr
-rvr
-rvr
-rvr
-dot
-kEI
+fyf
+fyf
+fyf
+mtL
+tBN
+mvv
+mvv
+mvv
+xxf
+fyf
+fyf
+fyf
 fyf
 jNE
 btk
@@ -90694,17 +90300,17 @@ srw
 fyf
 fyf
 sND
-kEI
-wZf
-xPb
-nZH
-rvr
-aGH
-feM
-muh
-rvr
-lKi
-kEI
+fyf
+fyf
+qOV
+vGg
+mPh
+mvv
+mvv
+bpD
+fyf
+fyf
+fyf
 fyf
 vfY
 dKr
@@ -90950,19 +90556,19 @@ kfo
 srw
 fyf
 fyf
-kEI
-kEI
-kEI
-kEI
-kEI
-rvr
-xPb
-hGe
-xPb
-rvr
-lKi
-kEI
 fyf
+fyf
+fyf
+tBN
+mvv
+mvv
+bet
+mvv
+bpD
+fyf
+fyf
+fyf
+qTY
 twP
 xGH
 xAx
@@ -91207,18 +90813,18 @@ gjP
 gjP
 fyf
 fyf
-kEI
-khy
-gSH
-wUa
-kEI
-mer
-xPb
-rvm
-xPb
-rvr
-lKi
-kEI
+fyf
+fyf
+rtR
+tBN
+bet
+mvv
+mvv
+aBH
+hCg
+fyf
+fyf
+fyf
 fyf
 qvN
 fXh
@@ -91464,18 +91070,18 @@ tJz
 srw
 fyf
 fyf
-kEI
-qAU
-rvr
-kCh
-kEI
-rvr
-xPb
-hGe
-xPb
-rvr
-sFJ
-kEI
+fyf
+fyf
+qOV
+daU
+mvv
+aBH
+mfD
+hCg
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -91721,18 +91327,18 @@ tJz
 srw
 fyf
 fyf
-kEI
-sfP
-rvr
-rvr
-vCc
-rvr
-kyx
-feM
-uoe
-rvr
-lKi
-kEI
+fyf
+fyf
+nlO
+mfD
+mfD
+hCg
+fyf
+fyf
+yaz
+fyf
+fyf
+sND
 fyf
 htO
 qUC
@@ -91978,18 +91584,18 @@ gjP
 gjP
 fyf
 fyf
-kEI
-tOU
-rvr
-cBz
-kEI
-rvr
-rvr
-rvr
-rvr
-rvr
-lKi
-kEI
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 xyX
 qyR
@@ -92235,19 +91841,19 @@ llj
 srw
 fyf
 fyf
-kEI
-sqv
-rvr
-uGg
-kEI
-rvr
-rvr
-rvr
-aDU
-tYw
-pir
-kEI
-sND
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 xyX
 pcP
 hgJ
@@ -92497,9 +92103,9 @@ kEI
 kEI
 kEI
 kEI
-wsO
-rvr
-hsZ
+kEI
+kEI
+kEI
 kEI
 kEI
 kEI
@@ -92513,7 +92119,7 @@ qyR
 hpj
 fyf
 fyf
-dDC
+fyf
 fyf
 sVO
 uxC
@@ -92755,7 +92361,7 @@ wln
 jxo
 kEI
 rvr
-rvr
+pir
 rvr
 kEI
 aOL
@@ -93527,7 +93133,7 @@ daM
 kEI
 xqa
 rvr
-rvr
+gdJ
 kEI
 kEI
 kEI
@@ -93787,7 +93393,7 @@ rvr
 rvr
 rvr
 rvr
-iZI
+rvr
 rvr
 exL
 kEI
@@ -94292,7 +93898,7 @@ dMW
 thG
 fyf
 kEI
-xJv
+vma
 sWI
 pIk
 kEI
@@ -95070,7 +94676,7 @@ kEI
 kEI
 kEI
 kEI
-kEI
+rvr
 xgi
 fOw
 nlA
@@ -95320,16 +94926,16 @@ dMW
 thG
 fyf
 kEI
-dsl
-dsl
 rvr
-kEI
+rvr
+rvr
+rvr
 pir
-xaf
-hyH
-kEI
 rvr
-nZH
+rvr
+rvr
+rvr
+rvr
 rvr
 oyW
 kEI
@@ -95577,15 +95183,15 @@ dMW
 thG
 fyf
 kEI
-lYE
-ftw
 rvr
+xrQ
+eRO
 alI
+iam
+sfP
+xrQ
+eRO
 rvr
-rvr
-rvr
-kEI
-alI
 kEI
 kEI
 kEI
@@ -95834,14 +95440,14 @@ dMW
 thG
 fyf
 kEI
-tVL
-etu
 rvr
-kEI
-alI
-kEI
-kEI
-kEI
+xgi
+fOw
+rvr
+rvr
+khy
+tOU
+fOw
 rvr
 kEI
 wCA
@@ -96092,13 +95698,13 @@ thG
 fyf
 kEI
 fgB
-qsS
 rvr
-kEI
 rvr
-oyW
-wTx
-epP
+rvr
+qAU
+xqa
+rvr
+rvr
 rvr
 iwm
 rRe
@@ -96348,15 +95954,15 @@ dMW
 thG
 fyf
 kEI
-kEI
-kEI
-alI
-kEI
+rvr
+mnG
+fCA
+fkD
 rvr
 xft
 uDk
-epP
-hsZ
+fCA
+rvr
 kEI
 kEI
 kEI
@@ -96605,14 +96211,14 @@ edA
 thG
 fyf
 kEI
-qKf
-giO
-giO
-kEI
 rvr
-rvr
-buj
-epP
+nlA
+gkZ
+exL
+jJa
+mgV
+nlA
+gkZ
 rvr
 iwm
 rRe
@@ -96862,15 +96468,15 @@ fyf
 thG
 fyf
 kEI
-vqS
-kKu
-lVi
-kEI
+rvr
+rvr
+rvr
+rvr
 fmN
-nZH
 rvr
 rvr
-tYw
+rvr
+rvr
 kEI
 rRe
 oHe

--- a/_maps/shuttles/cargo_pahrump.dmm
+++ b/_maps/shuttles/cargo_pahrump.dmm
@@ -12,7 +12,10 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/supply)
 "d" = (
-/obj/structure/simple_door/bunker,
+/obj/structure/simple_door/bunker{
+	CanAtmosPass = 0;
+	CanAtmosPassVertical = 0
+	},
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "e" = (
@@ -71,7 +74,10 @@
 	dwidth = 5;
 	width = 12
 	},
-/obj/structure/simple_door/bunker,
+/obj/structure/simple_door/bunker{
+	CanAtmosPass = 0;
+	CanAtmosPassVertical = 0
+	},
 /turf/open/floor/plating,
 /area/shuttle/supply)
 

--- a/code/modules/cargo/packs/armory.dm
+++ b/code/modules/cargo/packs/armory.dm
@@ -36,7 +36,7 @@
 	cost = 1700
 	contains = list(/obj/item/storage/box/chemimp)
 	crate_name = "chemical implant crate"
-
+/*
 /datum/supply_pack/security/armory/ballistic
 	name = "Combat Shotguns Crate"
 	desc = "For when the enemy absolutely needs to be replaced with lead. Contains three Aussec-designed Combat Shotguns, with three Shotgun Bandoliers, as well as seven buchshot and 12g shotgun slugs. Requires Armory access to open."
@@ -49,7 +49,7 @@
 					/obj/item/storage/belt/bandolier,
 					/obj/item/ammo_box/shotgun/buck)
 	crate_name = "combat shotguns crate"
-
+*/
 /datum/supply_pack/security/armory/dragnetgun
 	name = "DRAGnet gun Crate"
 	desc = "Contains two DRAGnet guns. A Dynamic Rapid-Apprehension of the Guilty net the revolution in law enforcement technology that YOU Want! Requires Armory access to open."
@@ -67,14 +67,14 @@
 					/obj/item/gun/energy/e_gun)
 	crate_name = "energy gun crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
-
+/*
 /datum/supply_pack/security/armory/exileimp // Theres boxes in 2 lockers as well as gateway never realy being used sad
 	name = "Exile Implants Crate"
 	desc = "Contains five Exile implants. Requires Armory access to open."
 	cost = 1050 //stops endless points
 	contains = list(/obj/item/storage/box/exileimp)
 	crate_name = "exile implant crate"
-
+*/
 /datum/supply_pack/security/armory/mindshield
 	name = "Mindshield Implants Crate"
 	desc = "Prevent against radical thoughts with three Mindshield implants. Requires Armory access to open."
@@ -88,7 +88,7 @@
 	cost = 1100
 	contains = list(/obj/item/storage/box/trackimp)
 	crate_name = "tracking implant crate"
-
+/*
 /datum/supply_pack/security/armory/fire
 	name = "Incendiary Weapons Crate"
 	desc = "Burn, baby burn. Contains three incendiary grenades, seven incendiary slugs, three plasma canisters, and a flamethrower. Requires Brige access to open."
@@ -124,7 +124,7 @@
 					/obj/item/clothing/suit/armor/laserproof)
 	crate_name = "reflector vest crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
-
+*/
 /datum/supply_pack/security/armory/riotarmor
 	name = "Riot Armor Crate"
 	desc = "Contains three sets of heavy body armor. Advanced padding protects against close-ranged weaponry, making melee attacks feel only half as potent to the user. Requires Armory access to open."
@@ -191,7 +191,7 @@
 					/obj/item/clothing/gloves/tackler/combat/insulated,
 					/obj/item/clothing/gloves/tackler/combat/insulated)
 	crate_name = "swat crate"
-
+/*
 /datum/supply_pack/security/armory/wt550ammo_nonlethal // Takes around 12 shots to stamcrit someone
 	name = "WT-550 Semi-Auto SMG Non-Lethal Ammo Crate"
 	desc = "Contains four 32-round magazines for the WT-550 Semi-Auto SMG. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
@@ -202,9 +202,10 @@
 					/obj/item/ammo_box/magazine/wt550m9/wtrubber)
 	crate_name = "auto rifle ammo crate"
 
-///datum/supply_pack/security/armory/hell_single
-//	name = "Hellgun Single-Pack"
-//	crate_name = "hellgun crate"
-//	desc = "Contains one hellgun, an old pattern of laser gun infamous for its ability to horribly disfigure targets with burns. Technically violates the Geneva Convention when used on humanoids."
-//	cost = 1500
-//	contains = list(/obj/item/gun/energy/laser/hellgun)
+datum/supply_pack/security/armory/hell_single
+	name = "Hellgun Single-Pack"
+	crate_name = "hellgun crate"
+	desc = "Contains one hellgun, an old pattern of laser gun infamous for its ability to horribly disfigure targets with burns. Technically violates the Geneva Convention when used on humanoids."
+	cost = 1500
+	contains = list(/obj/item/gun/energy/laser/hellgun)
+*/

--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -14,8 +14,8 @@
 	desc = "TUNNEL SNAKES OWN THIS TOWN. Contains an unbranded All Terrain Vehicle, two cans of spraypaint, and a complete gang outfit -- consists of black gloves, a menacing skull bandanna, and a SWEET leather overcoat!"
 	cost = 2500
 	contraband = TRUE
-	contains = list(/obj/vehicle/ridden/atv,
-					/obj/item/key,
+	contains = list(// /obj/vehicle/ridden/atv,
+					// /obj/item/key,
 					/obj/item/toy/crayon/spraycan,
 					/obj/item/toy/crayon/spraycan,
 					/obj/item/clothing/suit/jacket/leather/overcoat,
@@ -284,7 +284,7 @@
 					/obj/item/tank/jetpack/carbondioxide/eva)
 	crate_name = "eva jetpacks crate"
 	crate_type = /obj/structure/closet/crate/secure
-*/
+*//*
 /datum/supply_pack/emergency/specialops
 	name = "Special Ops Supplies"
 	desc = "(*!&@#NEED SOMETHING TO DEAL WITH THE GREYTIDE, HUH OPERATIVE? WELL, THIS LITTLE ORDER CAN HELP YOU OUT IN A PINCH. CONTAINS A BOX OF FIVE EMP GRENADES, THREE SMOKEBOMBS, AN INCENDIARY GRENADE, AND A \"SLEEPY PEN\" FULL OF NICE TOXINS!#@*$"
@@ -298,7 +298,7 @@
 					/obj/item/grenade/chem_grenade/incendiary)
 	crate_name = "emergency crate"
 	crate_type = /obj/structure/closet/crate/internals
-
+*/
 /datum/supply_pack/emergency/weedcontrol
 	name = "Weed Control Crate"
 	desc = "Keep those invasive species OUT. Contains a scythe, gasmask, two sprays of Plant-B-Gone, and two anti-weed chemical grenades. Warranty void if used on ambrosia. Requires Hydroponics access to open."

--- a/code/modules/cargo/packs/engineering.dm
+++ b/code/modules/cargo/packs/engineering.dm
@@ -153,7 +153,7 @@
 	cost = 1200
 	crate_name = "toolbox crate"
 	special = TRUE //Department resupply shuttle loan event.
-
+/* Stop nuking the fucking NCR!
 /datum/supply_pack/engineering/bsa
 	name = "Bluespace Artillery Parts"
 	desc = "The pride of Nanotrasen Naval Command. The legendary Bluespace Artillery Cannon is a devastating feat of human engineering and testament to wartime determination. Highly advanced research is required for proper construction. "
@@ -165,7 +165,7 @@
 					/obj/item/circuitboard/computer/bsa_control
 					)
 	crate_name= "bluespace artillery parts crate"
-/*
+
 /datum/supply_pack/engineering/dna_vault
 	name = "DNA Vault Parts"
 	desc = "Secure the longevity of the current state of civilization within this massive library of scientific knowledge, capable of granting superhuman powers and abilities. Highly advanced research is required for proper construction. Also contains five DNA probes." //C'mon now, it's nae just humans on the station these days

--- a/code/modules/cargo/packs/livestock.dm
+++ b/code/modules/cargo/packs/livestock.dm
@@ -5,7 +5,7 @@
 //////////////////////////////////////////////////////////////////////////////
 ////////////////////////////// Livestock /////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
-
+/* AHHHHHHHHAHAHAHAH HAHAHAHAHAHAH HAHAHAHA- Wait, you actually want to teleport 40 cow crates to the BoS?
 /datum/supply_pack/critter
 	group = "Livestock"
 	crate_type = /obj/structure/closet/crate/critter
@@ -186,3 +186,4 @@
 					/mob/living/simple_animal/hostile/retaliate/bat/secbat,
 					/mob/living/simple_animal/hostile/retaliate/bat/secbat)
 	crate_name = "security bat crate"
+*/

--- a/code/modules/cargo/packs/materials.dm
+++ b/code/modules/cargo/packs/materials.dm
@@ -84,7 +84,7 @@
 //////////////////////////////////////////////////////////////////////////////
 ///////////////////////////// Canisters //////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
-
+/* Sorry! No war crimes here!
 /datum/supply_pack/materials/bz
 	name = "BZ Canister Crate"
 	desc = "Contains a canister of BZ. Requires Toxins access to open."
@@ -118,7 +118,7 @@
 	contains = list(/obj/machinery/portable_atmospherics/canister/nitrous_oxide)
 	crate_name = "nitrous oxide canister crate"
 	crate_type = /obj/structure/closet/crate/secure
-
+*/
 /datum/supply_pack/materials/oxygen
 	name = "Oxygen Canister"
 	desc = "Contains a canister of Oxygen. Canned in Druidia."

--- a/code/modules/cargo/packs/misc.dm
+++ b/code/modules/cargo/packs/misc.dm
@@ -17,7 +17,7 @@
 /datum/supply_pack/misc/anvil
 	name = "Anvil Crate"
 	desc = "An anvil in a crate, we had to dig this out of the old warehouse. It's got wheels on it so you can move it."
-	cost = 7500
+	cost = 12500 // 7500 was alot, 12500 is more :)
 	contains = list(/obj/structure/anvil/obtainable/basic)
 
 /datum/supply_pack/misc/artsupply
@@ -168,7 +168,7 @@
 	. = ..()
 	for(var/i in 1 to 9)
 		new /obj/item/coin/silver(.)
-
+/*
 /datum/supply_pack/misc/dueling_stam
 	name = "Dueling Pistols"
 	desc = "Resolve all your quarrels with some nonlethal fun."
@@ -213,7 +213,7 @@
 	for(var/i in 1 to num_contained)
 		var/item = pick_n_take(L)
 		new item(C)
-
+*/
 //////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////// Misc Supplies //////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
@@ -266,18 +266,18 @@
 	desc = "Bling out with this crate of jewelry. Includes gold necklace and a set of two rings."
 	cost = 5000
 	contains = list(/obj/item/clothing/neck/necklace/dope,
-					/obj/item/storage/fancy/ringbox,
+					/obj/item/storage/fancy/ringbox, // Chance of a D-Ring spawning, worth the 5000 if anyone actually finds out about that
 					/obj/item/storage/fancy/ringbox/silver
 					)
 	crate_name = "jewelry crate"
-
+/* Lag boxes
 /datum/supply_pack/misc/jukebox
 	name = "Jukebox"
 	cost = 10000
 	contains = list(/obj/machinery/jukebox)
 	crate_name = "Jukebox"
-
-/datum/supply_pack/misc/abandonedcrate
+*/
+/datum/supply_pack/misc/abandonedcrate // 15,000 for a tiny chance at a potentially kinda useful item
 	name = "Loot Box"
 	desc = "Try your luck with these highly secure loot boxes! Solve the lock, win great prizes! WARNING: EXPLOSIVE FAILURE."
 	contraband = TRUE
@@ -398,7 +398,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////// Lewd Supplies ///////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
-
+/* No.
 /datum/supply_pack/misc/lewd
 	name = "Lewd Crate" // OwO
 	desc = "Pssst, want to have a good time with your sluts? Well I got what you want! Maid clothing, dildos, collars and more!"
@@ -452,3 +452,4 @@
 			continue
 		crate_value -= I.cost
 		new I.item(C)
+*/

--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -340,11 +340,11 @@
 /datum/supply_pack/organic/exoticseeds
 	name = "Seeds Crate (Exotic)"
 	desc = "Any entrepreneuring botanist's dream. Contains twelve different seeds, including three replica-pod seeds and two mystery seeds!"
-	cost = 1500
+	cost = 9500 // 9500 for some useless stuff and 2 exotic seeds
 	contains = list(/obj/item/seeds/nettle,
-					/obj/item/seeds/replicapod,
-					/obj/item/seeds/replicapod,
-					/obj/item/seeds/replicapod,
+					///obj/item/seeds/replicapod,
+					///obj/item/seeds/replicapod,
+					///obj/item/seeds/replicapod,
 					/obj/item/seeds/plump,
 					/obj/item/seeds/liberty,
 					/obj/item/seeds/amanita,

--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -9,7 +9,7 @@
 /datum/supply_pack/science
 	group = "Science"
 	crate_type = /obj/structure/closet/crate/science
-
+/*
 /datum/supply_pack/science/ape  //Ape out!
 	name = "Ape Cube Crate"
 	desc = "Pss what a new test subject with supper strangth, speed, and love for bananas all at the same time? Say no more... Contains a single ape cube. Dont add water!"
@@ -18,7 +18,7 @@
 	contains = list (/obj/item/reagent_containers/food/snacks/cube/ape)
 	crate_name = "ape cube crate"
 	can_private_buy = FALSE
-
+*/
 /datum/supply_pack/science/beakers
 	name = "Chemistry Beakers Crate"
 	desc = "Glassware for any chemistry lab! Contains four small beakers, three large, two plastic, and one metamaterial. As well as three droppers and two pairs of latex gloves."
@@ -40,7 +40,7 @@
 					/obj/item/clothing/gloves/color/latex,
 					/obj/item/clothing/gloves/color/latex)
 	crate_name = "chemistry beaker crate"
-
+/* Cant get the frame parts or stuff anyways, but still
 /datum/supply_pack/science/robotics/mecha_odysseus
 	name = "Circuit Crate (Odysseus)"
 	desc = "Ever wanted to build your own giant medical robot? Well, now you can! Contains the Odysseus main control board and Odysseus peripherals board. Requires Robotics access to open."
@@ -61,7 +61,7 @@
 					/obj/item/circuitboard/mecha/ripley/peripherals)
 	crate_name = "\improper APLU Ripley circuit crate"
 	crate_type = /obj/structure/closet/crate/secure/science
-
+*/
 /datum/supply_pack/science/circuitry
 	name = "Circuitry Starter Pack Crate"
 	desc = "Journey into the mysterious world of Circuitry with this starter pack. Contains a circuit printer, analyzer, debugger and wirer. Power cells not included."
@@ -118,6 +118,7 @@
 	crate_name = "plasma assembly crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
 */
+/*
 /datum/supply_pack/science/relic
 	name = "Relic Crate"
 	desc = "Ever wanted to play with old discounted toys? Look no further. Contains two relics."
@@ -126,7 +127,7 @@
 	contains = list(/obj/item/relic,
 					/obj/item/relic)
 	crate_name = "relic crate"
-
+*/
 /datum/supply_pack/science/robotics
 	name = "Robotics Assembly Crate"
 	desc = "The tools you need to replace those finicky humans with a loyal robot army! Contains three proximity sensors, two high-powered cells, six flashes, and an electrical toolbox. Requires Robotics access to open."
@@ -160,7 +161,7 @@
 					/obj/machinery/shieldwallgen)
 	crate_name = "shield generators crate"
 	crate_type = /obj/structure/closet/crate/secure/science
-
+/*
 /datum/supply_pack/science/slime
 	name = "Slime Core Crate"
 	desc = "Ran out of slimes? No problem, contains one gray slime core. Requires Xenobio access to open."
@@ -169,7 +170,7 @@
 	contains = list(/obj/item/slime_extract/grey)
 	crate_name = "slime core crate"
 	crate_type = /obj/structure/closet/crate/secure/science
-
+*/
 /datum/supply_pack/science/tablets
 	name = "Tablet Crate"
 	desc = "What's a computer? Contains five cargo tablets."
@@ -181,6 +182,7 @@
 					/obj/item/modular_computer/tablet/preset/cargo)
 	crate_name = "tablet crate"
 
+/* Removed, FO13
 /datum/supply_pack/science/transfer_valves
 	name = "Tank Transfer Valves Crate"
 	desc = "The key ingredient for making a lot of people very angry very fast. Contains two tank transfer valves. Requires RD access to open."
@@ -191,6 +193,7 @@
 	crate_name = "tank transfer valves crate"
 	crate_type = /obj/structure/closet/crate/secure/science
 	dangerous = TRUE
+*/
 
 //////// RAW ANOMALY CORES
 /*

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -28,7 +28,7 @@
 					/obj/item/clothing/suit/armor/vest,
 					/obj/item/clothing/suit/armor/vest)
 	crate_name = "armor crate"
-/*
+/* Pew pew legion ded.
 /datum/supply_pack/security/disabler
 	name = "Disabler Crate"
 	desc = "Three stamina-draining disabler weapons. Requires Security access to open."

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -11,7 +11,7 @@
 	access = ACCESS_SECURITY
 	crate_type = /obj/structure/closet/crate/secure/gear
 	can_private_buy = FALSE
-
+/*
 /datum/supply_pack/security/ammo
 	name = "Ammo Crate - General Purpose"
 	desc = "Contains two 20-round magazines for the WT-550 Auto Rifle, three boxes of buckshot ammo, three boxes of rubber ammo and special .38 speedloarders. Requires Security access to open."
@@ -19,7 +19,7 @@
 	contains = list(/obj/item/ammo_box/shotgun/buck,
 					/obj/item/ammo_box/shotgun/buck)
 	crate_name = "ammo crate"
-
+*/
 /datum/supply_pack/security/armor
 	name = "Armor Crate"
 	desc = "Three vests of well-rounded, decently-protective armor. Requires Security access to open."
@@ -28,7 +28,7 @@
 					/obj/item/clothing/suit/armor/vest,
 					/obj/item/clothing/suit/armor/vest)
 	crate_name = "armor crate"
-
+/*
 /datum/supply_pack/security/disabler
 	name = "Disabler Crate"
 	desc = "Three stamina-draining disabler weapons. Requires Security access to open."
@@ -37,7 +37,7 @@
 					/obj/item/gun/energy/disabler,
 					/obj/item/gun/energy/disabler)
 	crate_name = "disabler crate"
-
+*/
 /datum/supply_pack/security/forensics
 	name = "Forensics Crate"
 	desc = "Stay hot on the criminal's heels with Nanotrasen's Detective Essentials(tm). Contains a forensics scanner, six evidence bags, camera, tape recorder, white crayon, and of course, a fedora. Requires Security access to open."
@@ -59,7 +59,7 @@
 					/obj/item/clothing/head/helmet/sec,
 					/obj/item/clothing/head/helmet/sec)
 	crate_name = "helmet crate"
-
+/*
 /datum/supply_pack/security/laser
 	name = "Lasers Crate"
 	desc = "Contains three lethal, high-energy laser guns. Requires Security access to open."
@@ -68,8 +68,8 @@
 					/obj/item/gun/energy/laser,
 					/obj/item/gun/energy/laser)
 	crate_name = "laser crate"
-
-/datum/supply_pack/security/russianclothing
+*/
+/datum/supply_pack/security/russianclothing // Just some armor, may lead to LRP though so leaving this comment here
 	name = "Russian Surplus Clothing"
 	desc = "An old russian crate full of surplus armor that they used to use! Has two sets of bulletproff armor, a few union suits and some warm hats!"
 	contraband = TRUE
@@ -157,7 +157,7 @@
 					/obj/item/clothing/mask/gas/sechailer)
 	crate_name = "security clothing crate"
 	can_private_buy = TRUE
-
+/*
 /datum/supply_pack/security/baton
 	name = "Stun Batons Crate"
 	desc = "Arm the Civil Protection Forces with three stun batons. Batteries included. Requires Security access to open."
@@ -175,7 +175,7 @@
 					/obj/item/gun/energy/e_gun/advtaser,
 					/obj/item/gun/energy/e_gun/advtaser)
 	crate_name = "taser crate"
-
+*/
 /datum/supply_pack/security/wall_flash
 	name = "Wall-Mounted Flash Crate"
 	desc = "Contains four wall-mounted flashes. Requires Security access to open."
@@ -185,7 +185,7 @@
 					/obj/item/storage/box/wall_flash,
 					/obj/item/storage/box/wall_flash)
 	crate_name = "wall-mounted flash crate"
-
+/*
 /datum/supply_pack/security/hunting
 	name = "Hunting Gear"
 	desc = "Even in space, we can find prey to hunt, this crate contains everthing a fine hunter needs to have a sporting time. This crate needs armory access to open. A true huntter only needs a fine bottle of cognac, a nice coat, some good o' cigars, and of cource a hunting shotgun. "
@@ -214,4 +214,4 @@
 	desc = "Contains one \"stingbang\" grenade, perfect for playing meanhearted pranks. Requires Security access to open."
 	cost = 1400
 	contains = list(/obj/item/grenade/stingbang)
-
+*/

--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -65,7 +65,7 @@
 			/obj/item/clothing/mask/gas/explorer)
 	crate_name = "shaft miner starter kit"
 	crate_type = /obj/structure/closet/crate/secure
-
+/*
 /datum/supply_pack/service/snowmobile
 	name = "Snowmobile kit"
 	desc = "trapped on a frigid wasteland? need to get around fast? purchase a refurbished snowmobile, with a FREE 10 microsecond warranty!"
@@ -75,7 +75,7 @@
 			/obj/item/clothing/mask/gas/explorer = 1)
 	crate_name = "Snowmobile kit"
 	crate_type = /obj/structure/closet/crate/large
-
+*/
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////// Chef, Botanist, Bartender ////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
@@ -218,7 +218,7 @@
 					/obj/item/holosign_creator)
 	crate_name = "advanced santation crate"
 	crate_type = /obj/structure/closet/crate/secure
-
+/*
 /datum/supply_pack/service/janitor/janpimp
 	name = "Custodial Cruiser"
 	desc = "Clown steal your ride? Assistant lock it in the dorms? Order a new one and get back to cleaning in style!"
@@ -228,7 +228,7 @@
 					/obj/item/key/janitor)
 	crate_name = "janitor ride crate"
 	crate_type = /obj/structure/closet/crate/large
-
+*/
 /datum/supply_pack/service/janitor/janitank
 	name = "Janitor Backpack Crate"
 	desc = "Call forth divine judgement upon dirt and grime with this high capacity janitor backpack. Contains 500 units of station-cleansing cleaner. Requires janitor access to open."

--- a/code/modules/cargo/packs/vending.dm
+++ b/code/modules/cargo/packs/vending.dm
@@ -82,7 +82,7 @@
 					/obj/item/vending_refill/wallmed)
 	crate_name = "medical vending crate"
 	crate_type = /obj/structure/closet/crate/medical
-
+/*
 /datum/supply_pack/vending/security
 	name = "SecTech Supply Crate"
 	desc = "Officer Paul bought all the donuts? Then refill the security vendor with ths crate. Requires Security Access to open."
@@ -92,7 +92,7 @@
 	crate_name = "SecTech supply crate"
 	crate_type = /obj/structure/closet/crate/secure/gear
 	can_private_buy = FALSE
-
+*/
 /datum/supply_pack/vending/snack
 	name = "Snack Supply Crate"
 	desc = "One vending machine refill of cavity-bringin' goodness! The number one dentist recommended order!"

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -82,6 +82,7 @@
 		return pick(possible_areas)
 
 ///A rare variant that drops a crate containing syndicate uplink items
+/*
 /datum/round_event_control/stray_cargo/syndicate
 	name = "Stray Syndicate Cargo Pod"
 	typepath = /datum/round_event/stray_cargo/syndicate
@@ -97,3 +98,4 @@
 	var/obj/structure/closet/supplypod/S = new
 	S.setStyle(STYLE_SYNDICATE)
 	return S
+*/

--- a/code/modules/jobs/job_types/vault.dm
+++ b/code/modules/jobs/job_types/vault.dm
@@ -21,6 +21,9 @@ here's a tip, go search DEFINES/access.dm
 		return
 	ADD_TRAIT(H, TRAIT_TECHNOPHREAK, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
+
+//Easy changes
+
 /*
 Overseer
 */
@@ -34,10 +37,10 @@ Overseer
 	department_flag = VAULT
 	head_announce = list("Security")
 	faction = "Vault"
-	total_positions = 0
-	spawn_positions = 0
-	forbids = "The Vault forbids: Disobeying the Overseer. Deserting the Vault unless it is rendered unhospitable. Killing fellow Vault Dwellers. Betraying the Vault and its people."
-	enforces = "The Vault expects: Contributing to Vault society. Adherence to Vault-tec Corporate Regulations."
+	total_positions = 1
+	spawn_positions = 1
+	forbids = "The Vault forbids: Disobeying the Overseer. Deserting the Vault. Killing fellow Vault Dwellers. Creating or participating in conflicts outside of the vault."
+	enforces = "The Vault expects: Contributing to Vault society. Participation in special projects, as ordered by the Overseer."
 	description = "You are the leader of the Vault, and your word is law. Working with the Security team and your fellow Vault Dwellers, your goal is to ensure the continued prosperity and survival of the vault, through any and all means necessary."
 	supervisors = "Vault-tec"
 	selection_color = "#ccffcc"
@@ -76,7 +79,7 @@ Overseer
 /*
 Head of Security
 */
-
+/*
 /datum/job/vault/f13hos
 	title = "Chief of Security"
 	flag = F13HOS
@@ -130,6 +133,7 @@ Head of Security
 		/obj/item/crowbar = 1)
 
 	implants = list(/obj/item/implant/mindshield)
+*/
 
 /*
 Medical Doctor
@@ -140,10 +144,10 @@ Medical Doctor
 	department_head = list("Overseer")
 	department_flag = VAULT
 	faction = "Vault"
-	total_positions = 0
-	spawn_positions = 0
-	forbids = "The Vault forbids: Disobeying the Overseer. Deserting the Vault unless it is rendered unhospitable. Killing fellow Vault Dwellers. Betraying the Vault and its people."
-	enforces = "The Vault expects: Contributing to Vault society. Adherence to Vault-tec Corporate Regulations. Participation in special projects, as ordered by the Overseer."
+	total_positions = 2
+	spawn_positions = 2
+	forbids = "The Vault forbids: Disobeying the Overseer. Deserting the Vault. Killing fellow Vault Dwellers. Creating or participating in conflicts outside of the vault."
+	enforces = "The Vault expects: Contributing to Vault society. Participation in special projects, as ordered by the Overseer."
 	description = "You answer directly to the Overseer. You are tasked with providing medical care to Vault Dwellers and ensuring the medical well-being of everyone in the Vault."
 	supervisors = "the Overseer"
 	selection_color = "#ddffdd"
@@ -187,10 +191,10 @@ Scientist
 	department_head = list("Overseer")
 	department_flag = VAULT
 	faction = "Vault"
-	total_positions = 0
-	spawn_positions = 0
-	forbids = "The Vault forbids: Disobeying the Overseer. Deserting the Vault unless it is rendered unhospitable. Killing fellow Vault Dwellers. Betraying the Vault and its people."
-	enforces = "The Vault expects: Contributing to Vault society. Adherence to Vault-tec Corporate Regulations. Participation in special projects, as ordered by the Overseer."
+	total_positions = 2
+	spawn_positions = 2
+	forbids = "The Vault forbids: Disobeying the Overseer. Deserting the Vault. Killing fellow Vault Dwellers. Creating or participating in conflicts outside of the vault."
+	enforces = "The Vault expects: Contributing to Vault society. Participation in special projects, as ordered by the Overseer."
 	description = "You answer directly to the Overseer. You are tasked with researching new technologies, conducting mining expeditions (with the approval of Security or the Overseer), and upgrading the machinery of the Vault."
 	supervisors = "the Overseer"
 	selection_color = "#ddffdd"
@@ -229,10 +233,10 @@ Security Officer
 	department_head = list("Chief of Security")
 	department_flag = VAULT
 	faction = "Vault"
-	total_positions = 0 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
-	spawn_positions = 0 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
-	forbids = "The Vault forbids: Disobeying the Overseer. Deserting the Vault unless it is rendered unhospitable. Killing fellow Vault Dwellers. Betraying the Vault and its people."
-	enforces = "The Vault expects: Contributing to Vault society. Adherence to Vault-tec Corporate Regulations. Participation in special projects, as ordered by the Overseer."
+	total_positions = 1 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
+	spawn_positions = 1 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
+	forbids = "The Vault forbids: Disobeying the Overseer. Deserting the Vault. Killing fellow Vault Dwellers. Creating or participating in conflicts outside of the vault."
+	enforces = "The Vault expects: Contributing to Vault society. Participation in special projects, as ordered by the Overseer."
 	description = "You answer directly to the Chief of Security, and in their absence, the Overseer. You are the first line of defense against civil unrest and outside intrusion. It is your duty to enforce the laws created by the Overseer and proactively seek out potential threats to the safety of Vault residents."
 	supervisors = "the head of security"
 	selection_color = "#ddffdd"
@@ -307,10 +311,10 @@ Vault Engineer
 	department_head = list("Overseer")
 	department_flag = VAULT
 	faction = "Vault"
-	total_positions = 0
-	spawn_positions = 0
-	forbids = "The Vault forbids: Disobeying the Overseer. Deserting the Vault unless it is rendered unhospitable. Killing fellow Vault Dwellers. Betraying the Vault and its people."
-	enforces = "The Vault expects: Contributing to Vault society. Adherence to Vault-tec Corporate Regulations. Participation in special projects, as ordered by the Overseer."
+	total_positions = 1
+	spawn_positions = 1
+	forbids = "The Vault forbids: Disobeying the Overseer. Deserting the Vault. Killing fellow Vault Dwellers. Creating or participating in conflicts outside of the vault."
+	enforces = "The Vault expects: Contributing to Vault society. Participation in special projects, as ordered by the Overseer."
 	description = "You answer directly to the Overseer. You are tasked with overseeing the Reactor, maintaining Vault defenses and machinery, and engaging in construction projects to improve the Vault as a whole."
 	supervisors = "the Overseer"
 	selection_color = "#ddffdd"
@@ -342,10 +346,10 @@ Vault Engineer
 	flag = ASSISTANT
 	department_flag = VAULT
 	faction = "Vault"
-	total_positions = 0
-	spawn_positions = 0
-	forbids = "The Vault forbids: Disobeying the Overseer. Deserting the Vault unless it is rendered unhospitable. Killing fellow Vault Dwellers. Betraying the Vault and its people."
-	enforces = "The Vault expects: Contributing to Vault society. Adherence to Vault-tec Corporate Regulations. Participation in special projects, as ordered by the Overseer."
+	total_positions = 2
+	spawn_positions = 2
+	forbids = "The Vault forbids: Disobeying the Overseer. Deserting the Vault. Killing fellow Vault Dwellers. Creating or participating in conflicts outside of the vault."
+	enforces = "The Vault expects: Contributing to Vault society. Participation in special projects, as ordered by the Overseer."
 	description = "You answer directly to the Overseer, being assigned to fulfill whatever menial tasks are required. You lack an assignment, but may be given one the Overseer if required or requested. You should otherwise busy yourself with assisting personnel with tasks around the Vault."
 	supervisors = "absolutely everyone"
 	selection_color = "#ddffdd"

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -11,12 +11,12 @@
 
 		Base parts are available for shipping via cargo.
 		-Nanotrasen Naval Command"}
-
+/*
 /datum/station_goal/bluespace_cannon/on_report()
 	//Unlock BSA parts
 	var/datum/supply_pack/engineering/bsa/P = SSshuttle.supply_packs[/datum/supply_pack/engineering/bsa]
 	P.special_enabled = TRUE
-
+*/
 /datum/station_goal/bluespace_cannon/check_completion()
 	if(..())
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reworks the vault massively, making them more trade and tutorial oriented. More to come soon as well in the form of area localized disasters, better random events as a whole, and vault goals (TG vault moment). Hopefully.

## Why It's Good For The Game

The vault is generally disliked for how the people within power game, and in the case of the PR that removed it, clearly titled as "tweaking stuff", to many job slots was cited as a problem.

First power gaming, vault generally keeps to itself and if they do ruffle feathers, are easy to kill/cut off from the surface. and while they have access to some pretty mean tech, so do the BOS and Enclave, who also get better armor, and the components to easily craft weapons en-mass. Additionally they now have Forbid/Enforce text that tells them to not go outside and kick shit up.

Secondly, slots. The vault does have a stupid fucking amount of slots coming in at 19, that has been changed, mainly reducing the number of engineers and dwellers. Additionally, the servers population has rapidly increased, and we are now regularly near the top of the server list. If the need to decrease the number of people in vault more is felt, then that can be easily done, but it shouldn't just be completely removed, especially in an un-tagged, badly named PR.

Third, vault is a great place to learn and play around. Its a safe, secure bunker in the corner of the darkest part of the map where you can have fun conversations, play around with whatever bullshit you want, and generally learn and have fun.

Finally, interaction. The vault is now more trade oriented, having a dedicated trade area and easier access with a ladder leading down to them just west of the west bunker, behind a few scorpions, ghouls, and a blocked tunnel, to slightly delay access to them.

Also, if this PR gets merged then I'll be more than happy to expand on the vaults content, like
- giving them station like objectives. (something to do for the round, tg vault moment)
- starting the vault in a state of decay, requiring the dwellers to repair it. (more on the teaching new players side)
- Making a better event system, including a way to make events happen entirely in 1:~~ game area.

Since there were quite a few slots, here's how I've changed/removed some. (Because details fucking matter!)

- Overseer:                
       - 1 Before
       - 1 After
       -  Vault needs a leader (If someone ever decides to be one)
- Chief of Security:   
       - 1 Before
       -  0 After
       - The overseer works fine as a HOS.
- Doctor:                  
       - 2 Before
       - 2 After
       - One for actually treating people, the other is just a chemist.
- Scientist:                
       - 2 Before
       - 2 After
       - Science! That's what the vaults all about.
- Security Officer:     
       - 3 Before
       - 1 After
       - The vault has no solid laws, and if someone's being a shitter, anyone can deal with it.
- Engineer:               
       - 2 Before
       - 1 After
       - The engineering "department" has full access on its doors, and no real job.
- Dweller:            
       - **_8 Before_**
       - 2 After
       - They serve, no purpose. Just an overflow/miner slot.

And with that, vault goes from 19 jobs, to 10. While that's still a fair few, most SSD, Die, Or more likely, don't even join vault.

## Changelog
:cl:
add: Added vault slots back.
fix: Cargo shuttle leaking atmos.
tweak: Forbid/Enforce text.
tweak: The vault itself.
tweak: Cargo crates.
remove: Some vault slots.
remove: TTV's from cargo shuttle.

/:cl:
