### PR TITLE
Wastelander Rebalance/Old Aerodrome

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -167,11 +167,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "aeb" = (
-/obj/structure/table/wood/settler,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "aeg" = (
 /obj/structure/flora/grass/jungle/b,
 /mob/living/simple_animal/hostile/poison/giant_spider,
@@ -431,12 +433,17 @@
 	},
 /area/f13/wasteland)
 "ajU" = (
-/obj/structure/table/wood/settler,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/wasteland)
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/obj/item/crowbar/basic,
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg3"
+	},
+/area/f13/ncr)
 "ajW" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -524,12 +531,14 @@
 	},
 /area/f13/wasteland)
 "alE" = (
-/obj/structure/table/wood/settler,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/wasteland)
+/obj/structure/wreck/trash/autoshaft,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "alI" = (
 /obj/item/twohanded/required/kirbyplants/dead,
 /obj/item/reagent_containers/pill/fixer,
@@ -1401,10 +1410,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"aIb" = (
-/obj/structure/tires,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "aIe" = (
 /obj/structure/fence/handrail_corner{
 	dir = 8;
@@ -1741,10 +1746,7 @@
 "aQw" = (
 /obj/structure/target_stake,
 /obj/item/target,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "aQT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2382,8 +2384,13 @@
 	},
 /area/f13/city)
 "bgY" = (
-/turf/closed/indestructible/riveted,
-/area/f13/tcoms)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "bhC" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/road{
@@ -2490,6 +2497,15 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"bkl" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "bkr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2617,16 +2633,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "bnD" = (
-/obj/structure/table/wood/settler,
-/obj/item/claymore/machete/training,
-/obj/item/claymore/machete/training,
-/obj/item/claymore/machete/training,
-/obj/item/claymore/machete/training,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg3"
+	},
+/area/f13/ncr)
 "bnJ" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "khanrage";
@@ -3040,16 +3056,10 @@
 	},
 /area/f13/legion)
 "bwW" = (
-/obj/structure/table/wood/settler,
-/obj/item/clothing/gloves/boxing/blue,
-/obj/item/clothing/gloves/boxing/blue,
-/obj/item/clothing/gloves/boxing,
-/obj/item/clothing/gloves/boxing,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/ncr)
 "bxk" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3153,12 +3163,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"bzK" = (
-/obj/structure/tires,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "bzR" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -3189,13 +3193,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"bAq" = (
-/obj/structure/tires/half,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
 "bAH" = (
 /obj/structure/simple_door/house{
 	icon_state = "interior"
@@ -3351,11 +3348,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bEo" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/waterbottle{
+	pixel_x = -4;
+	pixel_y = 12
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "bEw" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -3633,15 +3634,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"bMB" = (
-/obj/structure/table/wood/settler,
-/obj/item/stack/medical/bruise_pack,
-/obj/item/stack/medical/bruise_pack,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "bMJ" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/f13/wood,
@@ -3751,13 +3743,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bQh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/waterbottle{
+	pixel_x = -4;
+	pixel_y = 12
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left"
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg3"
 	},
-/area/f13/wasteland)
+/area/f13/ncr)
 "bQr" = (
 /obj/structure/chair/stool/f13stool,
 /turf/open/floor/f13/wood{
@@ -3827,6 +3822,9 @@
 /obj/structure/debris/v2,
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
+"bRj" = (
+/turf/closed/indestructible/riveted,
+/area/f13/tcoms)
 "bRq" = (
 /obj/structure/chair/bench{
 	dir = 1
@@ -3917,24 +3915,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
 "bTf" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/obj/item/reagent_containers/glass/beaker/waterbottle{
-	pixel_x = -4;
-	pixel_y = 12
+/obj/structure/table,
+/obj/item/reagent_containers/glass/rag/towel,
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg3"
 	},
-/obj/item/reagent_containers/glass/beaker/waterbottle{
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/glass/beaker/waterbottle{
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/ncr)
 "bTh" = (
 /obj/structure/fence{
 	dir = 4
@@ -4329,13 +4315,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"cia" = (
-/obj/structure/tires/half,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "cio" = (
 /obj/structure/window/reinforced/spawner,
 /obj/machinery/light/small/broken{
@@ -5198,11 +5177,12 @@
 	},
 /area/f13/building)
 "cGs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/table,
+/obj/structure/bedsheetbin/towel,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/ncr)
 "cGw" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -6120,12 +6100,18 @@
 	},
 /area/f13/wasteland)
 "dca" = (
-/obj/structure/tires,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/obj/machinery/light{
+	dir = 1
 	},
-/area/f13/wasteland)
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "hangar1";
+	name = "Door Control"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "dcu" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /obj/effect/decal/cleanable/dirt,
@@ -6349,14 +6335,13 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/ncr)
 "diF" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "flag_ncr";
-	name = "NCR banner"
+/obj/structure/tires/two,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
 "diH" = (
@@ -6422,6 +6407,12 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building)
+"dkq" = (
+/obj/structure/weightmachine/stacklifter,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "dku" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -7449,6 +7440,18 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"dJM" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/car/rubbish4,
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg3"
+	},
+/area/f13/ncr)
 "dJQ" = (
 /obj/structure/table/wood/poker{
 	name = "felt table"
@@ -7884,12 +7887,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "dWH" = (
-/obj/structure/table/wood/settler,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
+/obj/structure/punching_bag,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/ncr)
 "dWZ" = (
 /obj/machinery/light{
 	dir = 1
@@ -8461,6 +8463,14 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"elw" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2right"
+	},
+/area/f13/wasteland)
 "ely" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice/catwalk,
@@ -8482,16 +8492,15 @@
 	},
 /area/f13/bar)
 "elT" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/structure/rack,
+/obj/item/claymore/machete/training,
+/obj/item/claymore/machete/training,
+/obj/item/claymore/machete/training,
+/obj/item/claymore/machete/training,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "eme" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -8534,12 +8543,15 @@
 	},
 /area/f13/building)
 "emU" = (
-/obj/structure/flora/tree/tall,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 7;
-	icon_state = "outerpavement"
+/obj/structure/rack,
+/obj/item/clothing/gloves/boxing/blue,
+/obj/item/clothing/gloves/boxing/blue,
+/obj/item/clothing/gloves/boxing,
+/obj/item/clothing/gloves/boxing,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/ncr)
 "enk" = (
 /obj/structure/simple_door/house{
 	icon_state = "interior"
@@ -8616,11 +8628,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
 "eoi" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/structure/wreck/trash/engine,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_x = -28
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg2"
+	},
+/area/f13/ncr)
 "eos" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -8663,11 +8682,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "epm" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/machinery/blackbox_recorder,
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg3"
+	},
+/area/f13/ncr)
 "ept" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -8835,12 +8857,21 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "etV" = (
-/obj/structure/flora/tree/tall,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerpavementcorner"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/wasteland)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "hangar2";
+	name = "Door Control"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg3"
+	},
+/area/f13/ncr)
 "eue" = (
 /obj/item/chair/stool,
 /obj/item/paper/crumpled,
@@ -10585,13 +10616,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"fiB" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "fiK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -11415,6 +11439,17 @@
 	},
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
+"fDe" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2left"
+	},
+/area/f13/wasteland)
 "fDi" = (
 /obj/structure/window/fulltile/house/broken,
 /turf/open/floor/f13/wood,
@@ -13382,8 +13417,13 @@
 	},
 /area/f13/building)
 "gyh" = (
-/obj/structure/punching_bag,
-/turf/open/indestructible/ground/outside/sidewalk,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/cargocrate,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
 /area/f13/ncr)
 "gyi" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -13758,6 +13798,17 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"gJA" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2right"
