### PR TITLE
Makes death claws and abominations stronger

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/fallout_NPC.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/fallout_NPC.dm
@@ -691,6 +691,7 @@
 	icon_dead = "abomination_dead"
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	environment_smash = ENVIRONMENT_SMASH_RWALLS
+	obj_damage = 500 // Begone, tables
 	robust_searching = 1
 	maxHealth = 1000
 	health = 1000
@@ -700,7 +701,7 @@
 	armour_penetration = 0.1
 	attack_verb_simple = "eviscerates"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
-	speed = -0.5
+	speed = -1
 	var/static/list/abom_sounds
 	deathmessage = "wails as its form shudders and violently comes to a stop."
 	death_sound = 'sound/voice/abomburning.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Deathclaws are now much faster, will charge more often and can ignore more projectiles.
The normal armor penetration is lowered, so PA users don't suffer too much.
Deathclaws and abominations now have very high structure damage.

## Why It's Good For The Game

Deathclaws are supposed to be an actual threat which you are not supposed to solo kill by simply running in a corridor because they can't run as fast as you.
They are still slower than most players, but that makes them more dangerous than they are right now.
Abominations have been cheesed with tables for as much as I've been playing, and at other times, players just lure them out and run away because the NPCs are slow. Same as death claws, you are not supposed to solo kill it with 0 preparations/equipment.

## Changelog
:cl:
balance: Deathclaws and Abominations now pose a real threat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
