### PR TITLE
removes desert ranger wastelander loadout

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -592,8 +592,7 @@ Raider
 	/datum/outfit/loadout/merchant,
 	/datum/outfit/loadout/scavenger,
 	/datum/outfit/loadout/citizen,
-	/datum/outfit/loadout/ncrcitizen,
-	/datum/outfit/loadout/wastelander_desert_ranger)
+	/datum/outfit/loadout/ncrcitizen,)
 
 /datum/outfit/job/wasteland/f13wastelander
 	name = "Wastelander"
@@ -720,17 +719,6 @@ Raider
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m556/rifle=2)
 
-/datum/outfit/loadout/wastelander_desert_ranger
-	name = "Desert Ranger Scout"
-	uniform = /obj/item/clothing/under/f13/desert_ranger_scout
-	shoes = /obj/item/clothing/shoes/f13/cowboy
-	head = /obj/item/clothing/head/f13/cowboy
-	gloves = /obj/item/clothing/gloves/color/brown
-	l_hand = /obj/item/gun/ballistic/revolver/colt357
-	backpack_contents = list(
-		/obj/item/ammo_box/a357=2,
-		/obj/item/binoculars=1,
-		/obj/item/radio=1)
 
 /datum/job/wasteland/f13enforcer
 	title = "Den Mob Enforcer"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
removes the desert ranger wastelander loadout
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
not lore friendly, made for very specific people.... for no reason. if you want to RP as a desert ranger then go and RP as one; you don't need this loadout to do so. regardless, desert rangers existing here is dumb.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: desert ranger loadout
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