+	},
+/area/f13/wasteland)
 "gJP" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -14998,6 +15049,12 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
+"hnw" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "hnG" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/structure/chair/wood/worn{
@@ -16515,12 +16572,15 @@
 	},
 /area/f13/wasteland)
 "hXW" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/wasteland)
+/obj/effect/decal/waste,
+/obj/item/wrench/basic,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "hYb" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -17853,12 +17913,16 @@
 	},
 /area/f13/building)
 "iHk" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 7;
-	icon_state = "outerpavement"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/wasteland)
+/obj/structure/wreck/car/bike{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "iHu" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -18670,6 +18734,18 @@
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
+"iWI" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "iWV" = (
 /obj/effect/decal/remains/deadeyebot,
 /obj/effect/decal/cleanable/dirt,
@@ -20485,9 +20561,13 @@
 	},
 /area/f13/village)
 "jOq" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "jOz" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt{
@@ -20522,6 +20602,12 @@
 /obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"jOP" = (
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "jPa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -20974,8 +21060,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "jXj" = (
-/turf/open/indestructible,
-/area/f13/tcoms)
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg3"
+	},
+/area/f13/ncr)
 "jXk" = (
 /obj/item/stack/ore/iron,
 /turf/open/indestructible/ground/outside/dirt{
@@ -24509,6 +24597,13 @@
 	icon_state = "verylittleshadowright"
 	},
 /area/f13/wasteland)
+"lQI" = (
+/obj/structure/table,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "lQL" = (
 /obj/effect/decal/remains/deadeyebot,
 /turf/open/indestructible/ground/outside/desert,
@@ -25527,6 +25622,9 @@
 /obj/machinery/door/airlock/freezer,
 /turf/open/floor/plasteel/bar,
 /area/f13/ncr)
+"mpM" = (
+/turf/open/indestructible,
+/area/f13/tcoms)
 "mpQ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25726,6 +25824,15 @@
 /area/f13/building)
 "mvv" = (
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"mvw" = (
+/obj/structure/closet/bus{
+	pixel_x = -14;
+	pixel_y = 5
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "innershade"
+	},
 /area/f13/wasteland)
 "mvB" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -27110,6 +27217,18 @@
 /mob/living/simple_animal/hostile/poison/giant_spider/tarantula,
 /turf/open/water,
 /area/f13/caves)
+"niw" = (
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "hangar2";
+	name = "hangar gate"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg2"
+	},
+/area/f13/ncr)
 "niD" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/indestructible/ground/inside/mountain,
@@ -27712,9 +27831,13 @@
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "nAr" = (
-/obj/structure/weightmachine/stacklifter,
-/obj/effect/turf_decal/stripes/white/full,
-/turf/open/indestructible/ground/outside/sidewalk,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
 /area/f13/ncr)
 "nAz" = (
 /turf/open/indestructible/ground/outside/road{
@@ -28571,6 +28694,18 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
+"nUs" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "nUF" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -28700,6 +28835,15 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
+"nYK" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2right"
+	},
+/area/f13/wasteland)
 "nYW" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -28909,6 +29053,17 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"oeM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "oeW" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/spider/stickyweb,
