### PR TITLE
Update ghoul.dm

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
@@ -22,7 +22,7 @@
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 20
 	gold_core_spawnable = HOSTILE_SPAWN
-	faction = list("ghoul")
+	faction = list("hostile")
 	decompose = TRUE
 	sharpness = SHARP_EDGED //They need to cut their finger nails
 	guaranteed_butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/human/ghoul = 2,


### PR DESCRIPTION
Feral ghouls are now hostile to ghoul players to prevent the cheesing of bunkers guarded by said ghouls. I know it sucks but so does having a ghoul rocking out with high tier weaponry 5 minutes into the game and then using it for foul play. Everyone should be equal when trying to attain gear. 
