### PR TITLE
Tuning of BoS, NCR and Legion loadouts

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -80,8 +80,8 @@ Elder
 	suit_store =	/obj/item/gun/energy/laser/laer
 	neck = /obj/item/clothing/neck/cloak/bos/right
 	backpack_contents = list(
-		/obj/item/stock_parts/cell/ammo/mfc=2, \
-		/obj/item/kitchen/knife/combat=1, \
+		/obj/item/stock_parts/cell/ammo/mfc=2,
+		/obj/item/kitchen/knife/combat=1,
 		/obj/item/gun/ballistic/automatic/pistol/n99=1)
 
 /*
@@ -148,7 +148,8 @@ Head Paladin
 	backpack_contents = list(
 		/obj/item/kitchen/knife/combat=1,
 		/obj/item/gun/ballistic/automatic/pistol/n99=1,
-		/obj/item/ammo_box/magazine/m10mm_adv/simple=2
+		/obj/item/ammo_box/magazine/m10mm_adv/simple=2,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak/super=1
 		)
 
 /datum/outfit/loadout/sentstand
@@ -233,8 +234,8 @@ Head Scribe
 	belt = 			/obj/item/storage/belt/utility/full/engi
 	id = 			/obj/item/card/id/dogtag
 	backpack_contents = list(
-		/obj/item/kitchen/knife/combat=1, \
-		/obj/item/reagent_containers/hypospray/medipen/stimpak/super=3, \
+		/obj/item/kitchen/knife/combat=1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak/super=3,
 		)
 
 /datum/outfit/loadout/hsstand
@@ -297,15 +298,16 @@ Head Knight
 	gunsmith_three = TRUE
 	gunsmith_four = TRUE
 	suit = 			/obj/item/clothing/suit/armor/f13/combat/brotherhood/captain
-	glasses =       /obj/item/clothing/glasses/night
+	glasses =		/obj/item/clothing/glasses/night
 	uniform =		/obj/item/clothing/under/syndicate/brotherhood
-	accessory = 	/obj/item/clothing/accessory/bos/knightcaptain
-	belt = 			/obj/item/storage/belt/security/full
+	accessory =		/obj/item/clothing/accessory/bos/knightcaptain
+	belt =			/obj/item/storage/belt/security/full
 	mask =			/obj/item/clothing/mask/gas/sechailer/swat
 	head =			/obj/item/clothing/head/helmet/f13/combat/brotherhood/captain
-	id = 			/obj/item/card/id/dogtag
+	id =			/obj/item/card/id/dogtag
 	backpack_contents = list(
-		/obj/item/kitchen/knife/combat=1, \
+		/obj/item/kitchen/knife/combat=1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak/super=1
 		)
 
 /datum/outfit/loadout/capstand
@@ -383,9 +385,11 @@ Star Paladin
 	neck = /obj/item/clothing/neck/cloak/bos/paladin
 
 	backpack_contents = list(
-		/obj/item/gun/energy/laser/plasma/pistol=1, \
+		/obj/item/gun/energy/laser/plasma/pistol=1,
 		/obj/item/stock_parts/cell/ammo/ec=2,
-		)
+		/obj/item/kitchen/knife/combat=1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak/super=1
+	)
 
 /datum/outfit/loadout/spaladina
 	name = "Long-Range Support Senior Paladin"
@@ -458,7 +462,8 @@ Paladin
 	belt = 			/obj/item/storage/belt/military
 	neck = /obj/item/clothing/neck/cloak/bos/paladin
 	backpack_contents = list(
-		/obj/item/kitchen/knife/combat=1, \
+		/obj/item/kitchen/knife/combat=1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak/super=1
 		)
 
 /datum/outfit/loadout/paladina
@@ -541,10 +546,10 @@ Senior Scribe
 	id = 			/obj/item/card/id/dogtag
 	glasses =		/obj/item/clothing/glasses/sunglasses/big
 	backpack_contents = list(
-		/obj/item/stock_parts/cell/ammo/ec=2, \
-		/obj/item/kitchen/knife/combat=1, \
-		/obj/item/gun/energy/laser/pistol=1, \
-		/obj/item/reagent_containers/hypospray/medipen/stimpak=2, \
+		/obj/item/stock_parts/cell/ammo/ec=2,
+		/obj/item/kitchen/knife/combat=1,
+		/obj/item/gun/energy/laser/pistol=1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak=2,
 		/obj/item/reagent_containers/hypospray/CMO=1)
 
 /*
@@ -593,10 +598,11 @@ Scribe
 	id = 			/obj/item/card/id/dogtag
 	glasses =		/obj/item/clothing/glasses/sunglasses/big
 	backpack_contents = list(
-		/obj/item/stock_parts/cell/ammo/ec=2, \
-		/obj/item/kitchen/knife/combat=1, \
-		/obj/item/gun/energy/laser/pistol=1, \
-		/obj/item/reagent_containers/hypospray/medipen/stimpak=2)
+		/obj/item/stock_parts/cell/ammo/ec=2,
+		/obj/item/kitchen/knife/combat=1,
+		/obj/item/gun/energy/laser/pistol=1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak=2
+		)
 
 /datum/outfit/job/bos/f13scribe/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -660,8 +666,10 @@ datum/job/bos/f13seniorknight
 	gunsmith_three = TRUE
 	gunsmith_four = TRUE
 	backpack_contents = list(
-	)
-
+		/obj/item/kitchen/knife/combat/survival=1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak/super=1
+		)
+	
 /datum/outfit/loadout/sknighta
 	name = "Footknight"
 	backpack_contents = list(
@@ -722,7 +730,9 @@ Knight
 	gunsmith_three = TRUE
 	gunsmith_four = TRUE
 	backpack_contents = list(
-	)
+		/obj/item/kitchen/knife/combat/survival=1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak/super=1
+		)
 
 /datum/outfit/loadout/knighta
 	name = "Junior Footknight"
@@ -792,6 +802,8 @@ Initiate
 	uniform =		/obj/item/clothing/under/syndicate/brotherhood
 	shoes = 		/obj/item/clothing/shoes/combat/swat
 	gloves = 		/obj/item/clothing/gloves/combat
+	backpack_contents = list(
+			/obj/item/kitchen/knife/combat/survival=1,)
 
 /datum/outfit/job/bos/f13initiate/post_equip(mob/living/carbon/human/H, visualsOnly)
 	..()

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -169,7 +169,7 @@ kept here incase it gets reworked later*/
 	box = 			/obj/item/storage/survivalkit_tribal/chief
 	backpack_contents = list(
 					/obj/item/restraints/legcuffs/bola=1,
-					/obj/item/storage/bag/money/small/legofficers=1)
+					/obj/item/storage/bag/money/small/legofficers=1,)
 
 /datum/outfit/loadout/palacent
 	name = 			"Paladin-Slayer Centurion"