@@ -30891,12 +31046,14 @@
 	},
 /area/f13/ncr)
 "pfd" = (
-/obj/structure/tires,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "pfk" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/genericbush,
@@ -31630,12 +31787,13 @@
 	},
 /area/f13/building)
 "pww" = (
-/obj/structure/table/wood/settler,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg3"
+	},
+/area/f13/ncr)
 "pwS" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -31869,6 +32027,13 @@
 /obj/machinery/microwave,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"pCO" = (
+/obj/structure/table,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "pCX" = (
 /obj/machinery/grill,
 /turf/open/indestructible/ground/outside/dirt,
@@ -33300,6 +33465,11 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"qjq" = (
+/obj/structure/table/wood,
+/obj/item/stack/medical/bruise_pack,
+/turf/open/floor/carpet/green,
+/area/f13/ncr)
 "qjv" = (
 /mob/living/simple_animal/hostile/raider/baseball,
 /turf/open/indestructible/ground/outside/dirt,
@@ -33461,9 +33631,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "qop" = (
-/obj/structure/tires/five,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/closed/wall/rust,
+/area/f13/ncr)
 "qos" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/floor/f13{
@@ -33887,6 +34056,15 @@
 /obj/structure/sign/poster/official/twelve_gauge,
 /turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood)
+"qAv" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/car/rubbish3,
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg3"
+	},
+/area/f13/ncr)
 "qAx" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -34227,6 +34405,15 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"qHE" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg2"
+	},
+/area/f13/ncr)
 "qHQ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -34855,6 +35042,16 @@
 /obj/structure/simple_door/wood,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
+"qVi" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "qVC" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
@@ -35194,6 +35391,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"reG" = (
+/obj/structure/weightmachine/stacklifter,
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg3"
+	},
+/area/f13/ncr)
 "reK" = (
 /obj/structure/fence,
 /obj/structure/table/wood,
@@ -35439,6 +35642,17 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/building)
+"rmJ" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor2"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "rmP" = (
 /obj/effect/decal/remains/human,
 /obj/machinery/light/small/broken{
@@ -35536,11 +35750,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "rpF" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "rpI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/deadeyebot,
@@ -36888,6 +37105,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"scQ" = (
+/obj/structure/tires,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "innershade"
+	},
+/area/f13/wasteland)
 "sdf" = (
 /obj/item/stack/ore/iron,
 /turf/open/indestructible/ground/outside/dirt{
@@ -37616,10 +37839,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "stt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2left"
+	},
 /area/f13/wasteland)
 "stD" = (
 /obj/effect/decal/cleanable/oil,
@@ -37915,6 +38140,15 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"sAD" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "sAH" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -38008,6 +38242,17 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"sDU" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "sEf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -38460,9 +38705,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "sPO" = (
-/obj/structure/tires,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
 /area/f13/wasteland)
 "sPR" = (
 /obj/structure/ladder/unbreakable{
@@ -39174,6 +39423,10 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"tjm" = (
+/obj/machinery/telecomms/relay/preset/telecomms,
+/turf/open/indestructible,
+/area/f13/tcoms)
 "tjB" = (
 /obj/item/ammo_casing/a50MG,
 /turf/open/indestructible/ground/outside/road{
@@ -40935,9 +41188,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "tYQ" = (
-/obj/machinery/telecomms/relay/preset/telecomms,
-/turf/open/indestructible,
-/area/f13/tcoms)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "tYV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -41102,6 +41362,14 @@
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"udz" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg2"
+	},
+/area/f13/ncr)
 "udT" = (
 /obj/structure/table/wood,
 /obj/item/stack/medical/suture,
@@ -41199,6 +41467,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"uge" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "ugj" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/decal/cleanable/dirt,
@@ -41586,6 +41862,18 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
 	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
+"uoW" = (
+/obj/structure/car,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor2"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
 "upe" = (
@@ -42023,9 +42311,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uxU" = (
-/obj/structure/tires/half,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "uyg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -42387,6 +42680,15 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"uFy" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/wreck/trash/autoshaft,
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg3"
+	},
+/area/f13/ncr)
 "uFB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -43495,6 +43797,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"vfe" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg2"
+	},
+/area/f13/ncr)
 "vff" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -43968,6 +44275,14 @@
 	icon_state = "outermaincornerouter"
 	},
 /area/f13/wasteland)
+"vqG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "vrB" = (
 /obj/item/trash/f13/electronic/toaster{
 	pixel_x = -5;
@@ -44206,6 +44521,16 @@
 	icon_state = "verticaloutermain2"
 	},
 /area/f13/wasteland)
+"vyj" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/rack,
+/obj/item/stack/medical/bruise_pack,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "vzb" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/trash,
@@ -45905,6 +46230,16 @@
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"wrk" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "wrP" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -46160,7 +46495,6 @@
 	},
 /area/f13/building)
 "wyi" = (
-/obj/structure/closet/bus,
 /obj/structure/ladder/unbreakable{
 	desc = "A short drive to the north from Miller for supplies. It's a shame the bus can't go further, maybe if it wasn't a rusty hunk of scrap you could reach Vegas!";
 	height = 2;
@@ -47055,6 +47389,18 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"wQK" = (
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "hangar1";
+	name = "hangar gate"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg3"
+	},
+/area/f13/ncr)
 "wQR" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -49467,9 +49813,17 @@
 	},
 /area/f13/building)
 "xTq" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/car/rubbish2,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor2"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/ncr)
 "xTw" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/inside/dirt,
