### PR TITLE
Tweaks to "Enclave Remnant" Outlaw loadout

### DIFF
--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -758,7 +758,12 @@
 	icon_state = "battlecoat_tan"
 	item_state = "maxson_battlecoat"
 
-/obj/item/clothing/suit/armor/f13/battlecoat/tan/enclave
+/obj/item/clothing/suit/armor/f13/battlecoat/tan/armored // For the "Enclave Remnant" loadout of the Outlaws.
+	name = "armored battlecoat"
+	desc = "(IV) A heavy padded leather coat with faded colors, usually worn by those who have once considered themselves a part of the US Government. This one has additional armor plating."
+	armor = list("tier" = 4, "energy" = 35, "bomb" = 35, "bio" = 40, "rad" = 10, "fire" = 60, "acid" = 10)
+
+/obj/item/clothing/suit/armor/f13/battlecoat/tan/enclave // For the Enclave Lieutenant.
 	name = "lieutenant's battlecoat"
 	desc = "(VII) A battle coat usually worn by the high-ranking officers within the US Military. This one has been armored with light-weight alloys, providing maximum defense at almost no weight cost."
 	armor = list("tier" = 7, "energy" = 35, "bomb" = 35, "bio" = 40, "rad" = 10, "fire" = 60, "acid" = 10)

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -575,10 +575,12 @@ Raider
 	name = "Enclave Remnant"
 	suit = /obj/item/clothing/suit/armor/f13/battlecoat/tan // Tier 3 armor, same as other raider things
 	uniform = /obj/item/clothing/under/f13/exile/enclave
+	shoes = /obj/item/clothing/shoes/f13/enclave/serviceboots
 	id = /obj/item/card/id/rusted/brokenholodog/enclave
 	backpack_contents = list(
-		/obj/item/gun/ballistic/automatic/pistol/pistol22=1,
-		/obj/item/ammo_box/magazine/m22=2)
+		/obj/item/storage/backpack/satchel/enclave
+		/obj/item/gun/ballistic/automatic/pistol/m1911/compact=1,
+		/obj/item/ammo_box/magazine/m45=2)
 
 
 /datum/job/wasteland/f13wastelander
@@ -638,7 +640,7 @@ Raider
 
 /datum/outfit/loadout/salvager
 	name = "Salvager"
-	uniform = /obj/item/clothing/under/f13/machinist	
+	uniform = /obj/item/clothing/under/f13/machinist
 	shoes = /obj/item/clothing/shoes/f13/explorer
 	gloves = /obj/item/clothing/gloves/f13/blacksmith
 	head = /obj/item/clothing/head/welding

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -573,7 +573,7 @@ Raider
 
 /datum/outfit/loadout/raider_enclave
 	name = "Enclave Remnant"
-	suit = /obj/item/clothing/suit/armor/f13/battlecoat/tan // Tier 3 armor, same as other raider things
+	suit = /obj/item/clothing/suit/armor/f13/battlecoat/tan/armored // Tier 4 armor, same as other raider things
 	uniform = /obj/item/clothing/under/f13/exile/enclave
 	shoes = /obj/item/clothing/shoes/f13/enclave/serviceboots
 	id = /obj/item/card/id/rusted/brokenholodog/enclave

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -573,7 +573,7 @@ Raider
 
 /datum/outfit/loadout/raider_enclave
 	name = "Enclave Remnant"
-	suit = /obj/item/clothing/suit/armor/f13/battlecoat/tan/armored // Tier 4 armor, same as other raider things
+	suit = /obj/item/clothing/suit/armor/f13/battlecoat/tan/armored // Tier 4 armor
 	uniform = /obj/item/clothing/under/f13/exile/enclave
 	shoes = /obj/item/clothing/shoes/f13/enclave/serviceboots
 	id = /obj/item/card/id/rusted/brokenholodog/enclave

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -578,7 +578,7 @@ Raider
 	shoes = /obj/item/clothing/shoes/f13/enclave/serviceboots
 	id = /obj/item/card/id/rusted/brokenholodog/enclave
 	backpack_contents = list(
-		/obj/item/storage/backpack/satchel/enclave
+		/obj/item/storage/backpack/satchel/enclave,
 		/obj/item/gun/ballistic/automatic/pistol/m1911/compact=1,
 		/obj/item/ammo_box/magazine/m45=2)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the pistol from .22 to compact M1911.
Buffs the jacket from tier 3 to tier 4.
Gives them some shoes for /style points/.
Service satchel.

## Why It's Good For The Game

So, first of all, most players on servers been telling me how outrageously bad .22 is, and asked to replace it, so I did exactly that.
I also found out that almost every other armor the outlaws can get is tier 4 and not 3, so I am fixing it.
Shoes and satchel are here just for the style points and have no real benefits to them.

## Changelog
:cl:
tweak: Small buff/tweak to "Enclave Remnant" loadout available to the Outlaws.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