@@ -178,7 +178,7 @@ kept here incase it gets reworked later*/
 	suit_store = 	/obj/item/twohanded/thermic_lance
 	backpack_contents = list(
 					/obj/item/gun/ballistic/automatic/smg/smg10mm=1,
-					/obj/item/ammo_box/magazine/m10mm_adv/ext=2)
+					/obj/item/ammo_box/magazine/m10mm_adv/ext=2,)
 
 /datum/outfit/loadout/rangerhunter
 	name = 			"Ranger-Hunter Centurion"
@@ -187,7 +187,7 @@ kept here incase it gets reworked later*/
 	backpack_contents = list(
 					/obj/item/ammo_box/c4570=3,
 					/obj/item/gun/ballistic/revolver/hunting=1,
-					/obj/item/melee/powered/ripper=1)
+					/obj/item/melee/powered/ripper=1,)
 
 /datum/outfit/loadout/centurion
 	name = 			"Frontline Centurion"
@@ -196,7 +196,8 @@ kept here incase it gets reworked later*/
 	suit_store = 	/obj/item/gun/ballistic/automatic/marksman
 	backpack_contents = list(
 					/obj/item/melee/powerfist/goliath=1,
-					/obj/item/ammo_box/magazine/m556/rifle=2)
+					/obj/item/ammo_box/magazine/m556/rifle=2,
+					/obj/item/tank/internals/oxygen=2,)
 
 /* /datum/outfit/loadout/berserkercenturion
 	name = 			"Praetorian Candidate"

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -465,7 +465,7 @@ Heavy Trooper
 		/obj/item/ammo_box/magazine/lmg=1, \
 		/obj/item/binoculars=1)
 
-/datum/outfit/job/ncr/f13logisticsofficer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/job/ncr/f13heavytrooper/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gave the Centurion tanks for his powerfist
Properly assigned the right traits to Heavy Troopers
Gave the BoS knives and stimpaks
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
BoS kits were a bit bare-bone after I re-did them so I wanted to polish the details a bit. The Centurion spawned with a melee weapon he couldn't use due to the lack of air tanks and for some reason the Heavy Trooper traits were assigned to the LO so I fixed that and Heavy Trooper should now have the proper traits.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