@@ -49646,6 +50000,9 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"xYa" = (
+/turf/closed/wall/f13/ruins,
+/area/f13/village)
 "xYi" = (
 /obj/structure/sign/poster/contraband/missing_gloves{
 	pixel_y = 32
@@ -50311,11 +50668,13 @@ ktB
 ktB
 ktB
 ktB
-ktB
-ktB
+vaA
 oYb
 oYb
 oYb
+oYb
+oYb
+vaA
 ktB
 ktB
 ktB
@@ -50343,15 +50702,13 @@ ktB
 ktB
 ktB
 ktB
-ktB
-ktB
-ktB
-ktB
+vaA
 oYb
 oYb
 oYb
-ktB
-ktB
+oYb
+oYb
+vaA
 ktB
 ktB
 ktB
@@ -50549,73 +50906,73 @@ ktB
 "}
 (2,1,1) = {"
 ktB
-bgY
-bgY
-bgY
-bgY
-bgY
-ktB
 gcK
 gcK
 gcK
-lPT
-lPT
-lPT
-lPT
-lPT
-lPT
-lPT
-lPT
-lPT
-lPT
-lPT
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+vaA
+vaA
 unI
 hbW
 hOl
 hOl
 eJb
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-ees
-gQv
-gQv
-ees
-ees
-eIC
+vaA
+vaA
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+vaA
+vaA
+muk
 hbW
 xzM
 xzM
 koD
-cpK
-dMW
-fyf
+vaA
+vaA
+gcK
 ezX
-fyf
-fyf
-fyf
-kGc
+gcK
+gcK
+gcK
+gcK
 mGC
 nTY
 ecM
@@ -50806,26 +51163,26 @@ ktB
 "}
 (3,1,1) = {"
 ktB
-bgY
-jXj
-jXj
-jXj
-bgY
-ktB
 gcK
-fyf
-fyf
-tFR
-qOV
-aQw
-bnY
-aQw
-bnY
-aQw
-bnY
-aQw
-wDc
-lPT
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gSt
+igz
+igz
+igz
+bEw
+kGc
 unI
 hbW
 hOl
@@ -50871,8 +51228,8 @@ sqA
 jwP
 fyf
 fyf
-fyf
-kGc
+gcK
+gcK
 mGC
 sTC
 rEi
@@ -51063,25 +51420,25 @@ ktB
 "}
 (4,1,1) = {"
 ktB
-bgY
-jXj
-tYQ
-jXj
-bgY
-ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 fyf
 fyf
-tFR
-upG
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-bpD
+fyf
+kGc
+fDe
+nUs
+nUs
+kOz
 kGc
 unI
 hbW
@@ -51129,7 +51486,7 @@ jwP
 fyf
 fyf
 sqA
-kGc
+vaA
 mGC
 qxO
 rEi
@@ -51137,7 +51494,7 @@ vDP
 pnz
 hoo
 mGC
-fyf
+vaA
 fyf
 fyf
 fyf
@@ -51320,29 +51677,29 @@ ktB
 "}
 (5,1,1) = {"
 ktB
-bgY
-jXj
-jXj
-jXj
-bgY
-ktB
 gcK
-fyf
-fyf
-tFR
-upG
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-hXW
-iHk
+gcK
+gcK
+gcK
+gcK
+gcK
+qop
+qop
+qop
+qop
+qop
+qop
+qop
+qop
+kGc
+bgY
+sPO
+iVQ
+kOz
+kGc
 unI
 hbW
-xzM
+mvw
 xzM
 koD
 xEc
@@ -51577,26 +51934,26 @@ ktB
 "}
 (6,1,1) = {"
 ktB
-bgY
-bgY
-bgY
-bgY
-bgY
-ktB
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+qop
+bwW
+jOq
+pww
+aeb
+jOq
+aeb
+qop
 fyf
+sPO
+sPO
 fyf
-tFR
-upG
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-hXW
-iHk
+jxH
+kGc
 unI
 hbW
 hOl
@@ -51834,26 +52191,26 @@ ktB
 "}
 (7,1,1) = {"
 ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+qop
+bEo
+bwW
+reG
+pww
+jOP
+aeb
+qop
 fyf
-pis
-tFR
-upG
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-hXW
-iHk
+fyf
+sPO
+fyf
+jxH
+kGc
 unI
 hbW
 hOl
@@ -52097,20 +52454,20 @@ gcK
 gcK
 gcK
 gcK
-gcK
+qop
+bQh
+aeb
+aeb
+pww
+aeb
+aeb
+qop
 fyf
 fyf
-tFR
-upG
-ymi
-lFX
-ymi
-lFX
-ymi
-lFX
-ymi
-hXW
-iHk
+sPO
+sPO
+jxH
+kGc
 unI
 wyi
 sgz
@@ -52168,9 +52525,9 @@ dMW
 fyf
 fyf
 thG
-nIp
-nIp
-nIp
+xYa
+xYa
+xYa
 nqb
 uxC
 uxC
@@ -52352,22 +52709,22 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+qop
+bTf
+aeb
+dkq
+aeb
+jOP
+bwW
+qop
 fyf
 fyf
-fyf
-fyf
-fyf
-tFR
-upG
-mvv
-lFX
-mvv
-lFX
-mvv
-lFX
-mvv
-hXW
-iHk
+bgY
+sPO
+jxH
+kGc
 unI
 hbW
 hOl
@@ -52425,7 +52782,7 @@ dMW
 fyf
 fyf
 thG
-nIp
+xYa
 wef
 jWM
 nHP
@@ -52608,23 +52965,23 @@ ktB
 gcK
 gcK
 gcK
-fyf
 gcK
 gcK
+gcK
+qop
+cGs
+bwW
+vfe
+pww
+pww
+aeb
+wQK
 fyf
 fyf
 fyf
-tFR
-upG
-mvv
-lFX
-mvv
-lFX
-mvv
-lFX
-mvv
-hXW
-iHk
+sPO
+uSm
+kGc
 unI
 hbW
 sgz
@@ -52682,7 +53039,7 @@ dMW
 fyf
 fyf
 thG
-nIp
+xYa
 faW
 mji
 aVF
@@ -52868,20 +53225,20 @@ gcK
 gcK
 gcK
 gcK
+qop
+dca
+jXj
+jXj
+pww
+bwW
+aeb
+udz
+kGc
 fyf
 fyf
-fyf
-tFR
-upG
-mvv
-lFX
-mvv
-lFX
-mvv
-lFX
-mvv
-hXW
-iHk
+sPO
+kOz
+kGc
 unI
 hbW
 sgz
@@ -52939,7 +53296,7 @@ dMW
 fyf
 fyf
 thG
-nIp
+xYa
 tYe
 vGQ
 fyf
@@ -53125,20 +53482,20 @@ gcK
 gcK
 gcK
 gcK
+qop
+bwW
+nAr
+oeM
+oeM
+oeM
+vqG
+pww
+kGc
+sPO
 fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-doX
-hgX
+bgY
+kOz
+kGc
 unI
 hbW
 hOl
@@ -53176,7 +53533,7 @@ fju
 unI
 hbW
 xzM
-xzM
+scQ
 koD
 cpK
 dMW
@@ -53196,7 +53553,7 @@ dMW
 fyf
 fyf
 thG
-nIp
+xYa
 sxP
 nHP
 fyf
@@ -53380,22 +53737,22 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+qop
+dWH
+pfd
+aeb
+aeb
+aeb
+aeb
+qop
+kGc
+sPO
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-cpK
+bgY
+kOz
+kGc
 unI
 hbW
 sgz
@@ -53453,7 +53810,7 @@ aeZ
 tFR
 tFR
 thG
-nIp
+xYa
 mji
 dhh
 peZ
@@ -53636,23 +53993,23 @@ ktB
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-aBH
-gNA
+gcK
+gcK
+gcK
+qop
+elT
+pfd
+aeb
+pww
+aeb
+aeb
+qop
+kGc
+bgY
+sPO
+bgY
+kOz
+kGc
 unI
 hbW
 sgz
@@ -53710,12 +54067,12 @@ dMW
 fyf
 fyf
 thG
-nIp
-nIp
-nIp
+xYa
+xYa
+xYa
 uxC
 uxC
-nIp
+xYa
 fyf
 fyf
 upX
@@ -53893,22 +54250,22 @@ ktB
 gcK
 gcK
 gcK
-fyf
 gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-bpD
+gcK
+gcK
+qop
+dWH
+pfd
+aeb
+pww
+pww
+bwW
+qop
+kGc
+bgY
+sPO
+sPO
+kOz
 kGc
 unI
 hbW
@@ -54150,22 +54507,22 @@ ktB
 gcK
 gcK
 gcK
-fyf
 gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-nlO
+gcK
+gcK
+qop
+emU
+rpF
+aeb
+bwW
 bnD
 bwW
-bMB
-mfD
-mfD
-mfD
-mfD
-hCg
+qop
+kGc
+sAD
+sPO
+bgY
+kOz
 kGc
 unI
 hbW
@@ -54410,20 +54767,20 @@ gcK
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-qOV
-cWG
-cWG
-wDc
-fyf
-fyf
-fyf
-emU
+qop
+qop
+qop
+qop
+qop
+qop
+qop
+qop
+kGc
+sPO
+qVi
+bgY
+jxH
+kGc
 unI
 hbW
 sgz
@@ -54665,21 +55022,21 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
+aQw
 fyf
 fyf
-trW
 fyf
-qOV
-cWG
-daU
-mvv
-mvv
-doX
-cWG
-wDc
 fyf
+fyf
+igz
+pCO
+igz
+igz
+hgX
+sPO
+sPO
+bgY
+jxH
 kGc
 unI
 hbW
@@ -54689,7 +55046,7 @@ koD
 xEc
 hIB
 hWJ
-hIB
+qjq
 jQd
 nbd
 nVM
@@ -54919,24 +55276,24 @@ ktB
 (19,1,1) = {"
 ktB
 gcK
-gcK
-gcK
-gcK
-gcK
+fyf
+fyf
+sqA
 fyf
 fyf
 fyf
 fyf
-qOV
-daU
-mvv
-aBH
-mfD
-mfD
-xGH
-mvv
-doX
-wDc
+stt
+sPO
+sPO
+wrk
+sPO
+stt
+bgY
+sPO
+bgY
+fyf
+jxH
 kGc
 unI
 hbW
@@ -55176,24 +55533,24 @@ ktB
 (20,1,1) = {"
 ktB
 gcK
-gcK
-gcK
-fyf
-gcK
+aQw
 fyf
 fyf
 fyf
+kGc
+bgY
+bgY
+bgY
+bgY
+sPO
+bkl
+bgY
+bgY
+sPO
+bgY
+bgY
 fyf
-tBN
-mvv
-aBH
-hCg
-fyf
-fyf
-nlO
-xGH
-mvv
-bpD
+jxH
 kGc
 unI
 hbW
@@ -55434,23 +55791,23 @@ ktB
 ktB
 gcK
 gcK
-gcK
-fyf
-gcK
-gcK
+aQw
 fyf
 fyf
-qOV
-daU
-aBH
-hCg
-qOV
-cia
-cWG
-wDc
-nlO
-xGH
-doX
+fyf
+fyf
+sPO
+sPO
+elw
+elw
+nYK
+sPO
+sPO
+sPO
+bgY
+sPO
+fyf
+dMW
 kGc
 unI
 hbW
@@ -55692,22 +56049,22 @@ ktB
 gcK
 gcK
 gcK
-fyf
 gcK
+aQw
 fyf
+ptf
+ptf
+ptf
+ptf
+ptf
+lQI
+ptf
+ptf
+gNA
+bgY
+sPO
 fyf
-fyf
-tBN
-mvv
-bpD
-fyf
-tBN
-aIb
-cST
-bpD
-fyf
-tBN
-mvv
+dMW
 kGc
 unI
 hbW
@@ -55949,22 +56306,22 @@ ktB
 gcK
 gcK
 gcK
-fyf
-fyf
 gcK
-fyf
-fyf
-tBN
-mvv
-bpD
-fyf
-bzK
+gcK
+gcK
 qop
-uxU
-bpD
-fyf
-tBN
-mvv
+qop
+qop
+qop
+qop
+qop
+qop
+qop
+kGc
+uge
+sPO
+bgY
+kOz
 kGc
 unI
 hbW
@@ -56209,19 +56566,19 @@ gcK
 gcK
 gcK
 gcK
-fyf
-fyf
-nlO
-xGH
-doX
-wDc
-bAq
-mfD
-dca
-hCg
-qOV
-daU
-aBH
+qop
+pww
+tYQ
+pww
+pww
+dJM
+pww
+qop
+kGc
+bgY
+sPO
+bgY
+kOz
 kGc
 unI
 hbW
@@ -56466,19 +56823,19 @@ gcK
 gcK
 gcK
 gcK
+qop
+eoi
+pww
+pww
+aeb
+aeb
+aeb
+qop
 fyf
-fyf
-fyf
-tBN
-mvv
-doX
-wDc
-fyf
-fyf
-qOV
-daU
-mvv
-bpD
+bgY
+sPO
+sPO
+kOz
 kGc
 unI
 hbW
@@ -56723,19 +57080,19 @@ gcK
 gcK
 gcK
 gcK
+qop
+aeb
+xTq
+pww
+jXj
+uxU
+aeb
+qop
+iVQ
 fyf
-fyf
-fyf
-nlO
-xGH
-mvv
-doX
-cWG
-cWG
-daU
-mvv
-aBH
-hCg
+bgY
+sPO
+kOz
 kGc
 unI
 hbW
@@ -56980,19 +57337,19 @@ gcK
 gcK
 gcK
 gcK
+qop
+aeb
+aeb
+aeb
+vfe
+vyj
+aeb
+qop
 fyf
 fyf
-sqA
-fyf
-nlO
-mfD
-xGH
-mvv
-mvv
-aBH
-mfD
-hCg
-fyf
+bgY
+sPO
+kOz
 kGc
 unI
 hbW
@@ -57237,19 +57594,19 @@ gcK
 fyf
 fyf
 gcK
+qop
+epm
+aeb
+aeb
+uFy
+uxU
+aeb
+niw
+kGc
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-nlO
-mfD
-mfD
-hCg
-fyf
-fyf
-fyf
+bgY
+sPO
+kOz
 kGc
 unI
 hbW
@@ -57494,19 +57851,19 @@ gcK
 gcK
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-fyf
-fyf
+qop
+etV
+aeb
+hnw
+pww
+pww
+aeb
+udz
+kGc
+sPO
+bgY
+sPO
+kOz
 kGc
 unI
 hbW
@@ -57751,19 +58108,19 @@ gcK
 gcK
 gcK
 fyf
-fyf
-fyf
+qop
+gyh
 aeb
-fiB
+uxU
 alE
-fiB
-fiB
-alE
-fiB
+jXj
+aeb
+pww
+kGc
 diF
-fiB
-alE
-dWH
+bgY
+bgY
+jxH
 kGc
 unI
 hbW
@@ -58008,19 +58365,19 @@ gcK
 gcK
 gcK
 fyf
-fyf
-fyf
-tBN
-uxU
-mvv
-ymi
-mvv
 qop
+aeb
+aeb
 uxU
-mvv
-ymi
-mvv
-bpD
+aeb
+vfe
+aeb
+qop
+kGc
+uoW
+sPO
+bgY
+jxH
 kGc
 unI
 hbW
@@ -58265,19 +58622,19 @@ gcK
 gcK
 gcK
 gcK
-fyf
-fyf
-tBN
-mvv
-aIb
-mvv
-mvv
-ymi
-mvv
-mvv
+qop
+hXW
+aeb
+qHE
+pww
+qAv
+aeb
+qop
+kGc
+uge
 sPO
-uxU
-pfd
+fyf
+jxH
 kGc
 unI
 hbW
@@ -58522,19 +58879,19 @@ gcK
 fyf
 gcK
 gcK
-fyf
-fyf
+qop
+iHk
 ajU
 pww
-aLA
-aLA
-pww
-aLA
-aLA
-pww
-aLA
-aLA
-bkN
+aeb
+rmJ
+aeb
+qop
+kGc
+sPO
+sPO
+fyf
+sZA
 kGc
 unI
 hbW
@@ -58779,19 +59136,19 @@ gcK
 fyf
 fyf
 gcK
+qop
+aeb
+sDU
+aeb
+aeb
+sDU
+aeb
+qop
+kGc
+sPO
+sPO
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-fyf
+uSm
 kGc
 unI
 hbW
@@ -59036,19 +59393,19 @@ gcK
 fyf
 qOV
 cWG
-cWG
-jrU
-cWG
-wDc
-fyf
-fyf
-ulH
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+qop
+qop
+qop
+qop
+qop
+qop
+qop
+qop
+kGc
+sPO
+bgY
+bgY
+dMW
 kGc
 unI
 hbW
@@ -59298,15 +59655,15 @@ mvv
 rjE
 doX
 wDc
-gSt
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-hgX
+fyf
+fyf
+fyf
+kGc
+iWI
+gJA
+iWI
+dMW
+kGc
 unI
 hbW
 hOl
@@ -59555,15 +59912,15 @@ lmc
 mvv
 ymi
 bpD
+fyf
+fyf
+fyf
+nJW
+ptf
+ptf
+ptf
+edA
 kGc
-jOq
-rpF
-rpF
-rpF
-bQh
-bQh
-rpF
-eoi
 unI
 hbW
 sgz
@@ -59812,15 +60169,15 @@ mvv
 rjE
 aBH
 hCg
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 kGc
-xTq
-bTf
-cpK
-cpK
-cpK
-cpK
-elT
-stt
 unI
 hbW
 sgz
@@ -60069,15 +60426,15 @@ rjE
 rjE
 bpD
 sqA
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 kGc
-xTq
-cpK
-nAr
-odW
-odW
-nAr
-cpK
-stt
 unI
 hbW
 dmL
@@ -60326,15 +60683,15 @@ mvv
 rjE
 bpD
 fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 kGc
-xTq
-cpK
-gyh
-odW
-odW
-odW
-cpK
-stt
 unI
 hbW
 hOl
@@ -60583,15 +60940,15 @@ erx
 aBH
 hCg
 fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 kGc
-xTq
-cpK
-gyh
-odW
-odW
-odW
-cpK
-stt
 unI
 hbW
 sgz
@@ -60840,15 +61197,15 @@ rjE
 mLN
 fyf
 fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 kGc
-xTq
-cpK
-nAr
-odW
-odW
-nAr
-cpK
-stt
 unI
 hbW
 sgz
@@ -61097,15 +61454,15 @@ uXj
 loX
 fyf
 fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 kGc
-xTq
-elT
-cpK
-cpK
-cpK
-cpK
-bTf
-stt
 unI
 hbW
 sgz
@@ -61354,15 +61711,15 @@ erx
 bpD
 fyf
 fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 kGc
-bEo
-cGs
-cGs
-cGs
-cGs
-cGs
-cGs
-epm
 unI
 hbW
 xzM
@@ -61611,15 +61968,15 @@ rjE
 bpD
 fyf
 fyf
-etV
-ptf
-ptf
-ptf
+sqA
+fyf
+fyf
+fyf
 btN
 btN
 btN
 btN
-gNA
+kGc
 unI
 hbW
 xzM
@@ -114533,11 +114890,11 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+bRj
+bRj
+bRj
+bRj
+bRj
 ktB
 "}
 (251,1,1) = {"
@@ -114790,11 +115147,11 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+bRj
+mpM
+mpM
+mpM
+bRj
 ktB
 "}
 (252,1,1) = {"
@@ -115047,11 +115404,11 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+bRj
+mpM
+tjm
+mpM
+bRj
 ktB
 "}
 (253,1,1) = {"
@@ -115304,11 +115661,11 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+bRj
+mpM
+mpM
+mpM
+bRj
 ktB
 "}
 (254,1,1) = {"
@@ -115561,11 +115918,11 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+bRj
+bRj
+bRj
+bRj
+bRj
 ktB
 "}
 (255,1,1) = {"

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -1905,8 +1905,6 @@
 	layer = 3.2;
 	pixel_x = 0
 	},
-/obj/structure/flora/junglebush/large,
-/obj/structure/flora/junglebush,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "bMe" = (
@@ -2762,11 +2760,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "cAV" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 0
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
 	},
-/obj/structure/flora/junglebush,
+/obj/structure/flora/ausbushes/grassybush,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "cBb" = (
@@ -13431,16 +13428,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"lak" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 0
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/tunnel)
 "laU" = (
 /obj/machinery/computer/rdconsole{
 	dir = 4
@@ -16775,9 +16762,6 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "nFg" = (
-/obj/structure/flora/junglebush/large,
-/obj/structure/flora/junglebush,
-/obj/structure/flora/junglebush,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "nFr" = (
@@ -50998,7 +50982,7 @@ lnr
 fmO
 lnr
 lnr
-rNJ
+cAV
 uqz
 uoO
 jXF
@@ -51512,7 +51496,7 @@ fmO
 fmO
 lnr
 qrt
-okH
+tUC
 nFg
 uoO
 vuv
@@ -51770,7 +51754,7 @@ lnr
 lnr
 qrt
 bLI
-nYD
+nFg
 uoO
 vuv
 igD
@@ -52026,8 +52010,8 @@ lnr
 lrl
 nfv
 xDM
-cAV
-nYD
+urU
+nFg
 uoO
 vuv
 vuv
@@ -52284,7 +52268,7 @@ lnr
 nfv
 lnr
 xDM
-lak
+aQn
 uoO
 uoO
 uoO

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -38746,7 +38746,7 @@ PE
 Yy
 Yy
 td
-WT
+DB
 tm
 DB
 DB
@@ -39517,7 +39517,7 @@ Yw
 zT
 Yy
 Ka
-DB
+WT
 tm
 DB
 DB

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -6,7 +6,7 @@
 
 	access = list(ACCESS_NCR)
 	minimal_access = list(ACCESS_NCR)
-	forbids = "The NCR forbids: Chem and drug use such as jet or alcohol while on duty. Execution of unarmed or otherwise subdued targets without authorisation."
+	forbids = "The NCR forbids: Chem and drug use such as jet or alcohol while on duty. Execution of unarmed or otherwise subdued targets without authorization."
 	enforces = "The NCR expects: Obeying the lawful orders of superiors. Proper treatment of prisoners.  Good conduct within the Republic's laws. Wearing the uniform."
 	objectivesList = list("Leadership recommends the following goal for this week: Establish an outpost at the radio tower","Leadership recommends the following goal for this week: Neutralize and capture dangerous criminals", "Leadership recommends the following goal for this week: Free slaves and establish good relations with unaligned individuals.")
 

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -214,7 +214,7 @@ Medical Officer
 	flag = F13MEDICALOFFICER
 	total_positions = 1
 	spawn_positions = 1
-	description = "You are lead medical professional in Camp Miller, you do not have any command authority unless it is of medical nature. Your duties are to ensure your troopers are in good health and that medical supplies are stocked for troopers."
+	description = "You are the lead medical professional in Camp Miller, you do not have any command authority unless it is of medical nature. Your duties are to ensure your troopers are in good health and that medical supplies are stocked for troopers."
 	supervisors = "Captain and above"
 	selection_color = "#fff5cc"
 	display_order = JOB_DISPLAY_ORDER_MEDICALOFFICER

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -577,13 +577,13 @@ Raider
 	faction = "Wastelander"
 	total_positions = -1
 	spawn_positions = -1
-	description = "You travelled far to arrive at the ruined town of Pahrump, a bleak paradise far from the troubles of the Mojave Conflict - protected by Red Rock Canyon to the east, free of the many factions vying for control over Nevada. Here in Pahrump, your story and fate is your own."
-	supervisors = "no one"
+	description = "You arrive in Yuma Valley, hoping to escape your past, the war, or perhaps something worse. But you’ve seen the torchlight and heard the bark of the military officers. You haven’t escaped anything. Try to survive, establish your own settlement, make your own legend. Suffer well and die gladly."
+	supervisors = "God"
 	selection_color = "#dddddd"
 
 	outfit = /datum/outfit/job/wasteland/f13wastelander
 
-	access = list()		//we can expand on this and make alterations as people suggest different loadouts
+	access = list()		//the loadouts need rebalance and alteration, wastelanders have it too easy right now - weezer
 	minimal_access = list()
 	loadout_options = list(
 	/datum/outfit/loadout/vault_refugee,
@@ -616,9 +616,7 @@ Raider
 	suit = pick(
 		/obj/item/clothing/suit/armor/f13/kit, \
 		/obj/item/clothing/suit/f13/veteran, \
-		/obj/item/clothing/suit/toggle/labcoat/f13/wanderer, \
-		/obj/item/clothing/suit/armor/f13/leatherarmor)
-	l_pocket = 	/obj/item/reagent_containers/food/drinks/flask
+		/obj/item/clothing/suit/toggle/labcoat/f13/wanderer)
 	r_pocket = /obj/item/flashlight/flare
 	belt = 	/obj/item/kitchen/knife/combat/survival
 	backpack_contents = list(
@@ -626,15 +624,9 @@ Raider
 		/obj/item/reagent_containers/pill/radx=1, \
 		/obj/item/storage/bag/money/small/wastelander, \
 		/obj/item/kitchen/knife)
-	suit_store = pick(
-	/obj/item/gun/ballistic/revolver/detective, \
-	/obj/item/gun/ballistic/rifle/hunting, \
-	/obj/item/gun/ballistic/automatic/hobo/zipgun, \
-	/obj/item/gun/ballistic/revolver/hobo/pepperbox)
 
 /datum/outfit/loadout/salvager
 	name = "Salvager"
-	suit = /obj/item/clothing/suit/apron
 	shoes = /obj/item/clothing/shoes/f13/explorer
 	gloves = /obj/item/clothing/gloves/f13/blacksmith
 	head = /obj/item/clothing/head/welding


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removing the gun that wastelanders spawn with since all their kits give them guns and ammunition, should result in less piles of items at the spawn points, also the leather armor but leaves the other armors you can spawn with. And salvager's apron.
![image](https://user-images.githubusercontent.com/38540951/125506887-e4c6783f-8908-4de8-bc8a-470b87d4cc0b.png)
Added an old aerodrome to the NCR base interior, to give a little bit of theme to the buildings they're occupying, what they used to be pre-collapse. I'll get to the rest of the base soon enough trust me, but for now, this is their training area.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes what isn't used to make for less server lag on processing piles of unused items, and helping to keep the map clean.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Old Aerodrome in the NCR base Camp Miller!
tweak: tweaked wastelander kits slightly
balance: rebalanced wastelander to have one gun instead of two
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
