### PR TITLE
Disables gutting, makes decap require no headgear

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -43,10 +43,19 @@
 	if(check_mask && wear_mask && (wear_mask.flags_cover & MASKCOVERSMOUTH))
 		return TRUE
 
+
 /mob/living/carbon/check_projectile_dismemberment(obj/item/projectile/P, def_zone)
+	switch(def_zone)
+		if(BODY_ZONE_CHEST)
+			return // Gutting the chest with a projectile would just be weird.
+		if(BODY_ZONE_HEAD)
+			if(head) // If any kind of headgear is worn, no decap.
+				return
 	var/obj/item/bodypart/affecting = get_bodypart(def_zone)
-	if(affecting && affecting.dismemberable && affecting.get_damage() >= (affecting.max_damage - P.dismemberment))
-		affecting.dismember(P.damtype)
+	if(!affecting?.dismemberable || affecting.get_damage() < (affecting.max_damage - P.dismemberment))
+		return
+	affecting.dismember(P.damtype)
+
 
 /mob/living/carbon/catch_item(obj/item/I, skip_throw_mode_check = FALSE)
 	. = ..()

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -414,6 +414,7 @@
 	body_part = CHEST
 	px_x = 0
 	px_y = 0
+	dismemberable = FALSE
 	var/obj/item/cavity_item
 
 /obj/item/bodypart/chest/Destroy()

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -39,7 +39,8 @@
 	scars_covered_by_clothes = FALSE
 
 /obj/item/bodypart/head/can_dismember(obj/item/I)
-	if(owner && !((owner.stat == DEAD) || owner.InFullCritical()))
+	// Can't decap people alive or with some kind of headgear. Balance reasons.
+	if(owner && (owner.stat != DEAD || owner.head))
 		return FALSE
 	return ..()
 


### PR DESCRIPTION
Requested.

* The chest is no longer dismemerable, so no gutting through regular means.
* The head won't suffer decapitation if anything is worn on it.

Should reduce some rather hard to solve issues from happening due to pure rng during combat.
If one is really intent on decapitating, it can still be done, it just requires a little bit more effort.
This is a bit more balanced towards the expected level of medicine available.